### PR TITLE
Fix Available and Processing condition should not both be true 

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -260,8 +260,8 @@ func setCondition(lws *leaderworkerset.LeaderWorkerSet, newCondition metav1.Cond
 			// Available and both are true. Must be mutually exclusive.
 			if exclusiveConditionTypes(curCondition, newCondition) &&
 				(newCondition.Status == metav1.ConditionTrue) && (curCondition.Status == metav1.ConditionTrue) {
-				// Progressing is true and Availalbe is true. Prevent this.
-				curCondition.Status = metav1.ConditionFalse
+				// Progressing is true and Available is true. Prevent this.
+				lws.Status.Conditions[i].Status = metav1.ConditionFalse
 				shouldUpdate = true
 			}
 		}

--- a/test/integration/controller/leaderworkerset_controller_test.go
+++ b/test/integration/controller/leaderworkerset_controller_test.go
@@ -394,6 +394,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ValidateLatestEvent(ctx, k8sClient, "GroupsAreProgressing", corev1.EventTypeNormal, "Creating resources, with 0 groups ready of total 2 groups", lws.Namespace)
 						// Force groups to ready.
 						testing.SetPodGroupsToReady(lwssts.Items, lws, k8sClient, ctx)
+						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Creating resources")
 						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "all replicas are ready")
 						testing.ValidateLatestEvent(ctx, k8sClient, "AllGroupsReady", corev1.EventTypeNormal, "all replicas are ready, with 2 groups ready of total 2 groups", lws.Namespace)
 						// Force a reconcile. Refetch most recent version of LWS, increase replicas.
@@ -413,6 +414,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 							},
 						}, patch)
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Creating resources")
+						testing.ExpectLeaderWorkerSetUnAvailable(ctx, k8sClient, lws, "all replicas are ready")
 						// Check most recent event.
 						testing.ValidateLatestEvent(ctx, k8sClient, "GroupsAreProgressing", corev1.EventTypeNormal, "Creating resources, with 2 groups ready of total 3 groups", lws.Namespace)
 					},

--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -237,7 +237,7 @@ func ExpectValidWorkerStatefulSets(ctx context.Context, lws *leaderworkerset.Lea
 }
 
 func ExpectLeaderWorkerSetProgressing(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, message string) {
-	ginkgo.By(fmt.Sprintf("checking leaderworkerset status is: %s", leaderworkerset.LeaderWorkerSetProgressing))
+	ginkgo.By(fmt.Sprintf("checking leaderworkerset status(%s) is true", leaderworkerset.LeaderWorkerSetProgressing))
 	condition := metav1.Condition{
 		Type:    string(leaderworkerset.LeaderWorkerSetProgressing),
 		Status:  metav1.ConditionTrue,
@@ -245,11 +245,32 @@ func ExpectLeaderWorkerSetProgressing(ctx context.Context, k8sClient client.Clie
 	}
 	gomega.Eventually(CheckLeaderWorkerSetHasCondition, Timeout, Interval).WithArguments(ctx, k8sClient, lws, condition).Should(gomega.Equal(true))
 }
+
+func ExpectLeaderWorkerSetNotProgressing(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, message string) {
+	ginkgo.By(fmt.Sprintf("checking leaderworkerset status(%s) is false", leaderworkerset.LeaderWorkerSetProgressing))
+	condition := metav1.Condition{
+		Type:    string(leaderworkerset.LeaderWorkerSetProgressing),
+		Status:  metav1.ConditionFalse,
+		Message: message,
+	}
+	gomega.Eventually(CheckLeaderWorkerSetHasCondition, Timeout, Interval).WithArguments(ctx, k8sClient, lws, condition).Should(gomega.Equal(true))
+}
+
 func ExpectLeaderWorkerSetAvailable(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, message string) {
-	ginkgo.By(fmt.Sprintf("checking leaderworkerset status is: %s", leaderworkerset.LeaderWorkerSetAvailable))
+	ginkgo.By(fmt.Sprintf("checking leaderworkerset status(%s) is true", leaderworkerset.LeaderWorkerSetAvailable))
 	condition := metav1.Condition{
 		Type:    string(leaderworkerset.LeaderWorkerSetAvailable),
 		Status:  metav1.ConditionTrue,
+		Message: message,
+	}
+	gomega.Eventually(CheckLeaderWorkerSetHasCondition, Timeout, Interval).WithArguments(ctx, k8sClient, lws, condition).Should(gomega.Equal(true))
+}
+
+func ExpectLeaderWorkerSetUnAvailable(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, message string) {
+	ginkgo.By(fmt.Sprintf("checking leaderworkerset status(%s) is false", leaderworkerset.LeaderWorkerSetAvailable))
+	condition := metav1.Condition{
+		Type:    string(leaderworkerset.LeaderWorkerSetAvailable),
+		Status:  metav1.ConditionFalse,
 		Message: message,
 	}
 	gomega.Eventually(CheckLeaderWorkerSetHasCondition, Timeout, Interval).WithArguments(ctx, k8sClient, lws, condition).Should(gomega.Equal(true))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
