### PR TITLE
Fix TPU env var assignment when leader doesn't request TPUs

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -69,7 +69,6 @@ func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, 
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 
 func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	// Get leaderworkerset object
 	lws := &leaderworkerset.LeaderWorkerSet{}
 	if err := r.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, lws); err != nil {

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -62,24 +62,15 @@ func TestAddTPUVariables(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/worker-index": "3",
 					},
+					Annotations: map[string]string{
+						LeaderRequestsTPUsAnnotationKey: "true",
+					},
 				},
 			},
 			size:                       5,
 			hasWorkerIndexLabelKey:     true,
 			expectedTpuWorkerHostNames: "test-sample-1.default,test-sample-1-1.default,test-sample-1-2.default,test-sample-1-3.default,test-sample-1-4.default",
 			expectedTpuWorkerId:        "3",
-		},
-		{
-			name: "No Worker Index included",
-			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-sample-1-3",
-					Namespace: "default",
-				},
-			},
-			size:                   1,
-			hasWorkerIndexLabelKey: false,
 		},
 	}
 

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -188,9 +188,18 @@ func CheckTPUContainerHasCorrectEnvVars(pod corev1.Pod, envVal string) error {
 				}
 			}
 			if env.Name == acceleratorutils.TpuWorkerId {
-				if env.Value != pod.Labels[leaderworkerset.WorkerIndexLabelKey] {
-					return fmt.Errorf("incorrect env value for %s", acceleratorutils.TpuWorkerId)
+				if pod.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" ||
+					pod.Annotations[acceleratorutils.LeaderRequestsTPUsAnnotationKey] == "true" {
+					if env.Value != pod.Labels[leaderworkerset.WorkerIndexLabelKey] {
+						return fmt.Errorf("incorrect env value for %s", acceleratorutils.TpuWorkerId)
+					}
+				} else {
+					index, _ := strconv.Atoi(pod.Labels[leaderworkerset.WorkerIndexLabelKey])
+					if env.Value != fmt.Sprint(index-1) {
+						return fmt.Errorf("incorrect env value for %s", acceleratorutils.TpuWorkerId)
+					}
 				}
+
 			}
 		}
 	}


### PR DESCRIPTION


#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

LWS injects TPU env vars necessary for multi-host workloads, this includes TPU_WORKER_ID and TPU_HOST_NAMES. Currently we inject that into the workers if they request TPUs assuming that the leader does too, and so TPU_WORKER_ID=0 is always assumed to be the leader pod, and the leader hostname is also added to TPU_HOST_NAMES list. 

In some cases, the leader may not be requesting TPUs and is not acting as a TPU worker, in which case its hostname should not be listed in the host names and the TPU_WORKER_ID should be assigned to the LWS workers starting from 0 (and so TPU_WORKER_ID = LWS_WORKER_INDEX-1)

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
