### PR TITLE
Add E2E test

### DIFF
--- a/test/e2e/config/image_pull_policy.yaml
+++ b/test/e2e/config/image_pull_policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: IfNotPresent

--- a/test/e2e/config/kustomization.yaml
+++ b/test/e2e/config/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../config/default
+
+patches:
+- path: image_pull_policy.yaml

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export CWD=$(pwd)
+function cleanup {
+    if [ $USE_EXISTING_CLUSTER == 'false' ] 
+    then 
+        $KIND delete cluster --name $KIND_CLUSTER_NAME
+    fi
+    (cd $CWD/config/manager && $KUSTOMIZE edit set image controller=gcr.io/k8s-staging-lws/lws:main)
+}
+function startup {
+    if [ $USE_EXISTING_CLUSTER == 'false' ] 
+    then 
+        $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION
+    fi
+}
+function kind_load {
+    $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
+}
+function lws_deploy {
+    cd $CWD/config/manager && $KUSTOMIZE edit set image controller=$IMAGE_TAG  
+    $KUSTOMIZE build $CWD/test/e2e/config | $KUBECTL apply --server-side -f -
+}
+trap cleanup EXIT
+startup
+kind_load
+lws_deploy
+$GINKGO -v $CWD/test/e2e/...

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	testing "sigs.k8s.io/lws/test/testutils"
+)
+
+var _ = Describe("lws", func() {
+
+	// Each test runs in a separate namespace.
+	var ns *corev1.Namespace
+
+	BeforeEach(func() {
+		// Create test namespace before each test.
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-ns-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		// Wait for namespace to exist before proceeding with test.
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	})
+
+	It("Can deploy lws", func() {
+		leaderWorkerSetSpec := testing.BuildLeaderWorkerSet(ns.Name).Replica(3).Obj()
+
+		Expect(k8sClient.Create(ctx, leaderWorkerSetSpec)).To(Succeed())
+
+		var leaderWorkerSetStruct leaderworkerset.LeaderWorkerSet
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: leaderWorkerSetSpec.Name, Namespace: ns.Name}, &leaderWorkerSetStruct); err != nil {
+				return err
+			}
+			return nil
+		}, testing.Timeout, testing.Interval).Should(Succeed())
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+const (
+	timeout  = 1 * time.Minute
+	interval = time.Millisecond * 250
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	By("bootstrapping test environment")
+	s, _ := os.Getwd()
+	fmt.Println(s)
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without calling the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = leaderworkerset.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = appsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

Currently we lack any kind of E2E testing, added a test that starts a kind cluster with LWS controller and CRDs and assures LWS can be created.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/lws/issues/6

#### Special notes for your reviewer

Test change locally via `make test-e2e`

