### PR TITLE
fix: make generate error: unbound variable

### DIFF
--- a/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetstatus.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetstatus.go
@@ -24,10 +24,11 @@ import (
 // LeaderWorkerSetStatusApplyConfiguration represents an declarative configuration of the LeaderWorkerSetStatus type for use
 // with apply.
 type LeaderWorkerSetStatusApplyConfiguration struct {
-	Conditions     []v1.Condition `json:"conditions,omitempty"`
-	ReadyReplicas  *int           `json:"readyReplicas,omitempty"`
-	Replicas       *int           `json:"replicas,omitempty"`
-	HPAPodSelector *string        `json:"hpaPodSelector,omitempty"`
+	Conditions      []v1.Condition `json:"conditions,omitempty"`
+	ReadyReplicas   *int32         `json:"readyReplicas,omitempty"`
+	UpdatedReplicas *int32         `json:"updatedReplicas,omitempty"`
+	Replicas        *int32         `json:"replicas,omitempty"`
+	HPAPodSelector  *string        `json:"hpaPodSelector,omitempty"`
 }
 
 // LeaderWorkerSetStatusApplyConfiguration constructs an declarative configuration of the LeaderWorkerSetStatus type for use with
@@ -49,15 +50,23 @@ func (b *LeaderWorkerSetStatusApplyConfiguration) WithConditions(values ...v1.Co
 // WithReadyReplicas sets the ReadyReplicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ReadyReplicas field is set to the value of the last call.
-func (b *LeaderWorkerSetStatusApplyConfiguration) WithReadyReplicas(value int) *LeaderWorkerSetStatusApplyConfiguration {
+func (b *LeaderWorkerSetStatusApplyConfiguration) WithReadyReplicas(value int32) *LeaderWorkerSetStatusApplyConfiguration {
 	b.ReadyReplicas = &value
+	return b
+}
+
+// WithUpdatedReplicas sets the UpdatedReplicas field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the UpdatedReplicas field is set to the value of the last call.
+func (b *LeaderWorkerSetStatusApplyConfiguration) WithUpdatedReplicas(value int32) *LeaderWorkerSetStatusApplyConfiguration {
+	b.UpdatedReplicas = &value
 	return b
 }
 
 // WithReplicas sets the Replicas field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Replicas field is set to the value of the last call.
-func (b *LeaderWorkerSetStatusApplyConfiguration) WithReplicas(value int) *LeaderWorkerSetStatusApplyConfiguration {
+func (b *LeaderWorkerSetStatusApplyConfiguration) WithReplicas(value int32) *LeaderWorkerSetStatusApplyConfiguration {
 	b.Replicas = &value
 	return b
 }

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -23,7 +23,6 @@ GO_CMD=${1:-go}
 CODEGEN_PKG=${2:-bin}
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-echo "GOPATH=$GOPATH"
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Failed to run `make generate` when env variable `GOPATH` was not set.
```bash
root@dev:~/work/lws# make generate
test -s /root/work/lws/bin/controller-gen && /root/work/lws/bin/controller-gen --version | grep -q v0.14.0 || \
GOBIN=/root/work/lws/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0

cp -f /root/go/pkg/mod/k8s.io/code-generator@v0.29.3/generate-groups.sh /root/work/lws/bin/
cp -f /root/go/pkg/mod/k8s.io/code-generator@v0.29.3/generate-internal-groups.sh /root/work/lws/bin/
cp -f /root/go/pkg/mod/k8s.io/code-generator@v0.29.3/kube_codegen.sh /root/work/lws/bin/
/root/work/lws/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
./hack/update-codegen.sh go /root/work/lws/bin
./hack/update-codegen.sh: line 26: GOPATH: unbound variable
make: *** [Makefile:93: generate] Error 1
```
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
