### PR TITLE
cleanup: use kubebuilder marker instead of webhook

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -110,7 +110,9 @@ type LeaderWorkerTemplate struct {
 	Size *int32 `json:"size,omitempty"`
 
 	// RestartPolicy defines the restart policy when pod failures happen.
-	RestartPolicy RestartPolicyType `json:"restartPolicy,omitempty"`
+	// +kubebuilder:default=Default
+	// +kubebuilder:validation:Enum={Default,RecreateGroupOnPodRestart}
+	RestartPolicy RestartPolicyType `json:"restartPolicy"`
 }
 
 // RolloutStrategy defines the strategy that the leaderWorkerSet controller

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -7648,8 +7648,12 @@ spec:
                         type: object
                     type: object
                   restartPolicy:
+                    default: Default
                     description: RestartPolicy defines the restart policy when pod
                       failures happen.
+                    enum:
+                    - Default
+                    - RecreateGroupOnPodRestart
                     type: string
                   size:
                     default: 1
@@ -15251,6 +15255,7 @@ spec:
                         type: object
                     type: object
                 required:
+                - restartPolicy
                 - workerTemplate
                 type: object
               replicas:

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -23,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGenGroupUniqueKey(t *testing.T) {
@@ -73,13 +72,13 @@ func TestSetExclusiveAffinities(t *testing.T) {
 		{
 			name: "Pod with only Exclusive Topology Annotation",
 			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey"},
 				},
 			},
 			groupUniqueKey: "test-key",
 			expectedPod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey"},
 				},
 				Spec: corev1.PodSpec{
@@ -119,7 +118,7 @@ func TestSetExclusiveAffinities(t *testing.T) {
 		{
 			name: "Pod with Exclusive Annotation, Affinity, and AntiAffinity",
 			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey"},
 				},
 				Spec: corev1.PodSpec{
@@ -135,7 +134,7 @@ func TestSetExclusiveAffinities(t *testing.T) {
 			},
 			groupUniqueKey: "test-key",
 			expectedPod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey"},
 				},
 				Spec: corev1.PodSpec{
@@ -203,7 +202,7 @@ func TestExclusiveAffinityApplied(t *testing.T) {
 		{
 			name: "Has annotiation, Pod Affinity and Pod AntiAffinity",
 			pod: corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 					},
@@ -224,7 +223,7 @@ func TestExclusiveAffinityApplied(t *testing.T) {
 		{
 			name: "Has annotiation, Pod Affinity, doesn't have Pod AntiAffinity",
 			pod: corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 					},
@@ -242,7 +241,7 @@ func TestExclusiveAffinityApplied(t *testing.T) {
 		{
 			name: "Has annotiation, Pod AntiAffinity, doesn't have Pod Affinity",
 			pod: corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 					},
@@ -260,7 +259,7 @@ func TestExclusiveAffinityApplied(t *testing.T) {
 		{
 			name: "Has annotiation, Pod Affinity and Pod AntiAffinity, Topology Key doesn't match",
 			pod: corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 					},

--- a/test/testutils/wrappers.go
+++ b/test/testutils/wrappers.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
-	v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
 type LeaderWorkerSetWrapper struct {
@@ -107,15 +106,15 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws.Namespace = nsName
 	lws.Spec = leaderworkerset.LeaderWorkerSetSpec{}
 	lws.Spec.Replicas = ptr.To[int32](2)
-	lws.Spec.LeaderWorkerTemplate = leaderworkerset.LeaderWorkerTemplate{}
+	lws.Spec.LeaderWorkerTemplate = leaderworkerset.LeaderWorkerTemplate{RestartPolicy: leaderworkerset.DefaultRestartPolicy}
 	lws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](2)
 	lws.Spec.LeaderWorkerTemplate.LeaderTemplate = &corev1.PodTemplateSpec{}
 	lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec = MakeLeaderPodSpec()
 	lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = MakeWorkerPodSpec()
 	// Manually set this for we didn't enable webhook in controller tests.
-	lws.Spec.RolloutStrategy = v1.RolloutStrategy{
-		Type: v1.RollingUpdateStrategyType,
-		RollingUpdateConfiguration: &v1.RollingUpdateConfiguration{
+	lws.Spec.RolloutStrategy = leaderworkerset.RolloutStrategy{
+		Type: leaderworkerset.RollingUpdateStrategyType,
+		RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt32(0),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #15 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
