### PR TITLE
Change the semantics of leaderWorkerSet Replicas

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -175,13 +175,13 @@ type LeaderWorkerSetStatus struct {
 	// Conditions track the condition of the leaderworkerset.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// ReadyReplicas track the number of groups that are in ready state.
+	// ReadyReplicas track the number of groups that are in ready state (updated or not).
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 
-	// UpdatedReplicas track the number of groups that have been updated.
+	// UpdatedReplicas track the number of groups that have been updated (ready or not).
 	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 
-	// Replicas track the active total number of groups.
+	// Replicas track the total number of groups that have been created (updated or not, ready or not)
 	Replicas int32 `json:"replicas,omitempty"`
 
 	// HPAPodSelector for pods that belong to the LeaderWorkerSet object, this is

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -15392,16 +15392,17 @@ spec:
                 type: string
               readyReplicas:
                 description: ReadyReplicas track the number of groups that are in
-                  ready state.
+                  ready state (updated or not).
                 format: int32
                 type: integer
               replicas:
-                description: Replicas track the active total number of groups.
+                description: Replicas track the total number of groups that have been
+                  created (updated or not, ready or not)
                 format: int32
                 type: integer
               updatedReplicas:
                 description: UpdatedReplicas track the number of groups that have
-                  been updated.
+                  been updated (ready or not).
                 format: int32
                 type: integer
             type: object

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -414,7 +414,7 @@ func (r *LeaderWorkerSetReconciler) updateStatus(ctx context.Context, lws *leade
 	}
 
 	// retrieve the current number of replicas -- the number of leaders
-	replicas := int(*sts.Spec.Replicas)
+	replicas := int(sts.Status.Replicas)
 	if lws.Status.Replicas != int32(replicas) {
 		lws.Status.Replicas = int32(replicas)
 		updateStatus = true

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -354,7 +354,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 	}
 
 	updateStatus := false
-	readyCount, updatedCount, availableCount := 0, 0, 0
+	readyCount, updatedCount, updatedAndReadyCount := 0, 0, 0
 	templateHash := utils.LeaderWorkerTemplateHash(lws)
 
 	// Iterate through all statefulsets.
@@ -377,7 +377,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 		if sts.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash && leaderPod.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash {
 			updatedCount++
 			if ready {
-				availableCount++
+				updatedAndReadyCount++
 			}
 		}
 	}
@@ -392,7 +392,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 		updateStatus = true
 	}
 
-	condition := makeCondition(availableCount == int(*lws.Spec.Replicas))
+	condition := makeCondition(updatedAndReadyCount == int(*lws.Spec.Replicas))
 	updateCondition := setCondition(lws, condition)
 	// if condition changed, record events
 	if updateCondition {

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -354,8 +354,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 	}
 
 	updateStatus := false
-	readyCount := 0
-	updatedCount := 0
+	readyCount, updatedCount, availableCount := 0, 0, 0
 	templateHash := utils.LeaderWorkerTemplateHash(lws)
 
 	// Iterate through all statefulsets.
@@ -364,22 +363,21 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 			continue
 		}
 
-		// this is the worker statefulset.
-		if statefulsetutils.StatefulsetReady(sts) {
+		var leaderPod corev1.Pod
+		if err := r.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: sts.Name}, &leaderPod); err != nil {
+			log.Error(err, "Fetching leader pod")
+			return false, err
+		}
 
-			// the worker pods are OK.
-			// need to check leader pod for this group.
-			var leaderPod corev1.Pod
-			if err := r.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: sts.Name}, &leaderPod); err != nil {
-				log.Error(err, "Fetching leader pod")
-				return false, err
-			}
-			if podutils.PodRunningAndReady(leaderPod) {
-				readyCount++
-
-				if sts.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash && leaderPod.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash {
-					updatedCount++
-				}
+		var ready bool
+		if statefulsetutils.StatefulsetReady(sts) && podutils.PodRunningAndReady(leaderPod) {
+			ready = true
+			readyCount++
+		}
+		if sts.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash && leaderPod.Labels[leaderworkerset.TemplateRevisionHashKey] == templateHash {
+			updatedCount++
+			if ready {
+				availableCount++
 			}
 		}
 	}
@@ -394,7 +392,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 		updateStatus = true
 	}
 
-	condition := makeCondition(updatedCount == int(*lws.Spec.Replicas))
+	condition := makeCondition(availableCount == int(*lws.Spec.Replicas))
 	updateCondition := setCondition(lws, condition)
 	// if condition changed, record events
 	if updateCondition {

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -437,13 +437,6 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						gomega.Eventually(func() (int32, error) {
-							var leaderWorkerSet leaderworkerset.LeaderWorkerSet
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderWorkerSet); err != nil {
-								return -1, err
-							}
-							return leaderWorkerSet.Status.Replicas, nil
-						}, testing.Timeout, testing.Interval).Should(gomega.Equal(int32(2)))
 						testing.ExpectValidLeaderStatefulSet(ctx, lws, k8sClient)
 						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,12 +92,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset)).To(gomega.Succeed())
-						testing.UpdateReplicaCount(ctx, k8sClient, &leaderworkerset, int32(3))
+						testing.UpdateReplicaCount(ctx, k8sClient, lws, int32(3))
 						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, &leaderworkerset, 2, 3)).To(gomega.Succeed())
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 2, 3)).To(gomega.Succeed())
 					},
 					checkLWSState: func(deployment *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidReplicasCount(ctx, deployment, 3, k8sClient)
@@ -113,12 +112,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset)).To(gomega.Succeed())
-						testing.UpdateReplicaCount(ctx, k8sClient, &leaderworkerset, int32(3))
+						testing.UpdateReplicaCount(ctx, k8sClient, lws, int32(3))
 						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						testing.DeleteLeaderPods(ctx, k8sClient, leaderworkerset)
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						testing.DeleteLeaderPods(ctx, k8sClient, lws)
 					},
 					checkLWSState: func(deployment *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidReplicasCount(ctx, deployment, 3, k8sClient)
@@ -135,12 +132,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset)).To(gomega.Succeed())
-						testing.UpdateReplicaCount(ctx, k8sClient, &leaderworkerset, int32(0))
+						testing.UpdateReplicaCount(ctx, k8sClient, lws, int32(0))
 						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						testing.DeleteLeaderPods(ctx, k8sClient, leaderworkerset)
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						testing.DeleteLeaderPods(ctx, k8sClient, lws)
 					},
 					checkLWSState: func(deployment *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidReplicasCount(ctx, deployment, 0, k8sClient)
@@ -157,12 +152,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset)).To(gomega.Succeed())
-						testing.UpdateReplicaCount(ctx, k8sClient, &leaderworkerset, int32(3))
+						testing.UpdateReplicaCount(ctx, k8sClient, lws, int32(3))
 						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, &leaderworkerset, 0, 3)).To(gomega.Succeed())
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 0, 3)).To(gomega.Succeed())
 					},
 					checkLWSState: func(deployment *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidReplicasCount(ctx, deployment, 3, k8sClient)
@@ -298,7 +291,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var scale v1.Scale
+						var scale autoscalingv1.Scale
 						gomega.Expect(k8sClient.SubResource("scale").Get(ctx, lws, &scale)).To(gomega.Succeed())
 						gomega.Expect(int32(scale.Spec.Replicas)).To(gomega.Equal(*lws.Spec.Replicas))
 						gomega.Expect(int32(scale.Status.Replicas)).To(gomega.Equal(lws.Status.Replicas))
@@ -307,24 +300,17 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var scale v1.Scale
-						gomega.Expect(k8sClient.SubResource("scale").Get(ctx, lws, &scale)).To(gomega.Succeed())
-						scale.Spec.Replicas = 3
-						lwsUnstructed, _ := ToUnstructured(lws)
-						lwsUnstructed.SetAPIVersion("leaderworkerset.x-k8s.io/v1")
-						lwsUnstructed.SetKind("LeaderWorkerSet")
-						scaleUnstructed, _ := ToUnstructured(scale.DeepCopy())
-						scaleUnstructed.SetAPIVersion("autoscaling/v1")
-						scaleUnstructed.SetKind("Scale")
-						gomega.Expect(k8sClient.SubResource("scale").Update(ctx, lwsUnstructed, client.WithSubResourceBody(scaleUnstructed))).To(gomega.Succeed())
+						dep := &leaderworkerset.LeaderWorkerSet{ObjectMeta: metav1.ObjectMeta{Namespace: lws.Namespace, Name: lws.Name}}
+						scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 3}}
+						gomega.Expect(k8sClient.SubResource("scale").Update(ctx, dep, client.WithSubResourceBody(scale))).To(gomega.Succeed())
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						gomega.Eventually(func() (int32, error) {
 							var leaderWorkerSet leaderworkerset.LeaderWorkerSet
 							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderWorkerSet); err != nil {
-								return -1, err
+								return 0, err
 							}
-							return leaderWorkerSet.Status.Replicas, nil
+							return *leaderWorkerSet.Spec.Replicas, nil
 						}, testing.Timeout, testing.Interval).Should(gomega.Equal(int32(3)))
 					},
 				},
@@ -561,7 +547,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
 						testing.ExpectValidLeaderStatefulSet(ctx, lws, k8sClient)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
+						// 3-index status is unready but template already updated.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
 					},
 				},
 				{
@@ -884,7 +871,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 							return k8sClient.Update(ctx, &leaderworkerset)
 						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
 						// Manually delete leader pods here because we have no statefulset controller.
-						testing.DeleteLeaderPods(ctx, k8sClient, leaderworkerset)
+						testing.DeleteLeaderPods(ctx, k8sClient, &leaderworkerset)
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidLeaderStatefulSet(ctx, lws, k8sClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/lws/issues/96#issuecomment-2063027769

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
