### PR TITLE
Add leader address environment variable injection

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -58,6 +58,10 @@ const (
 	// This will be applied to all API objects including:
 	// leaderStatefulset, leaderPods, workerStatefulsets, workerPods.
 	TemplateRevisionHashKey string = "leaderworkerset.sigs.k8s.io/template-revision-hash"
+
+	// Environment variable added to all containers in the LeaderWorkerSet to
+	// address the leader via the headless service.
+	LwsLeaderAddress string = "LWS_LEADER_ADDRESS"
 )
 
 // One group consists of a single leader and M workers, and the total number of pods in a group is M+1.

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -22,15 +22,15 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	podutils "sigs.k8s.io/lws/pkg/utils/pod"
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	statefulsetutils "sigs.k8s.io/lws/pkg/utils/statefulset"
 )
 
-var (
-	TpuResourceName                 = corev1.ResourceName("google.com/tpu")
-	TpuWorkerHostNames              = "TPU_WORKER_HOSTNAMES"
-	TpuWorkerId                     = "TPU_WORKER_ID"
-	LeaderRequestsTPUsAnnotationKey = "leaderworkerset.sigs.k8s.io/leader-requests-tpus"
+const (
+	TpuResourceName                 corev1.ResourceName = corev1.ResourceName("google.com/tpu")
+	TpuWorkerHostNames              string              = "TPU_WORKER_HOSTNAMES"
+	TpuWorkerId                     string              = "TPU_WORKER_ID"
+	LeaderRequestsTPUsAnnotationKey string              = "leaderworkerset.sigs.k8s.io/leader-requests-tpus"
 )
 
 // PodRequestsTPUs returns true if the pod requesting TPUs
@@ -94,7 +94,7 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 	leaderName := pod.Name
 	tpuWorkerId := 0
 	var hostnames []string
-	if podutils.LeaderPod(*pod) {
+	if pod.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" {
 		// if this is a leader, then we know it is requesting TPUs, and the leader will get TPU_WORKER_ID=0
 		hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderName, pod.Spec.Subdomain))
 	} else {

--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pod
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -87,4 +89,42 @@ func getPodConditionFromList(conditions []corev1.PodCondition, conditionType cor
 		}
 	}
 	return -1, nil
+}
+
+func addEnvVarIfNotExists(c *corev1.Container, e corev1.EnvVar) {
+	for _, env := range c.Env {
+		if env.Name == e.Name {
+			return
+		}
+	}
+	c.Env = append(c.Env, e)
+}
+
+// AddLWSVariables adds LWS_LEADER_ADDRESS environment variable to every container.
+func AddLWSVariables(pod *corev1.Pod) error {
+	lwsName, found := pod.Labels[leaderworkerset.SetNameLabelKey]
+	if !found {
+		return fmt.Errorf("Failure constructing environment variables, no name label found for pod %v", pod.Name)
+	}
+
+	groupIndex, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]
+	if !found {
+		return fmt.Errorf("Failure constructing environment variables, no group index label found for pod %v", pod.Name)
+	}
+
+	// The headless service name is assumed to be the same as the LWS name.
+	// See function [createHeadlessServiceIfNotExists](sigs.k8s.io/lws/pkg/controllers/leaderworkerset_controller.go).
+	leaderAddressEnvVar := corev1.EnvVar{
+		Name:  leaderworkerset.LwsLeaderAddress,
+		Value: fmt.Sprintf("%s-%s.%s.%s", lwsName, groupIndex, lwsName, pod.ObjectMeta.Namespace),
+	}
+
+	for i := range pod.Spec.Containers {
+		addEnvVarIfNotExists(&pod.Spec.Containers[i], leaderAddressEnvVar)
+	}
+	for i := range pod.Spec.InitContainers {
+		addEnvVarIfNotExists(&pod.Spec.InitContainers[i], leaderAddressEnvVar)
+	}
+
+	return nil
 }

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -139,6 +139,11 @@ func (p *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			return err
 		}
 	}
+
+	if err := podutils.AddLWSVariables(pod); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/testutils/wrappers.go
+++ b/test/testutils/wrappers.go
@@ -15,6 +15,8 @@ limitations under the License.
 package testutils
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,6 +131,24 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	}
 }
 
+func MakePodWithLabels(setName, groupIndex, workerIndex, namespace string) *corev1.Pod {
+	podName := fmt.Sprintf("%s-%s-%s", setName, groupIndex, workerIndex)
+	if workerIndex == "0" {
+		podName = fmt.Sprintf("%s-%s", setName, groupIndex)
+	}
+	return &corev1.Pod{
+		Spec: MakePodSpecWithInitContainer(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				leaderworkerset.GroupIndexLabelKey: groupIndex,
+				leaderworkerset.SetNameLabelKey:    setName,
+			},
+		},
+	}
+}
+
 func MakeWorkerPodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -141,6 +161,23 @@ func MakeWorkerPodSpec() corev1.PodSpec {
 						Protocol:      "TCP",
 					},
 				},
+			},
+		},
+	}
+}
+
+func MakePodSpecWithInitContainer() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "test",
+				Image: "busybox",
+			},
+		},
+		InitContainers: []corev1.Container{
+			{
+				Name:  "init-test",
+				Image: "busybox",
 			},
 		},
 	}


### PR DESCRIPTION
This adds LWS_LEADER_ADDRESS environment variable injection constructed via related LWS pod labels. This avoids making the user specify in yaml via downward api.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #143

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add LWS_LEADER_ADDRESS environment variable to all containers in a leaderworkerset.
```
