### PR TITLE
Switch the order of env var for LWS_LEADER_ADDRESS

### DIFF
--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -97,7 +97,7 @@ func addEnvVarIfNotExists(c *corev1.Container, e corev1.EnvVar) {
 			return
 		}
 	}
-	c.Env = append(c.Env, e)
+	c.Env = append([]corev1.EnvVar{e}, c.Env...)
 }
 
 // AddLWSVariables adds LWS_LEADER_ADDRESS environment variable to every container.

--- a/test/integration/webhooks/pod_test.go
+++ b/test/integration/webhooks/pod_test.go
@@ -465,7 +465,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 				return nil
 			},
 		}),
-		ginkgo.Entry("Pod has leader address env var populated", &testDefaultingCase{
+		ginkgo.Entry("Leader address env var should be populated and is the first env var", &testDefaultingCase{
 			makePod: func(ns *corev1.Namespace) corev1.Pod {
 				return corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -486,6 +486,9 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 				}
 				expectedLeaderAddress := fmt.Sprintf("test-sample-1.test-sample.%s", expected.ObjectMeta.Namespace)
 				if err := testutils.CheckContainerHasCorrectEnvVar(got, corev1.EnvVar{Name: leaderworkerset.LwsLeaderAddress, Value: expectedLeaderAddress}); err != nil {
+					return err
+				}
+				if err := testutils.IsContainerFirstEnvVarLWSLeaderAddress(got); err != nil {
 					return err
 				}
 				return nil

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -351,6 +351,16 @@ func CheckContainerHasCorrectEnvVar(pod corev1.Pod, expect corev1.EnvVar) error 
 	return nil
 }
 
+func IsContainerFirstEnvVarLWSLeaderAddress(pod corev1.Pod) error {
+	for _, container := range pod.Spec.Containers {
+		// check the first env var is the LWS_LEADER_ADDRESS
+		if container.Env[0].Name != leaderworkerset.LwsLeaderAddress {
+			return fmt.Errorf("expecting first container env var to be LWS_LEADER_ADDRESS, but got %s", container.Env[0].Name)
+		}
+	}
+	return nil
+}
+
 func HasTPUEnvVarsPopulated(pod corev1.Pod) bool {
 	return hasAllEnvVarPopulated(pod, []string{acceleratorutils.TpuWorkerHostNames, acceleratorutils.TpuWorkerId})
 }

--- a/test/testutils/wrappers.go
+++ b/test/testutils/wrappers.go
@@ -172,12 +172,32 @@ func MakePodSpecWithInitContainer() corev1.PodSpec {
 			{
 				Name:  "test",
 				Image: "busybox",
+				Env: []corev1.EnvVar{
+					corev1.EnvVar{
+						Name:  "key1",
+						Value: "value1",
+					},
+					corev1.EnvVar{
+						Name:  "key2",
+						Value: "value2",
+					},
+				},
 			},
 		},
 		InitContainers: []corev1.Container{
 			{
 				Name:  "init-test",
 				Image: "busybox",
+				Env: []corev1.EnvVar{
+					corev1.EnvVar{
+						Name:  "key1",
+						Value: "value1",
+					},
+					corev1.EnvVar{
+						Name:  "key2",
+						Value: "value2",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Quick change to make LWS_LEADER_ADDRESS to be the first container env var so we could reference that in the template from other env vars
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
