### PR TITLE
Fix missing startupPolicy in applyConfiguration

### DIFF
--- a/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetspec.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetspec.go
@@ -17,12 +17,17 @@ limitations under the License.
 
 package v1
 
+import (
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
 // LeaderWorkerSetSpecApplyConfiguration represents an declarative configuration of the LeaderWorkerSetSpec type for use
 // with apply.
 type LeaderWorkerSetSpecApplyConfiguration struct {
 	Replicas             *int32                                  `json:"replicas,omitempty"`
 	LeaderWorkerTemplate *LeaderWorkerTemplateApplyConfiguration `json:"leaderWorkerTemplate,omitempty"`
 	RolloutStrategy      *RolloutStrategyApplyConfiguration      `json:"rolloutStrategy,omitempty"`
+	StartupPolicy        *leaderworkersetv1.StartupPolicyType    `json:"startupPolicy,omitempty"`
 }
 
 // LeaderWorkerSetSpecApplyConfiguration constructs an declarative configuration of the LeaderWorkerSetSpec type for use with
@@ -52,5 +57,13 @@ func (b *LeaderWorkerSetSpecApplyConfiguration) WithLeaderWorkerTemplate(value *
 // If called multiple times, the RolloutStrategy field is set to the value of the last call.
 func (b *LeaderWorkerSetSpecApplyConfiguration) WithRolloutStrategy(value *RolloutStrategyApplyConfiguration) *LeaderWorkerSetSpecApplyConfiguration {
 	b.RolloutStrategy = value
+	return b
+}
+
+// WithStartupPolicy sets the StartupPolicy field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the StartupPolicy field is set to the value of the last call.
+func (b *LeaderWorkerSetSpecApplyConfiguration) WithStartupPolicy(value leaderworkersetv1.StartupPolicyType) *LeaderWorkerSetSpecApplyConfiguration {
+	b.StartupPolicy = &value
 	return b
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

When construcitng lws obj, found missing the startupPolicy.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
