### PR TITLE
Injecting TPU_NAME environment variable

### DIFF
--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -154,6 +154,10 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 			Name:  TpuWorkerId,
 			Value: fmt.Sprint(tpuWorkerId),
 		},
+		corev1.EnvVar{
+			Name:  "TPU_NAME",
+			Value: fmt.Sprint(pod.Name),
+		},
 	)
 	return nil
 

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -32,6 +32,7 @@ const (
 	TpuResourceName                 corev1.ResourceName = corev1.ResourceName("google.com/tpu")
 	TpuWorkerHostNames              string              = "TPU_WORKER_HOSTNAMES"
 	TpuWorkerId                     string              = "TPU_WORKER_ID"
+	TpuName                         string              = "TPU_NAME"
 	LeaderRequestsTPUsAnnotationKey string              = "leaderworkerset.sigs.k8s.io/leader-requests-tpus"
 )
 
@@ -155,7 +156,7 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 			Value: fmt.Sprint(tpuWorkerId),
 		},
 		corev1.EnvVar{
-			Name:  "TPU_NAME",
+			Name:  TpuName,
 			Value: fmt.Sprint(pod.Name),
 		},
 	)
@@ -216,7 +217,7 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 			Value: fmt.Sprint(tpuWorkerId),
 		},
 		corev1.EnvVar{
-			Name:  "TPU_NAME",
+			Name:  TpuName,
 			Value: fmt.Sprint(pod.Name),
 		},
 	)

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -157,7 +157,7 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 		},
 		corev1.EnvVar{
 			Name:  TpuName,
-			Value: fmt.Sprint(pod.Name),
+			Value: fmt.Sprint(leaderName),
 		},
 	)
 	return nil
@@ -218,7 +218,7 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 		},
 		corev1.EnvVar{
 			Name:  TpuName,
-			Value: fmt.Sprint(pod.Name),
+			Value: fmt.Sprint(leaderName),
 		},
 	)
 	return nil

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -215,6 +215,10 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 			Name:  TpuWorkerId,
 			Value: fmt.Sprint(tpuWorkerId),
 		},
+		corev1.EnvVar{
+			Name:  "TPU_NAME",
+			Value: fmt.Sprint(pod.Name),
+		},
 	)
 	return nil
 }

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -74,7 +74,7 @@ func TestAddTPUVariables(t *testing.T) {
 			hasWorkerIndexLabelKey:     true,
 			expectedTpuWorkerHostNames: "test-sample-1.default,test-sample-1-1.default,test-sample-1-2.default,test-sample-1-3.default,test-sample-1-4.default",
 			expectedTpuWorkerId:        "3",
-			expectedTpuName:            "test-sample-1-3",
+			expectedTpuName:            "test-sample-1",
 		},
 	}
 
@@ -133,7 +133,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "3",
 			expectedTpuWorkerHostNames: "test-sample-1.default,test-sample-1-1.default,test-sample-1-2.default,test-sample-1-3.default,test-sample-1-4.default",
-			expectedTpuName:            "test-sample-1-3",
+			expectedTpuName:            "test-sample-1",
 		},
 		{
 			name: "Leader requests TPU resources, worker with subgroup index > 0",
@@ -154,7 +154,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "3",
 			expectedTpuWorkerHostNames: "test-sample-1-4.default,test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default",
-			expectedTpuName:            "test-sample-1-7",
+			expectedTpuName:            "test-sample-1",
 		},
 		{
 			name: "Leader does not request TPU resources, worker with subgroup index > 0",
@@ -174,7 +174,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "0",
 			expectedTpuWorkerHostNames: "test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default,test-sample-1-8.default",
-			expectedTpuName:            "test-sample-1-5",
+			expectedTpuName:            "test-sample-1",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -35,6 +35,7 @@ func TestAddTPUVariables(t *testing.T) {
 		hasWorkerIndexLabelKey     bool
 		expectedTpuWorkerHostNames string
 		expectedTpuWorkerId        string
+		expectedTpuName            string
 	}{
 		{
 			name: "Worker Index is 0",
@@ -52,6 +53,7 @@ func TestAddTPUVariables(t *testing.T) {
 			hasWorkerIndexLabelKey:     true,
 			expectedTpuWorkerHostNames: "test-sample-1.default",
 			expectedTpuWorkerId:        "0",
+			expectedTpuName:            "test-sample-1",
 		},
 		{
 			name: "Worker Index is non-zero, size is above 2",
@@ -72,6 +74,7 @@ func TestAddTPUVariables(t *testing.T) {
 			hasWorkerIndexLabelKey:     true,
 			expectedTpuWorkerHostNames: "test-sample-1.default,test-sample-1-1.default,test-sample-1-2.default,test-sample-1-3.default,test-sample-1-4.default",
 			expectedTpuWorkerId:        "3",
+			expectedTpuName:            "test-sample-1-3",
 		},
 	}
 
@@ -95,6 +98,9 @@ func TestAddTPUVariables(t *testing.T) {
 				if diff := cmp.Diff(tc.pod.Spec.Containers[0].Env[1].Value, tc.expectedTpuWorkerId); diff != "" {
 					t.Errorf("unexpected add TPU worker ID operation: %s", diff)
 				}
+				if diff := cmp.Diff(tc.pod.Spec.Containers[0].Env[2].Value, tc.expectedTpuName); diff != "" {
+					t.Errorf("unexpected add TPU Name operation: %s", diff)
+				}
 			}
 		})
 	}
@@ -106,6 +112,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 		pod                        *corev1.Pod
 		expectedTpuWorkerHostNames string
 		expectedTpuWorkerId        string
+		expectedTpuName            string
 	}{
 		{
 			name: "Leader requests TPU resources",
@@ -126,6 +133,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "3",
 			expectedTpuWorkerHostNames: "test-sample-1.default,test-sample-1-1.default,test-sample-1-2.default,test-sample-1-3.default,test-sample-1-4.default",
+			expectedTpuName:            "test-sample-1-3",
 		},
 		{
 			name: "Leader requests TPU resources, worker with subgroup index > 0",
@@ -146,6 +154,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "3",
 			expectedTpuWorkerHostNames: "test-sample-1-4.default,test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default",
+			expectedTpuName:            "test-sample-1-7",
 		},
 		{
 			name: "Leader does not request TPU resources, worker with subgroup index > 0",
@@ -165,6 +174,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			},
 			expectedTpuWorkerId:        "0",
 			expectedTpuWorkerHostNames: "test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default,test-sample-1-8.default",
+			expectedTpuName:            "test-sample-1-5",
 		},
 	}
 	for _, tc := range tests {
@@ -178,6 +188,9 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.pod.Spec.Containers[0].Env[1].Value, tc.expectedTpuWorkerId); diff != "" {
 				t.Errorf("unexpected add TPU worker ID operation: %s", diff)
+			}
+			if diff := cmp.Diff(tc.pod.Spec.Containers[0].Env[2].Value, tc.expectedTpuName); diff != "" {
+				t.Errorf("unexpected add TPU Name operation: %s", diff)
 			}
 		})
 	}

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -367,7 +367,7 @@ func IsContainerFirstEnvVarLWSLeaderAddress(pod corev1.Pod) error {
 }
 
 func HasTPUEnvVarsPopulated(pod corev1.Pod) bool {
-	return hasAllEnvVarPopulated(pod, []string{acceleratorutils.TpuWorkerHostNames, acceleratorutils.TpuWorkerId})
+	return hasAllEnvVarPopulated(pod, []string{acceleratorutils.TpuWorkerHostNames, acceleratorutils.TpuWorkerId, acceleratorutils.TpuName})
 }
 
 func CheckTPUContainerHasCorrectEnvVars(pod corev1.Pod, envVal string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it
When requesting TPU resources, it injects the environment variable TPU_NAMES, which contains the name of the pod the TPU is in. This is needed as popular distributed runtime libraries such as Ray expect this variable to be set https://github.com/ray-project/ray/blob/ab27fe805c3fef4c8dc66bf5804f32cd522d1aad/python/ray/_private/accelerators/tpu.py#L247

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
