### PR TITLE
Make llama.cpp example become avaliable on macOS

### DIFF
--- a/docs/examples/llamacpp/dev/tasks/load-images-into-docker
+++ b/docs/examples/llamacpp/dev/tasks/load-images-into-docker
@@ -14,5 +14,9 @@ dev/tasks/start-blobserver
 
 docker buildx bake clichat --load --progress=plain
 
-docker buildx bake bartowski --load --progress=plain
+# Get the IP address of the host machine when os is darwin.
+# An Empty string means the address will be detected automatically via 
+# container default route during build.
+BLOB_SERVER=$([[ "$OSTYPE" == darwin* ]] && ipconfig getifaddr en0 || echo "")
+docker buildx bake bartowski --load --progress=plain --set bartowski.args.BLOB_SERVER="${BLOB_SERVER}"
 docker buildx bake llamacpp-worker --load --progress=plain

--- a/docs/examples/llamacpp/dev/tasks/stop-blobserver
+++ b/docs/examples/llamacpp/dev/tasks/stop-blobserver
@@ -7,4 +7,4 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}/docs/examples/llamacpp"
 
-pkill --exact blobserver || true
+kill $(pgrep -x blobserver) || true

--- a/docs/examples/llamacpp/docker-bake.hcl
+++ b/docs/examples/llamacpp/docker-bake.hcl
@@ -16,6 +16,9 @@ target "bartowski" {
   contexts = {
     llamacpp-leader = "target:llamacpp-leader"
   }
+  args = {
+    BLOB_SERVER = ""
+  }
   dockerfile = "images/bartowski/Dockerfile"
   tags = [ "llamacpp-llama3-8b-instruct-bartowski-q5km:latest" ]
 }

--- a/docs/examples/llamacpp/images/bartowski/Dockerfile
+++ b/docs/examples/llamacpp/images/bartowski/Dockerfile
@@ -1,12 +1,18 @@
 # syntax=docker/dockerfile:1
 FROM debian:bullseye AS quantizer
 
+ARG BLOB_SERVER
+
 RUN apt-get update && apt-get install --yes curl iproute2
 
 RUN mkdir -p /models/bartowski/Meta-Llama-3-8B-Instruct-GGUF
 WORKDIR /models/bartowski/Meta-Llama-3-8B-Instruct-GGUF
 # Pulling from our blobstore is much faster, even than copying from docker host
-RUN curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://$(ip -4 route show default | cut -d" " -f3):9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e
+RUN if [ -n "$BLOB_SERVER" ]; then \
+    curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://$BLOB_SERVER:9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e; \
+  else \
+    curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://$(ip -4 route show default | awk '/default/ { print $3 }'):9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e; \
+  fi
 RUN sha256sum /models/bartowski/Meta-Llama-3-8B-Instruct-GGUF/Meta-Llama-3-8B-Instruct-Q5_K_M.gguf
 
 FROM llamacpp-leader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

- ` curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://$(ip -4 route show default | awk '/default/ { print $3 }'):9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e; \` can not find the correct host IP when I run script on macOS
- the `--exact` option is unavailable on macOS

Test result:

```
(base) ➜  llamacpp git:(main) ✗ dev/tasks/run-in-kind
...
#23 [bartowski quantizer 5/6] RUN if [ -n "10.64.0.228" ]; then     curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://10.64.0.228:9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e;   else     curl -v -L --fail -o Meta-Llama-3-8B-Instruct-Q5_K_M.gguf http://$(ip -4 route show default | awk '/default/ { print $3 }'):9999/16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e;   fi
 24 5467M   24 1317M    0     0  6518k      0  0:14:18  0:03:26  0:10:52 1393k
...
leaderworkerset.leaderworkerset.x-k8s.io/llamacpp-llama3-8b-instruct-bartowski-q5km serverside-applied
service/llamacpp serverside-applied
+ kubectl run clichat --image=clichat:latest --rm=true -it --image-pull-policy=IfNotPresent --env=LLM_ENDPOINT=http://llamacpp:80
If you don't see a command prompt, try pressing enter.

> who are you
	I am LLaMA, a helpful AI assistant. I'm here to assist you with any questions or tasks you may have.
```


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
