### PR TITLE
Deprecated DefaultRestartPolicy with NoneRestartPolicy

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -152,8 +152,10 @@ type LeaderWorkerTemplate struct {
 	Size *int32 `json:"size,omitempty"`
 
 	// RestartPolicy defines the restart policy when pod failures happen.
-	// +kubebuilder:default=Default
-	// +kubebuilder:validation:Enum={Default,RecreateGroupOnPodRestart}
+	// The former named Default policy is deprecated, will be removed in the future,
+	// replace with None policy for the same behavior.
+	// +kubebuilder:default=RecreateGroupOnPodRestart
+	// +kubebuilder:validation:Enum={Default,RecreateGroupOnPodRestart,None}
 	// +optional
 	RestartPolicy RestartPolicyType `json:"restartPolicy,omitempty"`
 
@@ -255,15 +257,21 @@ const (
 type RestartPolicyType string
 
 const (
-	// RecreateGroupOnPodRestart will recreate all the pods in the group if
+	// DefaultRestartPolicy will recreate all the pods in the group if
 	// 1. Any individual pod in the group is recreated; 2. Any containers/init-containers
 	// in a pod is restarted. This is to ensure all pods/containers in the group will be
 	// started in the same time.
-	RecreateGroupOnPodRestart RestartPolicyType = "RecreateGroupOnPodRestart"
+	DefaultRestartPolicy RestartPolicyType = "RecreateGroupOnPodRestart"
 
 	// Default will follow the same behavior as the StatefulSet where only the failed pod
 	// will be restarted on failure and other pods in the group will not be impacted.
-	DefaultRestartPolicy RestartPolicyType = "Default"
+	//
+	// Note: deprecated, use NoneRestartPolicy instead.
+	DeprecatedDefaultRestartPolicy RestartPolicyType = "Default"
+
+	// None will follow the same behavior as the StatefulSet where only the failed pod
+	// will be restarted on failure and other pods in the group will not be impacted.
+	NoneRestartPolicy RestartPolicyType = "None"
 )
 
 type StartupPolicyType string

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -257,11 +257,11 @@ const (
 type RestartPolicyType string
 
 const (
-	// DefaultRestartPolicy will recreate all the pods in the group if
+	// RecreateGroupOnPodRestart will recreate all the pods in the group if
 	// 1. Any individual pod in the group is recreated; 2. Any containers/init-containers
 	// in a pod is restarted. This is to ensure all pods/containers in the group will be
 	// started in the same time.
-	DefaultRestartPolicy RestartPolicyType = "RecreateGroupOnPodRestart"
+	RecreateGroupOnPodRestart RestartPolicyType = "RecreateGroupOnPodRestart"
 
 	// Default will follow the same behavior as the StatefulSet where only the failed pod
 	// will be restarted on failure and other pods in the group will not be impacted.

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -8063,12 +8063,15 @@ spec:
                         type: object
                     type: object
                   restartPolicy:
-                    default: Default
-                    description: RestartPolicy defines the restart policy when pod
-                      failures happen.
+                    default: RecreateGroupOnPodRestart
+                    description: |-
+                      RestartPolicy defines the restart policy when pod failures happen.
+                      The Default policy is deprecated, will be removed in the future, replace
+                      with None for the same behavior.
                     enum:
                     - Default
                     - RecreateGroupOnPodRestart
+                    - None
                     type: string
                   size:
                     default: 1

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -8066,8 +8066,8 @@ spec:
                     default: RecreateGroupOnPodRestart
                     description: |-
                       RestartPolicy defines the restart policy when pod failures happen.
-                      The Default policy is deprecated, will be removed in the future, replace
-                      with None for the same behavior.
+                      The former named Default policy is deprecated, will be removed in the future,
+                      replace with None policy for the same behavior.
                     enum:
                     - Default
                     - RecreateGroupOnPodRestart

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -58,7 +58,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				}).
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				Size(1).
-				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
+				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -259,7 +259,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				}).
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				Size(1).
-				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
+				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -58,7 +58,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				}).
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				Size(1).
-				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
+				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -125,7 +125,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				}).
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				Size(2).
-				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
+				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -193,7 +193,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).
 				Size(2).
-				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
+				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -259,7 +259,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				}).
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				Size(1).
-				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
+				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -326,7 +326,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
 				LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).
 				Size(2).
-				RestartPolicy(leaderworkerset.DefaultRestartPolicy).Obj(),
+				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -165,7 +165,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod, leaderWorkerSet leaderworkerset.LeaderWorkerSet) (bool, error) {
-	if leaderWorkerSet.Spec.LeaderWorkerTemplate.RestartPolicy != leaderworkerset.RecreateGroupOnPodRestart {
+	if leaderWorkerSet.Spec.LeaderWorkerTemplate.RestartPolicy != leaderworkerset.DefaultRestartPolicy {
 		return false, nil
 	}
 	// the leader pod will be deleted if the worker pod is deleted or any containes were restarted

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -165,7 +165,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod, leaderWorkerSet leaderworkerset.LeaderWorkerSet) (bool, error) {
-	if leaderWorkerSet.Spec.LeaderWorkerTemplate.RestartPolicy != leaderworkerset.DefaultRestartPolicy {
+	if leaderWorkerSet.Spec.LeaderWorkerTemplate.RestartPolicy != leaderworkerset.RecreateGroupOnPodRestart {
 		return false, nil
 	}
 	// the leader pod will be deleted if the worker pod is deleted or any containes were restarted

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -57,6 +57,10 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, obj runtime.Object
 		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.DefaultRestartPolicy
 	}
 
+	if lws.Spec.LeaderWorkerTemplate.RestartPolicy == v1.DeprecatedDefaultRestartPolicy {
+		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.NoneRestartPolicy
+	}
+
 	if lws.Spec.RolloutStrategy.Type == "" {
 		lws.Spec.RolloutStrategy.Type = v1.RollingUpdateStrategyType
 	}

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -54,7 +54,7 @@ var _ webhook.CustomDefaulter = &LeaderWorkerSetWebhook{}
 func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	lws := obj.(*v1.LeaderWorkerSet)
 	if lws.Spec.LeaderWorkerTemplate.RestartPolicy == "" {
-		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.DefaultRestartPolicy
+		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.RecreateGroupOnPodRestart
 	}
 
 	if lws.Spec.LeaderWorkerTemplate.RestartPolicy == v1.DeprecatedDefaultRestartPolicy {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can deploy lws with 'replicas', 'size', and 'restart policy' set", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).Size(5).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).Size(5).RestartPolicy(v1.NoneRestartPolicy).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 
 		gomega.Expect(*lws.Spec.Replicas).To(gomega.Equal(int32(4)))
 		gomega.Expect(*lws.Spec.LeaderWorkerTemplate.Size).To(gomega.Equal(int32(5)))
-		gomega.Expect(lws.Spec.LeaderWorkerTemplate.RestartPolicy).To(gomega.Equal(v1.RecreateGroupOnPodRestart))
+		gomega.Expect(lws.Spec.LeaderWorkerTemplate.RestartPolicy).To(gomega.Equal(v1.NoneRestartPolicy))
 
 		expectedLabels := []string{v1.SetNameLabelKey, v1.GroupIndexLabelKey, v1.WorkerIndexLabelKey, v1.TemplateRevisionHashKey}
 		expectedAnnotations := []string{v1.LeaderPodNameAnnotationKey, v1.SizeAnnotationKey}
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can create/update a lws with size=1", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.DefaultRestartPolicy).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
@@ -262,8 +262,8 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 		}
 	})
 
-	ginkgo.It("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+	ginkgo.It("Pod restart will delete the pod group when restart policy is DefaultRestartPolicy", func() {
+		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.DefaultRestartPolicy).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can create/update a lws with size=1", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.DefaultRestartPolicy).Obj()
+		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
@@ -262,8 +262,8 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 		}
 	})
 
-	ginkgo.It("Pod restart will delete the pod group when restart policy is DefaultRestartPolicy", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.DefaultRestartPolicy).Obj()
+	ginkgo.It("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", func() {
+		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -420,9 +420,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("Pod restart will delete the pod group when restart policy is DefaultRestartPolicy", &testCase{
+		ginkgo.Entry("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.DefaultRestartPolicy).Replica(1).Size(3)
+				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Replica(1).Size(3)
 			},
 			updates: []*update{
 				{

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -391,9 +391,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("Pod restart will not recreate the pod group when restart policy is Default", &testCase{
+		ginkgo.Entry("Pod restart will not recreate the pod group when restart policy is None", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.DefaultRestartPolicy).Replica(1).Size(3)
+				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.NoneRestartPolicy).Replica(1).Size(3)
 			},
 			updates: []*update{
 				{
@@ -420,9 +420,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 			},
 		}),
-		ginkgo.Entry("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", &testCase{
+		ginkgo.Entry("Pod restart will delete the pod group when restart policy is DefaultRestartPolicy", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Replica(1).Size(3)
+				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.DefaultRestartPolicy).Replica(1).Size(3)
 			},
 			updates: []*update{
 				{

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -102,10 +102,18 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 		}),
 		ginkgo.Entry("defaulting logic won't apply when leaderworkertemplate.restartpolicy is set", &testDefaultingCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
+			},
+		}),
+		ginkgo.Entry("DeprecatedDefaultRestartPolicy will be shift to NoneRestartPolicy", &testDefaultingCase{
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.DeprecatedDefaultRestartPolicy)
+			},
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 		}),
 		ginkgo.Entry("defaulting logic applies when spec.startpolicy is not set", &testDefaultingCase{
@@ -364,7 +372,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 		}),
 		ginkgo.Entry("set restart policy should succeed", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 			lwsCreationShouldFail: false,
 		}),

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return lwsWrapper
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).RestartPolicy(leaderworkerset.DefaultRestartPolicy)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("apply defaulting logic for size", &testDefaultingCase{
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return lwsWrapper
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Size(1).RestartPolicy(leaderworkerset.DefaultRestartPolicy)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Size(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic won't apply when shouldn't", &testDefaultingCase{
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2)
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).RestartPolicy(leaderworkerset.DefaultRestartPolicy)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic applies when leaderworkertemplate.restartpolicy is not set", &testDefaultingCase{
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy("")
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.DefaultRestartPolicy)
+				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic won't apply when leaderworkertemplate.restartpolicy is set", &testDefaultingCase{
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return testutils.BuildLeaderWorkerSet(ns.Name).RolloutStrategy(leaderworkerset.RolloutStrategy{}) // unset rollout strategy
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.DefaultRestartPolicy).RolloutStrategy(leaderworkerset.RolloutStrategy{
+				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
 					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
 						MaxUnavailable: intstr.FromInt32(1),
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			},
 			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
 				return testutils.BuildLeaderWorkerSet(ns.Name).
-					RestartPolicy(leaderworkerset.DefaultRestartPolicy).
+					RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{

--- a/test/testutils/wrappers.go
+++ b/test/testutils/wrappers.go
@@ -136,7 +136,7 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws.Namespace = nsName
 	lws.Spec = leaderworkerset.LeaderWorkerSetSpec{}
 	lws.Spec.Replicas = ptr.To[int32](2)
-	lws.Spec.LeaderWorkerTemplate = leaderworkerset.LeaderWorkerTemplate{RestartPolicy: leaderworkerset.DefaultRestartPolicy}
+	lws.Spec.LeaderWorkerTemplate = leaderworkerset.LeaderWorkerTemplate{RestartPolicy: leaderworkerset.RecreateGroupOnPodRestart}
 	lws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](2)
 	lws.Spec.LeaderWorkerTemplate.LeaderTemplate = &corev1.PodTemplateSpec{}
 	lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec = MakeLeaderPodSpec()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/lws/issues/204

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deprecated the DefaultRestartPolicy and replace with NoneRestartPolicy
```
