### PR TITLE
Update KEP #173 to reflect implementation

### DIFF
--- a/keps/173-headless-service-per-replica/README.md
+++ b/keps/173-headless-service-per-replica/README.md
@@ -45,7 +45,7 @@ tags, and then generate with `hack/update-toc.sh`.
 ## Summary
 
 LeaderWorkerSet creates a single headless service for the entire object.
-This KEP is about allowing one to create a headless service for every replica of LWSs.
+This KEP is about allowing one to create a headless service for every replica of LWS.
 
 ## Motivation
 

--- a/keps/173-headless-service-per-replica/README.md
+++ b/keps/173-headless-service-per-replica/README.md
@@ -45,7 +45,7 @@ tags, and then generate with `hack/update-toc.sh`.
 ## Summary
 
 LeaderWorkerSet creates a single headless service for the entire object.
-This KEP is about allowing one to create a headless service that all replicas will share.
+This KEP is about allowing one to create a headless service for every replica of LWSs.
 
 ## Motivation
 

--- a/keps/173-headless-service-per-replica/README.md
+++ b/keps/173-headless-service-per-replica/README.md
@@ -26,7 +26,7 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
-  - [LeaderWorkerSet API](#leaderworkerset-api)
+  - [API](#api)
   - [Implementation](#implementation)
     - [Creation and Deletion of Headless Services](#creation-and-deletion-of-headless-services)
     - [Transition from Different Subdomain Policies](#transition-from-different-subdomain-policies)
@@ -123,7 +123,7 @@ required) or even code snippets. If there's any ambiguity about HOW your
 proposal will be implemented, this is the place to discuss them.
 -->
 
-### LeaderWorkerSet API
+### API
 
 We extend the LeaderWorkerSet API to introduce a new field: `NetworkConfig`. This field will have a subfield called `subDomainPolicy`. If set to `Shared`, LWS will create a single headless service per LWS manifest. If set to `UniquePerReplica`, it will create a headless service per replica. `subDomainPolicy` is a mutable field, and will trigger a rolling update when changed. 
 
@@ -158,7 +158,7 @@ const (
 The existing logic for creating the headless service will be used for the `Shared` option. 
 
 #### Creation and Deletion of Headless Services
-The pod controller will create the headless service if a leader pod is being reconciled. The leader pod is set as the owner of the service, so that when a leaderPod is restarted or deleted, the headless service is the deleted as well. The name of each headless service will be the same as the leader pod's name. 
+The pod controller will create the headless service if a leader pod is being reconciled. The leader pod is set as the owner of the service, so that when a leaderPod is restarted or deleted, the headless service is deleted as well. The name of each headless service will be the same as the leader pod's name. 
 
 
 #### Transition from Different Subdomain Policies
@@ -292,6 +292,7 @@ milestones with these graduation criteria:
 ## Implementation History
 
 KEP drafted: August 6th, 2024
+
 KEP updated: October 17th, 2024
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.

--- a/keps/173-headless-service-per-replica/README.md
+++ b/keps/173-headless-service-per-replica/README.md
@@ -158,7 +158,7 @@ const (
 The existing logic for creating the headless service will be used for the `Shared` option. 
 
 #### Creation and Deletion of Headless Services
-The pod controller will create the headless service if a leader pod is being reconciled. The leader pod is set as the owner of the service, so that when a leaderPod is restarted or deleted, the headless service is deleted as well. The name of each headless service will be the same as the leader pod's name. 
+The pod controller will create the headless service if a leader pod is being reconciled. The leader pod is set as the owner of the service, so that when a leaderPod is restarted or deleted, the headless service is deleted as well. The name of each headless service will be the same as the leader pod's name. In order for the headless service only select the pods in each replica, `leaderworkerset.sigs.k8s.io/group-index` will be used as selector to differentiate between LWS replicas, and `leaderworkerset.sigs.k8s.io/name` to differentiate between other LWS deployments.
 
 
 #### Transition from Different Subdomain Policies

--- a/keps/173-headless-service-per-replica/README.md
+++ b/keps/173-headless-service-per-replica/README.md
@@ -45,7 +45,7 @@ tags, and then generate with `hack/update-toc.sh`.
 ## Summary
 
 LeaderWorkerSet creates a single headless service for the entire object.
-This KEP is about allowing one to create a headless service per LWS replica.
+This KEP is about allowing one to create a headless service that all replicas will share.
 
 ## Motivation
 
@@ -125,7 +125,7 @@ proposal will be implemented, this is the place to discuss them.
 
 ### API
 
-We extend the LeaderWorkerSet API to introduce a new field: `NetworkConfig`. This field will have a subfield called `subDomainPolicy`. If set to `Shared`, LWS will create a single headless service per LWS manifest. If set to `UniquePerReplica`, it will create a headless service per replica. `subDomainPolicy` is a mutable field, and will trigger a rolling update when changed. 
+We extend the LeaderWorkerSet API to introduce a new field: `NetworkConfig`. This field will have a subfield called `subDomainPolicy`. If set to `Shared`, LWS will create a single headless service for all replicas to share. If set to `UniquePerReplica`, it will create a headless service per replica. `subDomainPolicy` is a mutable field, and will trigger a rolling update when changed. 
 
 In order to ensure backwards compatability, the default value will be `Shared`.
 
@@ -162,9 +162,9 @@ The pod controller will create the headless service if a leader pod is being rec
 
 
 #### Transition from Different Subdomain Policies
-When transitioning from `Shared` to `UniquePerReplica`, there will be one more headless service than number of replicas. This is because the LWS level headless service will not be deleted, allowing for a safer transition.
+When transitioning from `Shared` to `UniquePerReplica`, there will be one more headless service than number of replicas. This is because the shared headless service will not be deleted, allowing for a safer transition.
 
-When transitioning from `UniquePerReplica` to `Shared`, the LWS level headless service is created as soon as the transition starts. Once each replica is updated to `Shared`, their respective headless service will be deleted. 
+When transitioning from `UniquePerReplica` to `Shared`, the shared headless service is created as soon as the transition starts. Once each replica is updated to `Shared`, their respective headless service will be deleted. 
 
 
 #### Environment Variable Injection and Rolling Update


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #228 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
