### PR TITLE
Automated cherry pick of #250: change to not use NetworkConfig in hash calculation if it has default value

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,7 +41,7 @@ func NonZeroValue(value int32) int32 {
 }
 
 func LeaderWorkerTemplateHash(lws *leaderworkerset.LeaderWorkerSet) string {
-	if lws.Spec.NetworkConfig == nil {
+	if lws.Spec.NetworkConfig == nil || string(*lws.Spec.NetworkConfig.SubdomainPolicy) == string(leaderworkerset.SubdomainShared) {
 		return Sha1Hash(lws.Spec.LeaderWorkerTemplate.LeaderTemplate.String() +
 			lws.Spec.LeaderWorkerTemplate.WorkerTemplate.String())
 	}


### PR DESCRIPTION
Cherry pick of #250 on release-0.4.0.

#250: change to not use NetworkConfig in hash calculation if it has default value

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```