### PR TITLE
Unify Leader Election Namespace with Deployment Namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,13 +61,12 @@ func main() {
 		namespace   string
 
 		// leader election
-		enableLeaderElection         bool
-		leaderElectLeaseDuration     time.Duration
-		leaderElectRenewDeadline     time.Duration
-		leaderElectRetryPeriod       time.Duration
-		leaderElectResourceLock      string
-		leaderElectionID             string
-		leaderElectResourceNamespace string
+		enableLeaderElection     bool
+		leaderElectLeaseDuration time.Duration
+		leaderElectRenewDeadline time.Duration
+		leaderElectRetryPeriod   time.Duration
+		leaderElectResourceLock  string
+		leaderElectionID         string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -92,8 +91,6 @@ func main() {
 			"'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'")
 	flag.StringVar(&leaderElectionID, "leader-elect-resource-name", "b8b2488c.x-k8s.io",
 		"The name of resource object that is used for locking during leader election. ")
-	flag.StringVar(&leaderElectResourceNamespace, "leader-elect-resource-namespace", "lws-system",
-		"The namespace of resource object that is used for locking during leader election.")
 	flag.StringVar(&namespace, "namespace", "lws-system", "The namespace that is used to deploy leaderWorkerSet controller")
 
 	opts := zap.Options{
@@ -115,7 +112,7 @@ func main() {
 		LeaderElection:             enableLeaderElection,
 		LeaderElectionID:           leaderElectionID,
 		LeaderElectionResourceLock: leaderElectResourceLock,
-		LeaderElectionNamespace:    leaderElectResourceNamespace,
+		LeaderElectionNamespace:    namespace, // Using namespace variable here
 		LeaseDuration:              &leaderElectLeaseDuration,
 		RenewDeadline:              &leaderElectRenewDeadline,
 		RetryPeriod:                &leaderElectRetryPeriod,


### PR DESCRIPTION
This commit removes the separate leaderElectResourceNamespace flag and directly assigns the namespace flag value for leader election. This ensures consistency by using the same namespace for deployment and leader election, simplifying the configuration.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it
This commit removes the separate `leaderElectResourceNamespace` flag
and directly assigns the `namespace` flag value for leader election.
This ensures consistency by using the same namespace for deployment
and leader election, simplifying the configuration.
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #262 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
