### PR TITLE
Use the namespace of the service account

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	"sigs.k8s.io/lws/pkg/cert"
 	"sigs.k8s.io/lws/pkg/controllers"
+	"sigs.k8s.io/lws/pkg/utils"
 	"sigs.k8s.io/lws/pkg/webhooks"
 	//+kubebuilder:scaffold:imports
 )
@@ -58,7 +59,6 @@ func main() {
 		probeAddr   string
 		qps         float64
 		burst       int
-		namespace   string
 
 		// leader election
 		enableLeaderElection     bool
@@ -91,7 +91,6 @@ func main() {
 			"'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'")
 	flag.StringVar(&leaderElectionID, "leader-elect-resource-name", "b8b2488c.x-k8s.io",
 		"The name of resource object that is used for locking during leader election. ")
-	flag.StringVar(&namespace, "namespace", "lws-system", "The namespace that is used to deploy leaderWorkerSet controller")
 
 	opts := zap.Options{
 		Development: true,
@@ -104,6 +103,7 @@ func main() {
 	kubeConfig := ctrl.GetConfigOrDie()
 	kubeConfig.QPS = float32(qps)
 	kubeConfig.Burst = burst
+	namespace := utils.GetOperatorNamespace()
 
 	mgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme:                     scheme,

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -36,5 +36,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--namespace=lws-system"
         - "--zap-log-level=2"

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -67,36 +67,6 @@ To uninstall LeaderWorkerSet, run the following command:
 make undeploy
 ```
 
-# Install in a different namespace
-
-To install the leaderWorkerSet controller in a different namespace rather than `lws-system`, you should first:
-
-```sh
-git clone https://github.com/kubernetes-sigs/lws.git
-cd lws
-```
-
-Then change the [kustomization.yaml](../../config/default/kustomization.yaml) _namespace_ field as:
-
-```yaml
-namespace: <your-namespace>
-```
-
-You should change the [manager_auth_proxy_patch.yaml](../../config/default/manager_auth_proxy_patch.yaml) as well:
-
-```yaml
-- name: manager
-  args:
-  - "--namespace=<your-namespace>"
-```
-
-Finally run:
-
-```
-IMAGE_REGISTRY=<registry>/<project> make image-push deploy
-```
-
-
 # Optional: Use cert manager instead of internal cert
 The webhooks use an internal certificate by default. However, if you wish to use cert-manager (which
 supports cert rotation), instead of internal cert, you can by performing the following steps.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,11 +19,17 @@ package utils
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"os"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+const (
+	defaultNamespace = "lws-system"
 )
 
 // Sha1Hash accepts an input string and returns the 40 character SHA1 hash digest of the input string.
@@ -69,4 +75,14 @@ func SortByIndex[T appsv1.StatefulSet | corev1.Pod | int](indexFunc func(T) (int
 	}
 
 	return result
+}
+
+// GetOperatorNamespace will pick the namespace based on the serviceaccount
+func GetOperatorNamespace() string {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+	return defaultNamespace
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Users should not need to specify namespace in the deployment of the LWS operator. 
We want to default the namespace to where the serviceaccount of LWS lives. This allows us to avoid configuration problems where a user specifies the wrong namespace for the CLI and the deployment went to other namespace. In this case, the pod is non functional.

 
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
If the namespace of leaderworkerset deployment is different from default, we will take the service account for the namespace.
```
