### PR TITLE
Remove `namespace` arg from manager command

### DIFF
--- a/charts/lws/templates/manager/deployment.yaml
+++ b/charts/lws/templates/manager/deployment.yaml
@@ -36,7 +36,6 @@ spec:
           - --health-probe-bind-address=:8081
           - --metrics-bind-address=127.0.0.1:8080
           - --leader-elect
-          - --namespace={{ .Release.Namespace }}
           - --zap-log-level=2
           command:
           - /manager


### PR DESCRIPTION
There is no `--namespace` flag on manager.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

#### Which issue(s) this PR fixes

N/A

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
