### PR TITLE
Tests for Controller Revision

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -577,7 +577,7 @@ func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Co
 		// the revisionKey was used to detect update instead of controller revision.
 		revisionKey = revisionutils.GetRevisionKey(sts)
 	}
-	if stsRevision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); sts != nil || err != nil {
+	if stsRevision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); stsRevision != nil || err != nil {
 		return stsRevision, err
 	}
 	revision, err := revisionutils.NewRevision(ctx, r.Client, lws, revisionKey)

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -387,7 +387,6 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 			readyCount++
 		}
 		if (noWorkerSts || revisionutils.GetRevisionKey(&sts) == revisionKey) && revisionutils.GetRevisionKey(&pod) == revisionKey {
-			// log.Error(nil, fmt.Sprintf("revisionKey of %s does not match the revisionKey in pod %s", sts.Name, pod.Name))
 			updated = true
 			updatedCount++
 			if index < int(*lws.Spec.Replicas) {

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -387,6 +387,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 			readyCount++
 		}
 		if (noWorkerSts || revisionutils.GetRevisionKey(&sts) == revisionKey) && revisionutils.GetRevisionKey(&pod) == revisionKey {
+			// log.Error(nil, fmt.Sprintf("revisionKey of %s does not match the revisionKey in pod %s", sts.Name, pod.Name))
 			updated = true
 			updatedCount++
 			if index < int(*lws.Spec.Replicas) {

--- a/pkg/utils/revision/revision_utils.go
+++ b/pkg/utils/revision/revision_utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023.
+Copyright 2025.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/revision/revision_utils.go
+++ b/pkg/utils/revision/revision_utils.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package revision
 
 import (
@@ -97,7 +113,8 @@ func GetRevision(ctx context.Context, k8sClient client.Client, lws *leaderworker
 		return nil, nil
 	}
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{
-		leaderworkerset.RevisionKey: revisionKey,
+		leaderworkerset.SetNameLabelKey: lws.Name,
+		leaderworkerset.RevisionKey:     revisionKey,
 	}})
 	if err != nil {
 		return nil, err
@@ -168,10 +185,6 @@ func ApplyRevision(lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.Contro
 func EqualRevision(lhs *appsv1.ControllerRevision, rhs *appsv1.ControllerRevision) bool {
 	if lhs == nil || rhs == nil {
 		return lhs == rhs
-	}
-
-	if GetRevisionKey(lhs) == GetRevisionKey(rhs) {
-		return true
 	}
 
 	return bytes.Equal(lhs.Data.Raw, rhs.Data.Raw) && apiequality.Semantic.DeepEqual(lhs.Data.Object, rhs.Data.Object)

--- a/pkg/utils/revision/revision_utils_test.go
+++ b/pkg/utils/revision/revision_utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -31,7 +32,7 @@ import (
 func TestApplyRevision(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
 
-	lws := BuildLeaderWorkerSet("default")
+	lws := BuildLeaderWorkerSet("default").Obj()
 	revision, err := NewRevision(context.TODO(), client, lws, "")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +78,135 @@ func TestApplyRevision(t *testing.T) {
 	}
 }
 
-func BuildLeaderWorkerSet(nsName string) *leaderworkerset.LeaderWorkerSet {
+func TestEqualRevision(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	tests := []struct {
+		name             string
+		leftLws          *leaderworkerset.LeaderWorkerSet
+		rightLws         *leaderworkerset.LeaderWorkerSet
+		leftRevisionKey  string
+		rightRevisionKey string
+		equal            bool
+	}{
+		{
+			name:             "same LeaderWorkerTemplate, networkConfig, should be equal",
+			leftLws:          BuildLeaderWorkerSet("default").Obj(),
+			rightLws:         BuildLeaderWorkerSet("default").Obj(),
+			leftRevisionKey:  "",
+			rightRevisionKey: "",
+			equal:            true,
+		},
+		{
+			name:             "same LeaderWorkerTemplate, networkConfig, different revisionKey, should be equal",
+			leftLws:          BuildLeaderWorkerSet("default").Obj(),
+			rightLws:         BuildLeaderWorkerSet("default").Obj(),
+			leftRevisionKey:  "",
+			rightRevisionKey: "templateHash",
+			equal:            true,
+		},
+		{
+			name:             "left nil, right nil, should be equal",
+			leftLws:          nil,
+			rightLws:         nil,
+			leftRevisionKey:  "",
+			rightRevisionKey: "",
+			equal:            true,
+		},
+		{
+			name:             "left nil, right non-nil, should not be equal",
+			leftLws:          nil,
+			rightLws:         BuildLeaderWorkerSet("default").Obj(),
+			leftRevisionKey:  "",
+			rightRevisionKey: "",
+			equal:            false,
+		},
+		{
+			name:             "same LeaderWorkerTemplate, different networkConfig, should not be equal",
+			leftLws:          BuildLeaderWorkerSet("default").SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica).Obj(),
+			rightLws:         BuildLeaderWorkerSet("default").Obj(),
+			leftRevisionKey:  "",
+			rightRevisionKey: "",
+			equal:            false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var leftRevision *appsv1.ControllerRevision
+			var rightRevision *appsv1.ControllerRevision
+			var err error
+			if tc.leftLws != nil {
+				leftRevision, err = NewRevision(context.TODO(), client, tc.leftLws, tc.leftRevisionKey)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.rightLws != nil {
+				rightRevision, err = NewRevision(context.TODO(), client, tc.rightLws, tc.rightRevisionKey)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			equal := EqualRevision(leftRevision, rightRevision)
+			if tc.equal != equal {
+				t.Errorf("Expected equality between controller revisions to be %t, but was %t", tc.equal, equal)
+			}
+		})
+	}
+}
+
+func TestGetHighestRevision(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	lws := BuildLeaderWorkerSet("default").Obj()
+	revision1, err := NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision2 := revision1.DeepCopy()
+	revision2.Revision = 2
+	revision3 := revision2.DeepCopy()
+	revision3.Revision = 3
+	tests := []struct {
+		name             string
+		revisions        []*appsv1.ControllerRevision
+		expectedRevision *appsv1.ControllerRevision
+	}{
+		{
+			name:             "empty revision list, returns nil",
+			revisions:        []*appsv1.ControllerRevision{},
+			expectedRevision: nil,
+		},
+		{
+			name:             "only one revision in list, returns it",
+			revisions:        []*appsv1.ControllerRevision{revision1},
+			expectedRevision: revision1,
+		},
+		{
+			name:             "returns the revision with highest revision number",
+			revisions:        []*appsv1.ControllerRevision{revision2, revision3, revision2},
+			expectedRevision: revision3,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			revision := getHighestRevision(tc.revisions)
+			if tc.expectedRevision == nil {
+				if revision != nil {
+					t.Errorf("Expected revision to be nil")
+				}
+			} else {
+				if tc.expectedRevision.Revision != revision.Revision {
+					t.Errorf("Expected revision number to be %d, but it was %d", tc.expectedRevision.Revision, revision.Revision)
+				}
+			}
+		})
+	}
+}
+
+type LeaderWorkerSetWrapper struct {
+	leaderworkerset.LeaderWorkerSet
+}
+
+func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws := leaderworkerset.LeaderWorkerSet{}
 	lws.Name = "test-sample"
 	lws.Namespace = nsName
@@ -102,7 +231,30 @@ func BuildLeaderWorkerSet(nsName string) *leaderworkerset.LeaderWorkerSet {
 		SubdomainPolicy: &subdomainPolicy,
 	}
 
-	return &lws
+	return &LeaderWorkerSetWrapper{
+		lws,
+	}
+}
+
+func (lwsWrapper *LeaderWorkerSetWrapper) Obj() *leaderworkerset.LeaderWorkerSet {
+	return &lwsWrapper.LeaderWorkerSet
+}
+
+func (lwsWrapper *LeaderWorkerSetWrapper) SubdomainPolicy(subdomainPolicy leaderworkerset.SubdomainPolicy) *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.NetworkConfig = &leaderworkerset.NetworkConfig{
+		SubdomainPolicy: &subdomainPolicy,
+	}
+	return lwsWrapper
+}
+
+func (lwsWrapper *LeaderWorkerSetWrapper) MaxUnavailable(value int) *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt(value)
+	return lwsWrapper
+}
+
+func (lwsWrapper *LeaderWorkerSetWrapper) MaxSurge(value int) *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt(value)
+	return lwsWrapper
 }
 
 func MakeLeaderPodSpec() corev1.PodSpec {

--- a/pkg/utils/revision/revision_utils_test.go
+++ b/pkg/utils/revision/revision_utils_test.go
@@ -105,6 +105,14 @@ func TestEqualRevision(t *testing.T) {
 			equal:            true,
 		},
 		{
+			name:             "same LeaderWorkerTemplate, shared subdomainpolicy & nil, should be equal",
+			leftLws:          BuildLeaderWorkerSet("default").SubdomainPolicy(leaderworkerset.SubdomainShared).Obj(),
+			rightLws:         BuildLeaderWorkerSet("default").SubdomainNil().Obj(),
+			leftRevisionKey:  "",
+			rightRevisionKey: "",
+			equal:            true,
+		},
+		{
 			name:             "left nil, right nil, should be equal",
 			leftLws:          nil,
 			rightLws:         nil,
@@ -260,6 +268,10 @@ func (lwsWrapper *LeaderWorkerSetWrapper) SubdomainPolicy(subdomainPolicy leader
 	lwsWrapper.Spec.NetworkConfig = &leaderworkerset.NetworkConfig{
 		SubdomainPolicy: &subdomainPolicy,
 	}
+	return lwsWrapper
+}
+func (lwsWrapper *LeaderWorkerSetWrapper) SubdomainNil() *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.NetworkConfig = nil
 	return lwsWrapper
 }
 

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -1592,7 +1592,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.DeleteLeaderPod(ctx, k8sClient, lws, 0, 1)
 						var leaderSts appsv1.StatefulSet
 						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
-						testing.CreateNotUpdatedLeaderPods(ctx, leaderSts, k8sClient, lws, 0, 1)
+						testing.CreateLeaderPodsFromRevisionNumber(ctx, leaderSts, k8sClient, lws, 0, 1, 1)
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
@@ -1675,7 +1675,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						var leaderPod corev1.Pod
 						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name + "-3", Namespace: lws.Namespace}, &leaderPod)).To(gomega.Succeed())
-						gomega.Expect(leaderPod.DeletionTimestamp == nil).To(gomega.BeTrue())
+						gomega.Consistently(leaderPod.DeletionTimestamp == nil, testing.Timeout, testing.Interval).Should(gomega.BeTrue())
 					},
 				},
 				{

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -1531,6 +1531,158 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("Not updated worker gets recreated with old worker spec if restarted during update", &testCase{
+			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
+				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			},
+			updates: []*update{
+				{
+					// Set lws to available condition.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 4)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+					},
+				},
+				{
+					// Check the rolling update initial state.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.UpdateWorkerTemplate(ctx, k8sClient, lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+					},
+				},
+				{
+					// Rolling update 1 replica.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-3", lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-3")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-2")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-1")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+					},
+				},
+				{
+					// Delete the leaderPod and re-create it to force workerSts to be created
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.DeleteLeaderPod(ctx, k8sClient, lws, 0, 1)
+						var leaderSts appsv1.StatefulSet
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						testing.CreateNotUpdatedLeaderPods(ctx, leaderSts, k8sClient, lws, 0, 1)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-3")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-2")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-1")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+					},
+				},
+				{
+					// Rolling update all the replicas will make the leader statefulset ready again.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 4)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+					},
+				},
+			},
+		}),
+		ginkgo.Entry("leader with RecreateGroupOnPodRestart only gets restarted once during rolling update", &testCase{
+			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
+				return testing.BuildLeaderWorkerSet(nsName).Replica(4).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			},
+			updates: []*update{
+				{
+					// Set lws to available condition.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 4)
+						var leaderPod corev1.Pod
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name + "-3", Namespace: lws.Namespace}, &leaderPod)).To(gomega.Succeed())
+						testing.CreateWorkerPodsForLeaderPod(ctx, leaderPod, k8sClient, *lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+					},
+				},
+				{
+					// Check the rolling update initial state.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.UpdateWorkerTemplate(ctx, k8sClient, lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+					},
+				},
+				{
+					// Update LeaderPod. Triggers the first restart
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-3", lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+					},
+				},
+				{ // The workerPods are deleted to update them. This should not delete the leaderPod
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.DeleteWorkerPods(ctx, k8sClient, lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						var leaderPod corev1.Pod
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name + "-3", Namespace: lws.Namespace}, &leaderPod)).To(gomega.Succeed())
+						gomega.Expect(leaderPod.DeletionTimestamp == nil).To(gomega.BeTrue())
+					},
+				},
+				{
+					// Rolling update all the replicas will make the leader statefulset ready again.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 4)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("create a leaderworkerset with spec.startupPolicy=LeaderReady", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
 				return testing.BuildLeaderWorkerSet(nsName).Replica(4).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -1723,14 +1723,14 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 					// Set lws to available condition.
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.UpdateLeaderStatefulSetRevisionKey(ctx, k8sClient, lws, "template-hash")
-						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 4)
+						testing.SetPodGroupsToReady(ctx, k8sClient, lws, 2)
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
 						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
 					},
 				},
 			},

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -1440,6 +1440,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
 						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
 					},
 				},
 				{
@@ -1466,6 +1467,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
 				{
@@ -1481,6 +1483,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 2)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
 				{
@@ -1503,6 +1506,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						// Partition will transit from 4 to 3.
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 0)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 3)
 					},
 				},
 				{
@@ -1527,6 +1531,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
 					},
 				},
 			},
@@ -1546,6 +1551,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
 						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
 					},
 				},
 				{
@@ -1559,6 +1565,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
 				{
@@ -1572,6 +1579,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-2")
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-1")
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
@@ -1592,6 +1600,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-2")
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-1")
 						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
@@ -1608,6 +1617,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
 					},
 				},
 			},

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -77,6 +77,21 @@ func CreateWorkerPodsForLeaderPod(ctx context.Context, leaderPod corev1.Pod, k8s
 	}).Should(gomega.Succeed())
 }
 
+func DeleteWorkerPods(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet) {
+	gomega.Eventually(func() error {
+		var workers corev1.PodList
+		if err := k8sClient.List(ctx, &workers, client.InNamespace(lws.Namespace), &client.MatchingLabels{"worker.pod": "workers"}); err != nil {
+			return err
+		}
+		for i := range workers.Items {
+			if err := k8sClient.Delete(ctx, &workers.Items[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func DeleteLeaderPods(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet) {
 	// delete pods with the highest indexes
 	var leaders corev1.PodList
@@ -158,6 +173,74 @@ func CreateLeaderPods(ctx context.Context, leaderSts appsv1.StatefulSet, k8sClie
 		}
 	}
 	return nil
+}
+
+func CreateNotUpdatedLeaderPods(ctx context.Context, leaderSts appsv1.StatefulSet, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, start int, end int) {
+	gomega.Eventually(func() error {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{
+			leaderworkerset.SetNameLabelKey: lws.Name,
+		}})
+		if err != nil {
+			return err
+		}
+		revisions, err := revisionutils.ListRevisions(ctx, k8sClient, lws, selector)
+		if err != nil {
+			return err
+		}
+
+		if len(revisions) > 2 {
+			return fmt.Errorf("there are %d revisions, should not be larger than 2", len(revisions))
+		}
+		cr, err := revisionutils.NewRevision(ctx, k8sClient, lws, "")
+		if err != nil {
+			return err
+		}
+		oldRevision := revisions[0]
+		if revisionutils.GetRevisionKey(revisions[0]) == revisionutils.GetRevisionKey(cr) {
+			oldRevision = revisions[1]
+		}
+		oldLws, err := revisionutils.ApplyRevision(lws, oldRevision)
+		if err != nil {
+			return err
+		}
+		var podTemplateSpec corev1.PodTemplateSpec
+		// if leader template is nil, use worker template
+		if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+			podTemplateSpec = *oldLws.Spec.LeaderWorkerTemplate.LeaderTemplate.DeepCopy()
+		} else {
+			podTemplateSpec = *oldLws.Spec.LeaderWorkerTemplate.WorkerTemplate.DeepCopy()
+		}
+		for i := start; i < end; i++ {
+			pod := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      lws.Name + "-" + strconv.Itoa(i),
+					Namespace: lws.Namespace,
+					Labels: map[string]string{
+						leaderworkerset.SetNameLabelKey:         lws.Name,
+						leaderworkerset.WorkerIndexLabelKey:     strconv.Itoa(0),
+						leaderworkerset.GroupIndexLabelKey:      strconv.Itoa(i),
+						leaderworkerset.GroupUniqueHashLabelKey: "randomValue",
+						leaderworkerset.RevisionKey:             revisionutils.GetRevisionKey(oldRevision),
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SizeAnnotationKey: strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size)),
+					},
+				},
+				Spec: podTemplateSpec.Spec,
+			}
+			if lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "" {
+				pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
+			}
+			// Set the controller owner reference for garbage collection and reconciliation.
+			if err := ctrl.SetControllerReference(&leaderSts, &pod, scheme.Scheme); err != nil {
+				return err
+			}
+			if err := k8sClient.Create(ctx, &pod); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 // This should only be used in e2e test, since integration test will not automatically create worker pods.

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -58,6 +58,7 @@ func CreateWorkerPodsForLeaderPod(ctx context.Context, leaderPod corev1.Pod, k8s
 						"worker.pod":                        "workers",
 						leaderworkerset.WorkerIndexLabelKey: strconv.Itoa(i),
 						leaderworkerset.RevisionKey:         revisionutils.GetRevisionKey(&leaderPod),
+						leaderworkerset.GroupIndexLabelKey:  leaderPod.Labels[leaderworkerset.GroupIndexLabelKey],
 					},
 					Annotations: map[string]string{
 						leaderworkerset.SizeAnnotationKey: strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size)),

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -614,7 +614,7 @@ func UpdateLeaderStatefulSetRevisionKey(ctx context.Context, k8sClient client.Cl
 
 	gomega.Eventually(func() bool {
 		var leaderStsAfterUpdate appsv1.StatefulSet
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderStsAfterUpdate)).To(gomega.Succeed())
 		return revisionutils.GetRevisionKey(&leaderStsAfterUpdate) == revisionKey
 	}, Timeout, Interval).Should(gomega.Equal(true))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it
Adds tests for Controller Revision

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #294

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
