### PR TITLE
Refactored wrappers into its own package

### DIFF
--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -34,22 +34,22 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
-	testutils "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
-	lws1 := testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
-		LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).
-		WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).Obj()
+	lws1 := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		LeaderTemplateSpec(wrappers.MakeLeaderPodSpec()).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).Obj()
 	cr1, err := revisionutils.NewRevision(context.TODO(), client, lws1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	revisionKey1 := revisionutils.GetRevisionKey(cr1)
 
-	lws2 := testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
-		WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).Obj()
+	lws2 := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).Obj()
 	cr2, err := revisionutils.NewRevision(context.TODO(), client, lws2, "")
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +65,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 		{
 			name:        "1 replica, size 1, with empty leader template, exclusive placement disabled",
 			revisionKey: revisionKey2,
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
 				RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
@@ -73,7 +73,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						MaxUnavailable: intstr.FromInt32(1),
 					},
 				}).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Size(1).
 				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
@@ -131,7 +131,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 		{
 			name:        "1 replica, size 2 , with empty leader template, exclusive placement enabled",
 			revisionKey: revisionKey2,
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Annotation(map[string]string{
 					"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 				}).Replica(1).
@@ -141,7 +141,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						MaxUnavailable: intstr.FromInt32(1),
 					},
 				}).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Size(2).
 				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
@@ -200,7 +200,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 		{
 			name:        "2 replica, size 2, with leader template, exclusive placement enabled",
 			revisionKey: revisionKey1,
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").Annotation(map[string]string{
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Annotation(map[string]string{
 				"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 			}).Replica(2).
 				RolloutStrategy(leaderworkerset.RolloutStrategy{
@@ -209,8 +209,8 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						MaxUnavailable: intstr.FromInt32(1),
 					},
 				}).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
-				LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+				LeaderTemplateSpec(wrappers.MakeLeaderPodSpec()).
 				Size(2).
 				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
@@ -268,7 +268,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 		{
 			name:        "2 maxUnavailable, 1 maxSurge, with empty leader template, exclusive placement disabled",
 			revisionKey: revisionKey2,
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
 				RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
@@ -277,7 +277,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						MaxSurge:       intstr.FromInt32(1),
 					},
 				}).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Size(1).
 				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
@@ -335,7 +335,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 		{
 			name:        "1 replica, size 2, with leader template, exclusive placement enabled, subgroupsize enabled",
 			revisionKey: revisionKey1,
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").Annotation(map[string]string{
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Annotation(map[string]string{
 				leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
 			}).SubGroupSize(2).Replica(1).
 				RolloutStrategy(leaderworkerset.RolloutStrategy{
@@ -344,8 +344,8 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						MaxUnavailable: intstr.FromInt32(1),
 					},
 				}).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
-				LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+				LeaderTemplateSpec(wrappers.MakeLeaderPodSpec()).
 				Size(2).
 				RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj(),
 			wantApplyConfig: &appsapplyv1.StatefulSetApplyConfiguration{
@@ -483,7 +483,7 @@ func TestSetCondition(t *testing.T) {
 		{
 			name:      "Different condition type, same condition status",
 			condition: metav1.Condition{Type: "Progressing", Status: "True"},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Available", Status: "True"}}).
 				Obj(),
 			expectedShouldUpdate: true,
@@ -491,7 +491,7 @@ func TestSetCondition(t *testing.T) {
 		{
 			name:      "Same condition type, different condition status",
 			condition: metav1.Condition{Type: "Progressing", Status: "True"},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Progressing", Status: "False"}}).
 				Obj(),
 			expectedShouldUpdate: true,
@@ -499,7 +499,7 @@ func TestSetCondition(t *testing.T) {
 		{
 			name:      "Different conditio type, new condition status is true",
 			condition: metav1.Condition{Type: "Progressing", Status: "True"},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Available", Status: "False"}}).
 				Obj(),
 			expectedShouldUpdate: true,
@@ -507,20 +507,20 @@ func TestSetCondition(t *testing.T) {
 		{
 			name:                 "No initial condition",
 			condition:            metav1.Condition{Type: "Progressing", Status: "True"},
-			lws:                  testutils.BuildBasicLeaderWorkerSet("test-sample", "default").Obj(),
+			lws:                  wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Obj(),
 			expectedShouldUpdate: true,
 		},
 		{
 			name:      "Different condition type, new condition status is false",
 			condition: metav1.Condition{Type: "Progressing", Status: "False"},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Available", Status: "True"}}).
 				Obj(),
 		},
 		{
 			name:      "Same condition type, Same condition status",
 			condition: metav1.Condition{Type: "Progressing", Status: "False"},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Progressing", Status: "False"}}).
 				Obj(),
 		},

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -31,13 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
-	testutils "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
 
-	lws := testutils.BuildBasicLeaderWorkerSet("test-sample", "default").Replica(1).WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).Size(1).Obj()
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Replica(1).WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).Size(1).Obj()
 	updateRevision, err := revisionutils.NewRevision(context.TODO(), client, lws, "")
 	if err != nil {
 		t.Fatal(err)
@@ -67,9 +67,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 					},
 				},
 			},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Size(1).Obj(),
 			wantStatefulSetConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
@@ -141,9 +141,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 					},
 				},
 			},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Annotation(map[string]string{
 					"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
 				}).Size(2).Obj(),
@@ -218,9 +218,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 					},
 				},
 			},
-			lws: testutils.BuildBasicLeaderWorkerSet("test-sample", "default").
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
-				WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).
+				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Annotation(map[string]string{
 					leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
 				}).Size(2).SubGroupSize(2).Obj(),

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/resource"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,7 @@ func TestAddTPUVariables(t *testing.T) {
 		{
 			name: "Worker Index is 0",
 			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample-1",
 					Namespace: "default",
@@ -58,7 +59,7 @@ func TestAddTPUVariables(t *testing.T) {
 		{
 			name: "Worker Index is non-zero, size is above 2",
 			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample-1-3",
 					Namespace: "default",
@@ -117,7 +118,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 		{
 			name: "Leader requests TPU resources",
 			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample-1-3",
 					Namespace: "default",
@@ -138,7 +139,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 		{
 			name: "Leader requests TPU resources, worker with subgroup index > 0",
 			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample-1-7",
 					Namespace: "default",
@@ -159,7 +160,7 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 		{
 			name: "Leader does not request TPU resources, worker with subgroup index > 0",
 			pod: &corev1.Pod{
-				Spec: MakeLeaderPodSpecWithTPUResource(),
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample-1-5",
 					Namespace: "default",
@@ -204,7 +205,7 @@ func TestGetContainerRequestingTPUs(t *testing.T) {
 	}{
 		{
 			name:    "Single Container with TPU Resource",
-			podSpec: MakeLeaderPodSpecWithTPUResource(),
+			podSpec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 			expectedContainer: &corev1.Container{
 				Name:  "worker",
 				Image: "busybox",
@@ -217,7 +218,7 @@ func TestGetContainerRequestingTPUs(t *testing.T) {
 		},
 		{
 			name:    "Multiple Containers, one with TPU Resource",
-			podSpec: MakeLeaderPodSpecWithTPUResourceMultipleContainers(),
+			podSpec: wrappers.MakeLeaderPodSpecWithTPUResourceMultipleContainers(),
 			expectedContainer: &corev1.Container{
 				Name:  "worker",
 				Image: "busybox",
@@ -230,7 +231,7 @@ func TestGetContainerRequestingTPUs(t *testing.T) {
 		},
 		{
 			name:              "Container without TPU Resource",
-			podSpec:           MakeLeaderPodSpec(),
+			podSpec:           wrappers.MakeLeaderPodSpec(),
 			expectedContainer: nil,
 		},
 	}
@@ -241,60 +242,5 @@ func TestGetContainerRequestingTPUs(t *testing.T) {
 				t.Errorf("unexpected get container operation %s", diff)
 			}
 		})
-	}
-}
-
-func MakeLeaderPodSpec() corev1.PodSpec {
-	return corev1.PodSpec{
-		Containers: []corev1.Container{
-			{
-				Name:  "worker",
-				Image: "busybox",
-			},
-		},
-	}
-}
-
-func MakeLeaderPodSpecWithTPUResource() corev1.PodSpec {
-	return corev1.PodSpec{
-		Containers: []corev1.Container{
-			{
-				Name:  "worker",
-				Image: "busybox",
-				Resources: corev1.ResourceRequirements{
-					Limits: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceName("google.com/tpu"): resource.MustParse("4"),
-					},
-				},
-			},
-		},
-		Subdomain: "default",
-	}
-}
-
-func MakeLeaderPodSpecWithTPUResourceMultipleContainers() corev1.PodSpec {
-	return corev1.PodSpec{
-		Containers: []corev1.Container{
-			{
-				Name:  "worker",
-				Image: "busybox",
-				Resources: corev1.ResourceRequirements{
-					Limits: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceName("google.com/tpu"): resource.MustParse("4"),
-					},
-				},
-			},
-			{
-				Name:  "leader",
-				Image: "nginx:1.14.2",
-				Ports: []corev1.ContainerPort{
-					{
-						ContainerPort: 8080,
-						Protocol:      "TCP",
-					},
-				},
-			},
-		},
-		Subdomain: "default",
 	}
 }

--- a/pkg/utils/pod/pod_utils_test.go
+++ b/pkg/utils/pod/pod_utils_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 func TestContainerRestarted(t *testing.T) {
@@ -109,37 +109,37 @@ func TestAddLWSVariables(t *testing.T) {
 	}{
 		{
 			name:                     "Leader pod",
-			pod:                      testutils.MakePodWithLabels("test-sample", "0", "", "default", 3),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "0", "", "default", 3),
 			expectedLwsLeaderAddress: "test-sample-0.test-sample.default",
 			expectedGroupSize:        3,
 		},
 		{
 			name:                     "Worker pod",
-			pod:                      testutils.MakePodWithLabels("test-sample", "0", "1", "default", 3),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "0", "1", "default", 3),
 			expectedLwsLeaderAddress: "test-sample-0.test-sample.default",
 			expectedGroupSize:        3,
 		},
 		{
 			name:                     "Leader pod, group 1",
-			pod:                      testutils.MakePodWithLabels("test-sample", "1", "", "default", 2),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "", "default", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.default",
 			expectedGroupSize:        2,
 		},
 		{
 			name:                     "Worker pod, group 1",
-			pod:                      testutils.MakePodWithLabels("test-sample", "1", "3", "default", 2),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "default", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.default",
 			expectedGroupSize:        2,
 		},
 		{
 			name:                     "Leader pod, group 1, non-default namespace",
-			pod:                      testutils.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.lws",
 			expectedGroupSize:        2,
 		},
 		{
 			name:                     "Worker pod, group 1, non-default namespace",
-			pod:                      testutils.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.lws",
 			expectedGroupSize:        2,
 		},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	"sigs.k8s.io/lws/test/testutils"
 	testing "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
@@ -64,7 +65,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can deploy lws with 'replicas', 'size', and 'restart policy' set", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).Size(5).RestartPolicy(v1.NoneRestartPolicy).Obj()
+		lws = wrappers.BuildLeaderWorkerSet(ns.Name).Replica(4).Size(5).RestartPolicy(v1.NoneRestartPolicy).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 
@@ -99,7 +100,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can create/update a lws with size=1", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+		lws = wrappers.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(1).Size(1).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
@@ -116,7 +117,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can perform a rolling update", func() {
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Obj()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		// Wait for leaderWorkerSet to be ready then update it.
@@ -131,7 +132,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can perform a rolling update with maxSurge set", func() {
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).Obj()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		// Wait for leaderWorkerSet to be ready then update it.
@@ -150,9 +151,9 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Can deploy lws with subgroupsize set", func() {
-		leaderPodSpec := testing.MakeLeaderPodSpecWithTPUResource()
-		workerPodSpec := testing.MakeWorkerPodSpecWithTPUResource()
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(4).SubGroupSize(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
+		leaderPodSpec := wrappers.MakeLeaderPodSpecWithTPUResource()
+		workerPodSpec := wrappers.MakeWorkerPodSpecWithTPUResource()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(4).SubGroupSize(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
 
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
@@ -177,7 +178,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 		}
 	})
 	ginkgo.It("Can perform a rolling update with subgroupsize and MaxSurge set", func() {
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).SubGroupSize(1).Obj()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).SubGroupSize(1).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		// Wait for leaderWorkerSet to be ready then update it.
@@ -196,9 +197,9 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Adds env vars to containers when using TPU", func() {
-		leaderPodSpec := testing.MakeLeaderPodSpecWithTPUResource()
-		workerPodSpec := testing.MakeWorkerPodSpecWithTPUResource()
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(4).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
+		leaderPodSpec := wrappers.MakeLeaderPodSpecWithTPUResource()
+		workerPodSpec := wrappers.MakeWorkerPodSpecWithTPUResource()
+		lws = wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(4).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
 
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		lwsPods := &corev1.PodList{}
@@ -210,9 +211,9 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("When changing subdomainPolicy, adds correct env vars", func() {
-		leaderPodSpec := testing.MakeLeaderPodSpecWithTPUResource()
-		workerPodSpec := testing.MakeWorkerPodSpecWithTPUResource()
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
+		leaderPodSpec := wrappers.MakeLeaderPodSpecWithTPUResource()
+		workerPodSpec := wrappers.MakeWorkerPodSpecWithTPUResource()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectValidPods(ctx, k8sClient, lws, &corev1.PodList{})
 		testing.UpdateSubdomainPolicy(ctx, k8sClient, lws, leaderworkerset.SubdomainUniquePerReplica)
@@ -235,7 +236,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("headless services scale up during MaxSurge", func() {
-		lws := testing.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica).Obj()
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(4).MaxSurge(4).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 
 		// Happen during rolling update.
@@ -256,9 +257,9 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Doesnt add env vars to containers when not using TPU", func() {
-		leaderPodSpec := testutils.MakeLeaderPodSpec()
-		workerPodSpec := testutils.MakeWorkerPodSpec()
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
+		leaderPodSpec := wrappers.MakeLeaderPodSpec()
+		workerPodSpec := wrappers.MakeWorkerPodSpec()
+		lws = wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(leaderPodSpec).WorkerTemplateSpec(workerPodSpec).Obj()
 
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		lwsPods := &corev1.PodList{}
@@ -270,7 +271,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	})
 
 	ginkgo.It("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", func() {
-		lws = testing.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+		lws = wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(3).RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
 		testing.MustCreateLws(ctx, k8sClient, lws)
 		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
-	"sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -89,7 +89,7 @@ func LwsReadyForTesting(client client.Client) {
 	By("waiting for webhooks to come up")
 
 	// To verify that webhooks are ready, let's create a simple lws.
-	lws := testutils.BuildLeaderWorkerSet(metav1.NamespaceDefault).Replica(3).Obj()
+	lws := wrappers.BuildLeaderWorkerSet(metav1.NamespaceDefault).Replica(3).Obj()
 
 	// Once the creation succeeds, that means the webhooks are ready
 	// and we can begin testing.

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/lws/pkg/controllers"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
 	testing "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
@@ -44,7 +45,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 	}
 	// class representing a testCase
 	type testCase struct {
-		makeLeaderWorkerSet func(nsName string) *testing.LeaderWorkerSetWrapper
+		makeLeaderWorkerSet func(nsName string) *wrappers.LeaderWorkerSetWrapper
 		updates             []*update
 	}
 	ginkgo.DescribeTable("leaderWorkerSet creating or updating",
@@ -86,8 +87,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			}
 		},
 		ginkgo.Entry("scale up number of groups", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(2)
 			},
 			updates: []*update{
 				{
@@ -105,8 +106,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("scale down number of groups", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
 			updates: []*update{
 				{
@@ -124,8 +125,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("scale down to 0", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(2)
 			},
 			updates: []*update{
 				{
@@ -143,8 +144,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("scale up from 0", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(0)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(0)
 			},
 			updates: []*update{
 				{
@@ -162,8 +163,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("group size is 1", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Size(1)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Size(1)
 			},
 			updates: []*update{
 				{
@@ -183,8 +184,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("zero replicas", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(0)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(0)
 			},
 			updates: []*update{
 				{
@@ -196,7 +197,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Successfully create a leaderworkerset with 2 groups, size as 4.", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(deployment *leaderworkerset.LeaderWorkerSet) {
@@ -211,8 +212,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Deleted worker statefulSet will be recreated", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(2)
 			},
 			updates: []*update{
 				{
@@ -229,7 +230,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("headless service created", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -239,7 +240,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("service deleted will be recreated", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -261,8 +262,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("subdomain policy LeadersSharedWorkersDedicated, more than one headless service created", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica)
 			},
 			updates: []*update{
 				{
@@ -273,7 +274,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("leader statefulset deleted will be recreated", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					// Fetch the headless service and force delete it, so we can test if it is recreated.
@@ -290,7 +291,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Able to get scale subResource information", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -304,7 +305,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("HPA is able trigger scaling up/down through scale endpoint", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -334,7 +335,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Test available state", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -347,7 +348,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Testing condition switch from progressing to available to progressing", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -383,8 +384,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Leader/worker pods/Statefulset have required labels and annotations when exclusive placement enabled", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).ExclusivePlacement()
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).ExclusivePlacement()
 			},
 			updates: []*update{
 				{
@@ -396,8 +397,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Pod restart will not recreate the pod group when restart policy is None", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.NoneRestartPolicy).Replica(1).Size(3)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.NoneRestartPolicy).Replica(1).Size(3)
 			},
 			updates: []*update{
 				{
@@ -425,8 +426,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Pod restart will delete the pod group when restart policy is RecreateGroupOnPodRestart", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Replica(1).Size(3)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Replica(1).Size(3)
 			},
 			updates: []*update{
 				{
@@ -451,7 +452,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Replicas are processing will set condition to progressing with correct message with correct event", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -464,7 +465,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Test default progressing state", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -478,7 +479,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Leaderworkerset has available state with correct event", &testCase{
-			makeLeaderWorkerSet: testing.BuildLeaderWorkerSet,
+			makeLeaderWorkerSet: wrappers.BuildLeaderWorkerSet,
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
@@ -494,8 +495,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 
 		// Rolling update test cases
 		ginkgo.Entry("leaderTemplate changed with default strategy", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
 			updates: []*update{
 				{
@@ -592,8 +593,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("workerTemplate changed with maxUnavailable=2", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).MaxUnavailable(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxUnavailable(2)
 			},
 			updates: []*update{
 				{
@@ -670,8 +671,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("workerTemplate changed with maxUnavailable greater than replicas", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).MaxUnavailable(10)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxUnavailable(10)
 			},
 			updates: []*update{
 				{
@@ -719,8 +720,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("rolling update with both worker template and number of replicas changed", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
 			updates: []*update{
 				{
@@ -779,8 +780,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("replicas increases during rolling update", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
 			updates: []*update{
 				{
@@ -871,8 +872,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("replicas decreases during rolling update", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(6)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(6)
 			},
 			updates: []*update{
 				{
@@ -951,8 +952,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("rolling update with maxSurge set", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(1)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(1)
 			},
 			updates: []*update{
 				{
@@ -1070,8 +1071,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("rolling update with replicas scaled up and maxSurge set", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).MaxSurge(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).MaxSurge(2)
 			},
 			updates: []*update{
 				{
@@ -1139,8 +1140,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("rolling update with replicas scaled down and maxSurge set", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(6).MaxSurge(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(6).MaxSurge(2)
 			},
 			updates: []*update{
 				{
@@ -1205,8 +1206,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("rolling update with maxSurge greater than replicas", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).MaxSurge(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).MaxSurge(4)
 			},
 			updates: []*update{
 				{
@@ -1275,8 +1276,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("scale up and down during rolling update with maxSurge set", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(2)
 			},
 			updates: []*update{
 				{
@@ -1432,8 +1433,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("multiple rolling update with maxSurge set", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(2)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(2)
 			},
 			updates: []*update{
 				{
@@ -1544,8 +1545,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("Not updated worker gets recreated with old worker spec if restarted during update", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
 			updates: []*update{
 				{
@@ -1630,8 +1631,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("leader with RecreateGroupOnPodRestart only gets restarted once during rolling update", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 			updates: []*update{
 				{
@@ -1722,8 +1723,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("if a leaderSts exists, but a matching controllerRevision doesn't, it will create one that matches the leaderSts", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName)
 			},
 			updates: []*update{
 				{
@@ -1757,8 +1758,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("create a leaderworkerset with spec.startupPolicy=LeaderReady", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
 			},
 			updates: []*update{
 				{
@@ -1786,8 +1787,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 		}),
 		ginkgo.Entry("create a leaderworkerset with spec.startupPolicy=LeaderCreated", &testCase{
-			makeLeaderWorkerSet: func(nsName string) *testing.LeaderWorkerSetWrapper {
-				return testing.BuildLeaderWorkerSet(nsName).Replica(4).StartupPolicy(leaderworkerset.LeaderCreatedStartupPolicy)
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).StartupPolicy(leaderworkerset.LeaderCreatedStartupPolicy)
 			},
 			updates: []*update{
 				{

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
-	testutils "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func() {
@@ -47,8 +47,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)).Should(gomega.Succeed())
 	})
 	type testDefaultingCase struct {
-		makeLeaderWorkerSet func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper
-		getExpectedLWS      func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper
+		makeLeaderWorkerSet func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper
+		getExpectedLWS      func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper
 	}
 	ginkgo.DescribeTable("test defaulting",
 		func(tc *testDefaultingCase) {
@@ -65,89 +65,89 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			gomega.Expect(cmp.Diff(expectedLWS.Spec, fetchedLWS.Spec)).Should(gomega.Equal(""))
 		},
 		ginkgo.Entry("apply defaulting logic for replicas", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lwsWrapper := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lwsWrapper := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lwsWrapper.Spec.Replicas = nil
 				return lwsWrapper
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("apply defaulting logic for size", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lwsWrapper := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lwsWrapper := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lwsWrapper.Spec.LeaderWorkerTemplate.Size = nil
 				return lwsWrapper
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Size(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Size(1).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic won't apply when shouldn't", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2)
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(testutils.MakeLeaderPodSpec()).WorkerTemplateSpec(testutils.MakeWorkerPodSpec()).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).LeaderTemplateSpec(wrappers.MakeLeaderPodSpec()).WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic applies when leaderworkertemplate.restartpolicy is not set", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy("")
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy("")
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)
 			},
 		}),
 		ginkgo.Entry("defaulting logic won't apply when leaderworkertemplate.restartpolicy is set", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 		}),
 		ginkgo.Entry("DeprecatedDefaultRestartPolicy will be shift to NoneRestartPolicy", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.DeprecatedDefaultRestartPolicy)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.DeprecatedDefaultRestartPolicy)
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 		}),
 		ginkgo.Entry("defaulting logic applies when spec.startpolicy is not set", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2)
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderCreatedStartupPolicy)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderCreatedStartupPolicy)
 			},
 		}),
 		ginkgo.Entry("defaulting logic applies when spec.startpolicy is set", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
 			},
 		}),
 		ginkgo.Entry("defaulting of subdomainPolicy applies when spec.NetworkConfig is not set", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lwsWrapper := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lwsWrapper := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lwsWrapper.Spec.NetworkConfig = nil
 				return lwsWrapper
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainShared)
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainShared)
 			},
 		}),
 		ginkgo.Entry("apply default rollout strategy", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).RolloutStrategy(leaderworkerset.RolloutStrategy{}) // unset rollout strategy
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).RolloutStrategy(leaderworkerset.RolloutStrategy{}) // unset rollout strategy
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).RolloutStrategy(leaderworkerset.RolloutStrategy{
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
 					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
 						MaxUnavailable: intstr.FromInt32(1),
@@ -156,8 +156,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			},
 		}),
 		ginkgo.Entry("wouldn't apply default rollout strategy when configured", &testDefaultingCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
@@ -165,8 +165,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 							MaxSurge:       intstr.FromInt32(1),
 						}})
 			},
-			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).
+			getExpectedLWS: func(lws *leaderworkerset.LeaderWorkerSet) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).
 					RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 	)
 
 	type testValidationCase struct {
-		makeLeaderWorkerSet   func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper
+		makeLeaderWorkerSet   func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper
 		lwsCreationShouldFail bool
 		updateLeaderWorkerSet func(lws *leaderworkerset.LeaderWorkerSet)
 		updateShouldFail      bool
@@ -214,50 +214,50 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			}
 		},
 		ginkgo.Entry("creation with invalid name should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Name("2cube")
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Name("2cube")
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with invalid replicas and size should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(100000).Size(1000000)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(100000).Size(1000000)
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with invalid size should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(-1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(-1)
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with invalid replicas should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Size(2).Replica(-1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Size(2).Replica(-1)
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with invalid startpolicy should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).StartupPolicy("invalidValue")
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).StartupPolicy("invalidValue")
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with invalid subGroupSize should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Size(2).SubGroupSize(-1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Size(2).SubGroupSize(-1)
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("creation with subGroupSize larger than size should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Size(2).SubGroupSize(3)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Size(2).SubGroupSize(3)
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("update with invalid replicas should fail (larger than maxInt32)", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(100000).Size(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(100000).Size(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](100000000)
@@ -265,8 +265,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("update with invalid replicas should fail (number is negative)", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.Replicas = ptr.To[int32](-1)
@@ -274,8 +274,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("update with invalid startpolicy should fail", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).StartupPolicy(leaderworkerset.LeaderReadyStartupPolicy)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.StartupPolicy = "invalidValue"
@@ -283,8 +283,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("number of size can not be updated", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](2)
@@ -292,8 +292,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("number of subGroupSize can not be updated", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).SubGroupSize(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).SubGroupSize(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize = ptr.To[int32](2)
@@ -301,8 +301,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("number of subGroupSize cannot be added after update", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &leaderworkerset.SubGroupPolicy{}
@@ -311,8 +311,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("number of subGroupSize can not be removed after update", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).SubGroupSize(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).SubGroupSize(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = nil
@@ -320,8 +320,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: true,
 		}),
 		ginkgo.Entry("number of replicas can be updated", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(1)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.Replicas = ptr.To[int32](3)
@@ -329,18 +329,18 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("leader/workerTemplate can be updated", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
-				lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec = testutils.MakeWorkerPodSpec()
-				lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = testutils.MakeLeaderPodSpec()
+				lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec = wrappers.MakeWorkerPodSpec()
+				lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = wrappers.MakeLeaderPodSpec()
 			},
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("subdomainPolicy can be updated from UniquePerReplica to Shared", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				*lws.Spec.NetworkConfig.SubdomainPolicy = leaderworkerset.SubdomainShared
@@ -348,8 +348,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("subdomainPolicy can be updated from Shared to UniquePerReplica", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainShared)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).SubdomainPolicy(leaderworkerset.SubdomainShared)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				*lws.Spec.NetworkConfig.SubdomainPolicy = leaderworkerset.SubdomainUniquePerReplica
@@ -357,8 +357,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("subdomainPolicy can be updated from nil to UniquePerReplica", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lwsWrapper := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lwsWrapper := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lwsWrapper.Spec.NetworkConfig = nil
 				return lwsWrapper
 			},
@@ -368,8 +368,8 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("subdomainPolicy can be updated to nil", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name)
 			},
 			updateLeaderWorkerSet: func(lws *leaderworkerset.LeaderWorkerSet) {
 				lws.Spec.NetworkConfig.SubdomainPolicy = nil
@@ -377,78 +377,78 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			updateShouldFail: false,
 		}),
 		ginkgo.Entry("set restart policy should succeed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				return testutils.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.NoneRestartPolicy)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.NoneRestartPolicy)
 			},
 			lwsCreationShouldFail: false,
 		}),
 		ginkgo.Entry("set restart policy should fail when value is invalid", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.LeaderWorkerTemplate.RestartPolicy = "invalidValue"
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set invalid rolloutStrategyType should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.Type = "invalidValue"
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set maxUnavailable greater than replicas is allowed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt32(10)
 				return lws
 			},
 			lwsCreationShouldFail: false,
 		}),
 		ginkgo.Entry("set maxUnavailable greater than 100% should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromString("200%")
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set maxUnavailable less than 0 should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt32(-1)
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set maxSurge greater than replicas is allowed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt32(10)
 				return lws
 			},
 			lwsCreationShouldFail: false,
 		}),
 		ginkgo.Entry("set maxSurge greater than 100% should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromString("200%")
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set maxSurge less than 0 should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt32(-1)
 				return lws
 			},
 			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set maxUnavailable and maxSurge both to 0 should be failed", &testValidationCase{
-			makeLeaderWorkerSet: func(ns *corev1.Namespace) *testutils.LeaderWorkerSetWrapper {
-				lws := testutils.BuildLeaderWorkerSet(ns.Name)
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt32(0)
 				return lws
 			},

--- a/test/integration/webhooks/pod_test.go
+++ b/test/integration/webhooks/pod_test.go
@@ -31,6 +31,7 @@ import (
 	acceleratorutils "sigs.k8s.io/lws/pkg/utils/accelerators"
 	"sigs.k8s.io/lws/pkg/webhooks"
 	testutils "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
 )
 
 var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", func() {
@@ -72,7 +73,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							"random-label": "random-value",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpec(),
+					Spec: wrappers.MakeLeaderPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -99,7 +100,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "2",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpec(),
+					Spec: wrappers.MakeWorkerPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -128,7 +129,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "2",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpec(),
+					Spec: wrappers.MakeWorkerPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -163,7 +164,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey:        "4",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -204,7 +205,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey:        "2",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpec(),
+					Spec: wrappers.MakeWorkerPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -240,7 +241,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey: "2",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -266,7 +267,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 						Name:      "test-1",
 						Namespace: ns.Name,
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -290,7 +291,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "2",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpec(),
+					Spec: wrappers.MakeWorkerPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -314,7 +315,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "3",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpec(),
+					Spec: wrappers.MakeWorkerPodSpec(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -338,7 +339,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "5",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -366,7 +367,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubdomainPolicyAnnotationKey: string(leaderworkerset.SubdomainUniquePerReplica),
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -404,7 +405,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey: "5",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -433,7 +434,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							acceleratorutils.LeaderRequestsTPUsAnnotationKey: "true",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -463,7 +464,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey:        "5",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -491,7 +492,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "5",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -520,7 +521,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey: "5",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -549,7 +550,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							acceleratorutils.LeaderRequestsTPUsAnnotationKey: "true",
 						},
 					},
-					Spec: testutils.MakeWorkerPodSpecWithTPUResource(),
+					Spec: wrappers.MakeWorkerPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -576,7 +577,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "1",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -604,7 +605,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.ExclusiveKeyAnnotationKey: "topologyKey",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -629,7 +630,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey:         "2",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -656,7 +657,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SubGroupSizeAnnotationKey:         "2",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -679,7 +680,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "4",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -702,7 +703,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.ExclusiveKeyAnnotationKey: "topologyKey",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 				webhooks.SetExclusiveAffinities(pod, "uniquehash", "topologyKey", leaderworkerset.GroupUniqueHashLabelKey)
 				return *pod
@@ -727,7 +728,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.ExclusiveKeyAnnotationKey: "topologyKey",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpecWithTPUResource(),
+					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
 				pod.Spec.Affinity = &corev1.Affinity{}
 				pod.Spec.Affinity.PodAffinity = &corev1.PodAffinity{}
@@ -783,7 +784,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							leaderworkerset.SizeAnnotationKey: "2",
 						},
 					},
-					Spec: testutils.MakePodSpecWithInitContainer(),
+					Spec: wrappers.MakePodSpecWithInitContainer(),
 				}
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {
@@ -848,7 +849,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 							"random-label": "random-value",
 						},
 					},
-					Spec: testutils.MakeLeaderPodSpec(),
+					Spec: wrappers.MakeLeaderPodSpec(),
 				}
 			},
 			podCreationShouldFail: false,

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package testutils
+package wrappers
 
 import (
 	"fmt"
@@ -113,6 +113,11 @@ func (lwsWrapper *LeaderWorkerSetWrapper) SubdomainPolicy(subdomainPolicy leader
 	lwsWrapper.Spec.NetworkConfig = &leaderworkerset.NetworkConfig{
 		SubdomainPolicy: &subdomainPolicy,
 	}
+	return lwsWrapper
+}
+
+func (lwsWrapper *LeaderWorkerSetWrapper) SubdomainNil() *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.NetworkConfig = nil
 	return lwsWrapper
 }
 
@@ -287,5 +292,79 @@ func MakeLeaderPodSpecWithTPUResource() corev1.PodSpec {
 			},
 		},
 		Subdomain: "default",
+	}
+}
+
+func MakeLeaderPodSpecWithTPUResourceMultipleContainers() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "worker",
+				Image: "busybox",
+				Resources: corev1.ResourceRequirements{
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceName("google.com/tpu"): resource.MustParse("4"),
+					},
+				},
+			},
+			{
+				Name:  "leader",
+				Image: "nginx:1.14.2",
+				Ports: []corev1.ContainerPort{
+					{
+						ContainerPort: 8080,
+						Protocol:      "TCP",
+					},
+				},
+			},
+		},
+		Subdomain: "default",
+	}
+}
+
+func MakeWorkerPodSpecWithVolume() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "leader",
+				Image: "nginx:1.14.2",
+				Ports: []corev1.ContainerPort{
+					{
+						ContainerPort: 8080,
+						Protocol:      "TCP",
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "dshm",
+			},
+		},
+	}
+}
+
+func MakeWorkerPodSpecWithVolumeAndNilImage() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "leader",
+				Image: "nginx:1.14.2",
+				Ports: []corev1.ContainerPort{
+					{
+						ContainerPort: 8080,
+						Protocol:      "TCP",
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "dshm",
+				VolumeSource: corev1.VolumeSource{
+					Image: nil,
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #296

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
