### PR TITLE
Automated cherry pick of #347: Removed update operation from pod webhook

### DIFF
--- a/charts/lws/templates/webhook/webhook.yaml
+++ b/charts/lws/templates/webhook/webhook.yaml
@@ -43,7 +43,6 @@ webhooks:
           - v1
         operations:
           - CREATE
-          - UPDATE
         resources:
           - pods
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -40,7 +40,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - pods
   sideEffects: None

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -77,7 +77,7 @@ func (p *PodWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (ad
 	return nil, nil
 }
 
-//+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,sideEffects=None,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 func (p *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	log := logf.FromContext(ctx)


### PR DESCRIPTION
Cherry pick of #347 on release-0.5.1.

#347: Removed update operation from pod webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```