### PR TITLE
Automated cherry pick of #342: Added handling of nil revision in pod controller

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -126,6 +127,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err != nil {
 		log.Error(err, "Getting lws revisions")
 		return ctrl.Result{}, err
+	}
+	if revision == nil {
+		log.V(2).Info("Revision has not been created yet, requeing reconciler for pod %s", pod.Name)
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 	statefulSet, err := constructWorkerStatefulSetApplyConfiguration(pod, leaderWorkerSet, revision)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #342 on release-0.5.1.

#342: Added handling of nil revision in pod controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```