### PR TITLE
Automated cherry pick of #341: Removed restarting group log in pod controller

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -89,7 +89,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 	if leaderDeleted {
-		log.V(2).Info("restarting the group")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Cherry pick of #341 on release-0.5.1.

#341: Removed restarting group log in pod controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```