### PR TITLE
Deprecate flags as the recommended path is to pass configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests fmt vet envtest gotestsum ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- ./api/... ./pkg/... -coverprofile  $(ARTIFACTS)/cover.out
+	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- ./api/... ./pkg/... ./cmd/... -coverprofile  $(ARTIFACTS)/cover.out
 
 KIND = $(shell pwd)/bin/kind
 .PHONY: kind

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,28 +76,28 @@ func main() {
 		configFile               string
 	)
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.Float64Var(&qps, "kube-api-qps", 500, "Maximum QPS to use while talking with Kubernetes API")
-	flag.IntVar(&burst, "kube-api-burst", 500, "Maximum burst for throttle while talking with Kubernetes API")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "DEPRECATED(please pass configuration file via --config flag): The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "DEPRECATED(please pass configuration file via --config flag): The address the probe endpoint binds to.")
+	flag.Float64Var(&qps, "kube-api-qps", 500, "DEPRECATED(please pass configuration file via --config flag): Maximum QPS to use while talking with Kubernetes API")
+	flag.IntVar(&burst, "kube-api-burst", 500, "DEPRECATED(please pass configuration file via --config flag): Maximum burst for throttle while talking with Kubernetes API")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
-		"Enable leader election for controller manager. "+
+		"DEPRECATED(please pass configuration file via --config flag): Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&leaderElectLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
-		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire "+
+		"DEPRECATED(please pass configuration file via --config flag): The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire "+
 			"leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped"+
 			" before it is replaced by another candidate. This is only applicable if leader election is enabled.")
 	flag.DurationVar(&leaderElectRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
-		"The interval between attempts by the acting master to renew a leadership slot before it stops leading. This"+
+		"DEPRECATED(please pass configuration file via --config flag): The interval between attempts by the acting master to renew a leadership slot before it stops leading. This"+
 			"must be less than or equal to the lease duration. This is only applicable if leader election is enabled.")
 	flag.DurationVar(&leaderElectRetryPeriod, "leader-elect-retry-period", 2*time.Second,
-		"The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only"+
+		"DEPRECATED(please pass configuration file via --config flag): The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only"+
 			"applicable if leader election is enabled.")
 	flag.StringVar(&leaderElectResourceLock, "leader-elect-resource-lock", "leases",
-		"The type of resource object that is used for locking during leader election. Supported options are "+
+		"DEPRECATED(please pass configuration file via --config flag): The type of resource object that is used for locking during leader election. Supported options are "+
 			"'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'")
 	flag.StringVar(&leaderElectionID, "leader-elect-resource-name", "b8b2488c.x-k8s.io",
-		"The name of resource object that is used for locking during leader election. ")
+		"DEPRECATED(please pass configuration file via --config flag): The name of resource object that is used for locking during leader election. ")
 	flag.StringVar(&configFile, "config", "",
 		"The controller will load its initial configuration from this file. "+
 			"Command-line flags will override any configurations set in this file. "+

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -101,10 +101,13 @@ internalCertManagement:
 				LeaderElection:             false,
 				LeaderElectionResourceLock: "changed",
 				LeaderElectionID:           "changed",
+				LeaderElectionNamespace:    "lws-system",
 				LeaseDuration:              ptr.To(1 * time.Minute),
 				RenewDeadline:              ptr.To(1 * time.Minute),
 				RetryPeriod:                ptr.To(1 * time.Minute),
 				HealthProbeBindAddress:     ":9443",
+				LivenessEndpointName:       "/healthz",
+				ReadinessEndpointName:      "/readyz",
 			},
 		},
 		{
@@ -122,10 +125,13 @@ internalCertManagement:
 				LeaderElection:             true,
 				LeaderElectionResourceLock: "test",
 				LeaderElectionID:           "test",
+				LeaderElectionNamespace:    "lws-system",
 				LeaseDuration:              ptr.To(5 * time.Minute),
 				RenewDeadline:              ptr.To(5 * time.Minute),
 				RetryPeriod:                ptr.To(5 * time.Minute),
 				HealthProbeBindAddress:     ":8081",
+				LivenessEndpointName:       "/healthz",
+				ReadinessEndpointName:      "/readyz",
 			},
 		},
 		{
@@ -146,10 +152,13 @@ internalCertManagement:
 				LeaderElection:             false,
 				LeaderElectionResourceLock: "test",
 				LeaderElectionID:           "test",
+				LeaderElectionNamespace:    "lws-system",
 				LeaseDuration:              ptr.To(5 * time.Minute),
 				RenewDeadline:              ptr.To(5 * time.Minute),
 				RetryPeriod:                ptr.To(5 * time.Minute),
 				HealthProbeBindAddress:     ":9443",
+				LivenessEndpointName:       "/healthz",
+				ReadinessEndpointName:      "/readyz",
 			},
 		},
 	}
@@ -164,7 +173,8 @@ internalCertManagement:
 				tc.leaderElectRenewDeadline,
 				tc.leaderElectRetryPeriod,
 				tc.leaderElectResourceLock,
-				tc.leaderElectionID)
+				tc.leaderElectionID,
+				"metrics-addr")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -259,7 +259,7 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 	}
 
 	stsReplicas := *sts.Spec.Replicas
-	maxSurge, err := intstr.GetValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge, int(lwsReplicas), true)
+	maxSurge, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge, int(lwsReplicas), true)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -316,7 +316,7 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 	// Case 5:
 	// Calculating the Partition during rolling update, no leaderWorkerSet updates happens.
 
-	rollingStep, err := intstr.GetValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable, int(lwsReplicas), false)
+	rollingStep, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable, int(lwsReplicas), false)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -157,11 +157,11 @@ func (r *LeaderWorkerSetWebhook) generalValidate(obj runtime.Object) field.Error
 		allErrs = append(allErrs, validatePositiveIntOrPercent(maxSurge, maxSurgePath)...)
 		allErrs = append(allErrs, isNotMoreThan100Percent(maxSurge, maxSurgePath)...)
 	}
-	maxUnavailableValue, err := intstr.GetValueFromIntOrPercent(&maxUnavailable, int(*lws.Spec.Replicas), false)
+	maxUnavailableValue, err := intstr.GetScaledValueFromIntOrPercent(&maxUnavailable, int(*lws.Spec.Replicas), false)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "invalid value"))
 	}
-	maxSurgeValue, err := intstr.GetValueFromIntOrPercent(&maxSurge, int(*lws.Spec.Replicas), true)
+	maxSurgeValue, err := intstr.GetScaledValueFromIntOrPercent(&maxSurge, int(*lws.Spec.Replicas), true)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(maxSurgePath, maxSurge, "invalid value"))
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
It was suggested in here https://github.com/kubernetes-sigs/lws/pull/325#discussion_r1923006469 by @kerthcet to deprecate the flags, because passing them in the configuration file via `--config` flag is cleaner.

This PR
* Deprecates the flags as continuation of https://github.com/kubernetes-sigs/lws/pull/325
* Migrates from deprecated function `GetValueFromIntOrPercent` to `GetScaledValueFromIntOrPercent`
* Moves metric server initialization logic in `apply` function as suggested in https://github.com/kubernetes-sigs/lws/pull/325#discussion_r1926762256

#### Which issue(s) this PR fixes
Fixes #

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deprecating the flags whose can be cleanly passed through configuration file
```
