### PR TITLE
Update k8s binary dependencies to align with 1.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod|head -n1)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 1.32.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -57,7 +57,7 @@ ARTIFACTS ?= $(PROJECT_DIR)/bin
 
 INTEGRATION_TARGET ?= ./test/integration/...
 
-E2E_KIND_VERSION ?= kindest/node:v1.30.0
+E2E_KIND_VERSION ?= kindest/node:v1.32.0
 USE_EXISTING_CLUSTER ?= false
 
 # For local testing, we should allow user to use different kind cluster name
@@ -117,7 +117,7 @@ test: manifests fmt vet envtest gotestsum ## Run tests.
 KIND = $(shell pwd)/bin/kind
 .PHONY: kind
 kind:
-	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on go install sigs.k8s.io/kind@v0.23.0
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on go install sigs.k8s.io/kind@v0.26.0
 
 .PHONY: kind-image-build
 kind-image-build: PLATFORMS=linux/amd64

--- a/Makefile-deps.mk
+++ b/Makefile-deps.mk
@@ -23,7 +23,7 @@ GO_CMD ?= go
 
 GOLANGCI_LINT = $(PROJECT_DIR)/bin/golangci-lint
 golangci-lint:
-	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 GENREF = $(PROJECT_DIR)/bin/genref
 .PHONY: genref


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it

Code base relies on 1.32 of k8s. But the dependencies in Makefiles point to older versions. 

This PR updates;

* `ENVTEST_K8S_VERSION` to 1.32.0
* Kind image tag to 1.32.0
* kind go module to 0.26
* golangci-lint to 1.63.4

#### Which issue(s) this PR fixes
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
None
```
