### PR TITLE
support kubernetes version < 1.26

### DIFF
--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -165,7 +165,7 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 }
 
 // AddTPUVariables adds TPU related environment variables to containers
-func AddTPUVariables(pod *corev1.Pod, size int) error {
+func AddTPUVariables(pod *corev1.Pod, size int, enableStartOrdinal bool) error {
 	_, foundSubGroupSize := pod.Annotations[leaderworkerset.SubGroupSizeAnnotationKey]
 	if foundSubGroupSize {
 		return addTPUVariablesSubGroup(pod)
@@ -192,10 +192,11 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 		if leaderName == "" {
 			return fmt.Errorf("parsing parent name from pod %s", pod.Name)
 		}
+
 		if pod.Annotations[LeaderRequestsTPUsAnnotationKey] == "true" {
 			// The leader requests TPUs, and so it will be added to the hostnames and will get TPU_WORKER_ID=0
 			hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderName, pod.Spec.Subdomain))
-		} else {
+		} else if enableStartOrdinal {
 			// The leader doesn't request TPUs, and so it is only the workers that will be assigned
 			// TPU_WORKER_ID, and so we have to shift the IDs by 1 since the leader is not a TPU worker.
 			tpuWorkerId = tpuWorkerId - 1

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -81,7 +81,7 @@ func TestAddTPUVariables(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := AddTPUVariables(tc.pod, tc.size)
+			err := AddTPUVariables(tc.pod, tc.size, true)
 			if err != nil {
 				t.Errorf("Error parsing parent: %s", err.Error())
 			}

--- a/test/integration/webhooks/suite_test.go
+++ b/test/integration/webhooks/suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	err = webhooks.SetupLeaderWorkerSetWebhook(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = webhooks.SetupPodWebhook(mgr)
+	err = webhooks.SetupPodWebhook(mgr, true)
 	Expect(err).NotTo(HaveOccurred())
 	//+kubebuilder:scaffold:webhook
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

The LeaderWorkerSet will falling into infinite reconciliation loops with kubernetes < 1.26.  Actually, we want to enable it in 1.24.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #391 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
