### PR TITLE
Inject environment variable LWS_WORKER_INDEX

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -69,6 +69,10 @@ const (
 	// track the size of the LWS group.
 	LwsGroupSize string = "LWS_GROUP_SIZE"
 
+	// Environment variable added to all containers in the LeaderWorkerSet to
+	// the index/identity of the pod in the group.
+	LwsWorkerIndex string = "LWS_WORKER_INDEX"
+
 	// Subgroup index tracks which subgroup the pod is part of. It will be added
 	// as a label to the pod only if LeaderWorkerSet.Spec.SubGroupSize is set.
 	SubGroupIndexLabelKey string = "leaderworkerset.sigs.k8s.io/subgroup-index"

--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -147,13 +147,23 @@ func AddLWSVariables(pod *corev1.Pod) error {
 		Value: size,
 	}
 
+	workerIndex, found := pod.Labels[leaderworkerset.WorkerIndexLabelKey]
+	if !found {
+		return fmt.Errorf("Failure constructing environment variables, no worker index label found for pod %v", klog.KObj(pod))
+	}
+
+	workerIndexEnvVar := corev1.EnvVar{
+		Name:  leaderworkerset.LwsWorkerIndex,
+		Value: workerIndex,
+	}
+
 	// The order of injection needs attention, see
 	// https://github.com/kubernetes-sigs/lws/pull/152
 	for i := range pod.Spec.Containers {
-		addEnvVarsIfNotExists(&pod.Spec.Containers[i], leaderAddressEnvVar, sizeEnvVar)
+		addEnvVarsIfNotExists(&pod.Spec.Containers[i], leaderAddressEnvVar, sizeEnvVar, workerIndexEnvVar)
 	}
 	for i := range pod.Spec.InitContainers {
-		addEnvVarsIfNotExists(&pod.Spec.InitContainers[i], leaderAddressEnvVar, sizeEnvVar)
+		addEnvVarsIfNotExists(&pod.Spec.InitContainers[i], leaderAddressEnvVar, sizeEnvVar, workerIndexEnvVar)
 	}
 
 	return nil

--- a/pkg/utils/pod/pod_utils_test.go
+++ b/pkg/utils/pod/pod_utils_test.go
@@ -106,42 +106,49 @@ func TestAddLWSVariables(t *testing.T) {
 		pod                      *corev1.Pod
 		expectedLwsLeaderAddress string
 		expectedGroupSize        int
+		expectedWorkerIndex      string
 	}{
 		{
 			name:                     "Leader pod",
-			pod:                      wrappers.MakePodWithLabels("test-sample", "0", "", "default", 3),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "0", "0", "default", 3),
 			expectedLwsLeaderAddress: "test-sample-0.test-sample.default",
 			expectedGroupSize:        3,
+			expectedWorkerIndex:      "0",
 		},
 		{
 			name:                     "Worker pod",
 			pod:                      wrappers.MakePodWithLabels("test-sample", "0", "1", "default", 3),
 			expectedLwsLeaderAddress: "test-sample-0.test-sample.default",
 			expectedGroupSize:        3,
+			expectedWorkerIndex:      "1",
 		},
 		{
 			name:                     "Leader pod, group 1",
-			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "", "default", 2),
+			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "0", "default", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.default",
 			expectedGroupSize:        2,
+			expectedWorkerIndex:      "0",
 		},
 		{
 			name:                     "Worker pod, group 1",
 			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "default", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.default",
 			expectedGroupSize:        2,
+			expectedWorkerIndex:      "3",
 		},
 		{
 			name:                     "Leader pod, group 1, non-default namespace",
 			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.lws",
 			expectedGroupSize:        2,
+			expectedWorkerIndex:      "3",
 		},
 		{
 			name:                     "Worker pod, group 1, non-default namespace",
 			pod:                      wrappers.MakePodWithLabels("test-sample", "1", "3", "lws", 2),
 			expectedLwsLeaderAddress: "test-sample-1.test-sample.lws",
 			expectedGroupSize:        2,
+			expectedWorkerIndex:      "3",
 		},
 	}
 
@@ -168,6 +175,10 @@ func TestAddLWSVariables(t *testing.T) {
 				envVar = container.Env[1]
 				if diff := cmp.Diff(envVar.Value, strconv.Itoa(tc.expectedGroupSize)); diff != "" {
 					t.Errorf("Unexpected lws group size %s", diff)
+				}
+				envVar = container.Env[2]
+				if diff := cmp.Diff(envVar.Value, tc.expectedWorkerIndex); diff != "" {
+					t.Errorf("Unexpected lws worker index %s", diff)
 				}
 			}
 		})

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -389,7 +389,7 @@ func hasAllEnvVarPopulated(pod corev1.Pod, envVars []string) bool {
 }
 
 func HasLWSEnvVarsPopulated(pod corev1.Pod) bool {
-	return hasAllEnvVarPopulated(pod, []string{leaderworkerset.LwsLeaderAddress, leaderworkerset.LwsGroupSize})
+	return hasAllEnvVarPopulated(pod, []string{leaderworkerset.LwsLeaderAddress, leaderworkerset.LwsGroupSize, leaderworkerset.LwsWorkerIndex})
 }
 
 func CheckContainerHasCorrectEnvVar(pod corev1.Pod, expect corev1.EnvVar) error {

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -176,8 +176,9 @@ func MakePodWithLabels(setName, groupIndex, workerIndex, namespace string, size 
 			Name:      podName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				leaderworkerset.GroupIndexLabelKey: groupIndex,
-				leaderworkerset.SetNameLabelKey:    setName,
+				leaderworkerset.GroupIndexLabelKey:  groupIndex,
+				leaderworkerset.SetNameLabelKey:     setName,
+				leaderworkerset.WorkerIndexLabelKey: workerIndex,
 			},
 			Annotations: map[string]string{
 				leaderworkerset.SizeAnnotationKey: strconv.Itoa(size),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
When using sglang for distributed inference, it is necessary to use the environment variable LWS_WORKER_INDEX, which can be directly injected and used
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
