### PR TITLE
Run controller-gen only for api and pkg directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 		rbac:roleName=manager-role output:rbac:artifacts:config=config/rbac \
 		crd:generateEmbeddedObjectMeta=true output:crd:artifacts:config=config/crd/bases \
 		webhook output:webhook:artifacts:config=config/webhook \
-		paths="./..."
+		paths="{./api/..., ./pkg/...}"
 
 .PHONY: generate
 generate: controller-gen code-generator ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and client-go libraries.

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen code-generator ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and client-go libraries.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./api/..."
 	./hack/update-codegen.sh go $(PROJECT_DIR)/bin
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@bbc9711d9b2db31ce828714e7d3c875c00b4c1f1
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 GINKGO = $(shell pwd)/bin/ginkgo
 .PHONY: ginkgo


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
There are go.mods under `docs/examples/llamacpp/tools/` path (e.g. `docs/examples/llamacpp/tools/blobserver/go.mod`) which are not directly related to the actual code block and they present only as an examples. However, controller-gen executes also for them unnecessarily. 

This PR modifies controller-gen's path to only execute `api` and `pkg` to align with jobset https://github.com/kubernetes-sigs/jobset/blob/e8702b95e33c38d8a856ab63b14ffec5abd5e22a/Makefile#L90

Additionally, this PR updates to use branch name instead of commit hash in setupenv-test binary for better readability.

#### Does this PR introduce a user-facing change?
```release-note
None
```
