### PR TITLE
Add Label `leaderworkerset.sigs.k8s.io/name` to the headlessService

### DIFF
--- a/pkg/utils/controller/controller_utils.go
+++ b/pkg/utils/controller/controller_utils.go
@@ -41,6 +41,7 @@ func CreateHeadlessServiceIfNotExists(ctx context.Context, k8sClient client.Clie
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: lws.Namespace,
+				Labels:    map[string]string{leaderworkerset.SetNameLabelKey: lws.Name},
 			},
 			Spec: corev1.ServiceSpec{
 				ClusterIP:                "None", // defines service as headless


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it

From the comment in https://github.com/kubernetes-sigs/lws/blob/main/api/leaderworkerset/v1/leaderworkerset_types.go#L35 ,  
The service needs to have the label `leaderworkerset.sigs.k8s.io/name`.

Add Label `leaderworkerset.sigs.k8s.io/name` to the headlessService.

Needs to change the docs after https://github.com/kubernetes-sigs/lws/pull/431 merged.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #429

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add Label `leaderworkerset.sigs.k8s.io/name` to the headlessService.
```
