### PR TITLE
Change annotation `leaderworkerset.gke.io/subgroup-size` to `leaderworkerset.sigs.k8s.io/subgroup-size`

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -79,7 +79,7 @@ const (
 
 	// SubGroupSize will be added to pods as an annotation which corresponds to
 	// LeaderWorkerSet.Spec.SubGroupPolicy.SubGroupSize
-	SubGroupSizeAnnotationKey string = "leaderworkerset.gke.io/subgroup-size"
+	SubGroupSizeAnnotationKey string = "leaderworkerset.sigs.k8s.io/subgroup-size"
 
 	// Pods that are part of the same subgroup will have the same unique hash value.
 	SubGroupUniqueHashLabelKey string = "leaderworkerset.sigs.k8s.io/subgroup-key"


### PR DESCRIPTION
…sigs.k8s.io/subgroup-size`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it

From the KEP: https://github.com/kubernetes-sigs/lws/blob/main/keps/115-Subgroup-support/README.md?plain=1#L144,
the annotation needs to be `leaderworkerset.sigs.k8s.io/subgroup-size`, 
So change annotation `leaderworkerset.gke.io/subgroup-size` to `leaderworkerset.sigs.k8s.io/subgroup-size`.

And needs to change the docs if https://github.com/kubernetes-sigs/lws/pull/431 is merged.

The label should be more consistent with others.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #430

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change annotation  `leaderworkerset.gke.io/subgroup-size` to `leaderworkerset.sigs.k8s.io/subgroup-size`
```
