### PR TITLE
Use create jobs command instead of run pods in e2e testing

### DIFF
--- a/config/samples/leaderworkerset_exclusiveplacement.yaml
+++ b/config/samples/leaderworkerset_exclusiveplacement.yaml
@@ -19,7 +19,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/config/samples/leaderworkerset_multi_template.yaml
+++ b/config/samples/leaderworkerset_multi_template.yaml
@@ -15,7 +15,7 @@ spec:
       spec:
         containers:
         - name: nginx2
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"
@@ -28,7 +28,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/config/samples/leaderworkerset_tpu.yaml
+++ b/config/samples/leaderworkerset_tpu.yaml
@@ -19,7 +19,7 @@ spec:
           cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               google.com/tpu: 4

--- a/config/samples/leaderworkerset_v1_leaderworkerset.yaml
+++ b/config/samples/leaderworkerset_v1_leaderworkerset.yaml
@@ -21,7 +21,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/docs/examples/sample/lws-exclusive-placement.yaml
+++ b/docs/examples/sample/lws-exclusive-placement.yaml
@@ -13,7 +13,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/docs/examples/sample/lws-multi-template.yaml
+++ b/docs/examples/sample/lws-multi-template.yaml
@@ -9,7 +9,7 @@ spec:
       spec:
         containers:
         - name: nginx2
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"
@@ -22,7 +22,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/docs/examples/sample/lws-restart-policy.yaml
+++ b/docs/examples/sample/lws-restart-policy.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/docs/examples/sample/lws-rollout-strategy.yaml
+++ b/docs/examples/sample/lws-rollout-strategy.yaml
@@ -15,7 +15,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/docs/examples/sample/lws.yaml
+++ b/docs/examples/sample/lws.yaml
@@ -10,7 +10,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -113,7 +113,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -182,7 +182,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -251,7 +251,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
 							},
@@ -317,7 +317,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -387,7 +387,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
 							},

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -112,7 +112,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -189,7 +189,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -267,7 +267,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginx:1.14.2"),
+									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -31,7 +31,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: nginx:1.14.2
+          image: nginxinc/nginx-unprivileged:1.27
           resources:
             limits:
               cpu: "100m"

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -897,7 +897,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
 								return err
 							}
-							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "nginx:1.16.1"
+							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "nginxinc/nginx-unprivileged:1.26"
 							return k8sClient.Update(ctx, &leaderworkerset)
 						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
 					},

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -192,7 +192,7 @@ func MakeWorkerPodSpec() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -247,7 +247,7 @@ func MakeWorkerPodSpecWithTPUResource() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -273,7 +273,7 @@ func MakeLeaderPodSpec() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "worker",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 			},
 		},
 	}
@@ -310,7 +310,7 @@ func MakeLeaderPodSpecWithTPUResourceMultipleContainers() corev1.PodSpec {
 			},
 			{
 				Name:  "leader",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -328,7 +328,7 @@ func MakeWorkerPodSpecWithVolume() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -350,7 +350,7 @@ func MakeWorkerPodSpecWithVolumeAndNilImage() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginx:1.14.2",
+				Image: "nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
curl-metrics test tries to run a curl command to collect the metrics and
it is intended to be short lived. This is typical use case for jobs rather
than pods. This PR modifies the test to run job by using `kubectl create job`
command. Besides, kubectl run is not recommended.

Additionally, Default nginx image requires privileged access in the pod which is
unwanted and not recommended even in testing environments.

This PR switches to `nginxinc/nginx-unprivileged` that installs nginx
in an unprivileged way. This PR also updates the nginx version to 1.27
instead of the very old 1.14.2 (we only need to update the e2e tests, but just to
align all the pieces, this PR switches everywhere to the same version).

This PR must no affect on any functionality or any test.

#### Does this PR introduce a user-facing change?
```release-note
None
```
