### PR TITLE
Check controller_runtime_webhook_requests_total that always exists in both pods

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -386,7 +386,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 		ginkgo.By("getting the metrics by checking curl-metrics logs")
 		metricsOutput := getMetricsOutput(namespace)
 		gomega.Expect(metricsOutput).To(gomega.ContainSubstring(
-			"controller_runtime_reconcile_total",
+			"controller_runtime_webhook_requests_total",
 		))
 
 		ginkgo.By("cleaning up the curl-metrics job")


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/kind cleanup

#### What this PR does / why we need it
LWS runs 2 pods and one of them is elected as leader. So that reconciliation logic will only be running in the leader pod and the other will only accept webhook requests.

`controller_runtime_reconcile_total` is the measurement of how many times reconciliation function is executed. As a result, if there isn't any leader changes between pods, leader pod's reconciliation is supposed to be always greater than 0 and the other one should always be equal to 0.

That means this test should be flaky and it should fail when it gets the metrics from non-leader pod (although I couldn't find any such failures, maybe because at some point leader pod has changed?).

This PR switches to  `controller_runtime_webhook_requests_total`  metric to check the existence. `Service` resource should distribute the webhook traffic between 2 pods in round robin and it is guaranteed that `controller_runtime_webhook_requests_total` should exist in both of the pods unlike to `controller_runtime_reconcile_total`.

#### Does this PR introduce a user-facing change?
```release-note
None
```
