### PR TITLE
Set readOnlyRootFilesystem explicitly to true

### DIFF
--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -23,6 +23,7 @@ podSecurityContext:
   # fsGroup: 2000
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
This PR sets `readOnlyRootFilesystem` to true. This is important aspect to prevent any writes in root file system. Besides, LWS does not need to write root file system at all.

#### Does this PR introduce a user-facing change?
```release-note
Setting the pods readOnlyRootFilesystem to true
```
