### PR TITLE
Explicitly bind metrics 8443 as containerPort in kustomize and helm

### DIFF
--- a/charts/lws/templates/manager/deployment.yaml
+++ b/charts/lws/templates/manager/deployment.yaml
@@ -48,6 +48,11 @@ spec:
             - name: webhook-server
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.enablePrometheus }}
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/lws/templates/manager/service.yaml
+++ b/charts/lws/templates/manager/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enablePrometheus }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       targetPort: 8443
   selector:
     control-plane: controller-manager
+{{- end }}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -36,6 +36,8 @@ patches:
 # Other configurations
 - path: manager_config_patch.yaml
 
+- path: manager_metrics_patch.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,15 @@
+# This patch exposes 8443 port used by metrics service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
Although metrics should serve without mentioning this explicitly in deployment yaml (as we discussed in https://github.com/kubernetes-sigs/jobset/pull/844#issuecomment-2742642125), this is a good UI to define this port in deployment spec.

#### Does this PR introduce a user-facing change?
```release-note
Adding 8443 metrics port in deployment's containerPort field
```
