### PR TITLE
set golang to the minimum viable version of go

### DIFF
--- a/docs/examples/llamacpp/tools/blobserver/go.mod
+++ b/docs/examples/llamacpp/tools/blobserver/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/lws/docs/examples/llamacpp/tools/blobserver
 
-go 1.24
+go 1.22
 
 require k8s.io/klog/v2 v2.110.1
 

--- a/docs/examples/llamacpp/tools/clichat/go.mod
+++ b/docs/examples/llamacpp/tools/clichat/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/lws/docs/examples/llamacpp/tools/clichat
 
-go 1.24
+go 1.22
 
 require k8s.io/klog/v2 v2.110.1
 

--- a/docs/examples/llamacpp/tools/llamacpp-leader/go.mod
+++ b/docs/examples/llamacpp/tools/llamacpp-leader/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/lws/docs/examples/llamacpp/tools/clichat
 
-go 1.24
+go 1.22
 
 require k8s.io/klog/v2 v2.110.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/lws
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/lws/issues/476

go.mod's go stanza is tracking the minimum viable version of go to build the project. Since we are not using any Go 1.24 language features yet, the go.mod declarations should not be bumped.