### PR TITLE
Inject certs for metrics endpoint when cert-manager is enabled

### DIFF
--- a/charts/lws/templates/certmanager/certificate.yaml
+++ b/charts/lws/templates/certmanager/certificate.yaml
@@ -12,6 +12,7 @@ spec:
     - lws-webhook-service.{{ .Release.Namespace }}.svc
     - lws-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
+    group: cert-manager.io
     kind: Issuer
     name: lws-selfsigned-issuer
   secretName: lws-webhook-server-cert

--- a/charts/lws/templates/certmanager/certificatemetrics.yaml
+++ b/charts/lws/templates/certmanager/certificatemetrics.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.enableCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/instance: serving-cert
+    {{- include "lws.labels" . | nindent 4 }}
+  name: lws-metrics-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ include "lws.fullname" . }}-metrics
+  dnsNames:
+    - {{ include "lws.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+    - {{ include "lws.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: lws-selfsigned-issuer
+  secretName: lws-metrics-server-cert
+{{- end }}

--- a/charts/lws/templates/manager/deployment.yaml
+++ b/charts/lws/templates/manager/deployment.yaml
@@ -71,6 +71,11 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+            {{- if .Values.enableCertManager }}
+            - mountPath: /tmp/k8s-metrics-server/serving-certs
+              name: metrics-cert
+              readOnly: true
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -88,3 +93,16 @@ spec:
           secret:
             defaultMode: 420
             secretName: lws-webhook-server-cert
+        {{- if .Values.enableCertManager }}
+        - name: metrics-cert
+          secret:
+            secretName: lws-metrics-server-cert
+            optional: false
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+        {{- end }}

--- a/charts/lws/templates/prometheus/monitor.yaml
+++ b/charts/lws/templates/prometheus/monitor.yaml
@@ -15,7 +15,23 @@ spec:
       port: https
       scheme: https
       tlsConfig:
-        insecureSkipVerify: true
+        {{- if .Values.enableCertManager }}
+        serverName: {{ include "lws.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: lws-metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: lws-metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: lws-metrics-server-cert
+          key: tls.key
+        {{- else }}
+          insecureSkipVerify: true
+        {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,19 @@
+# The following manifests contain a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: metrics-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  commonName: lws-metrics
+  dnsNames:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    # replacements in the config/default/kustomization.yaml file.
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -34,6 +34,7 @@ spec:
   - SERVICE_NAME.SERVICE_NAMESPACE.svc
   - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
+    group: cert-manager.io
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - certificate.yaml
+- certificate-metrics.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/components/prometheus/kustomization.yaml
+++ b/config/components/prometheus/kustomization.yaml
@@ -1,3 +1,11 @@
 resources:
 - monitor.yaml
 - role.yaml
+# [PROMETHEUS-WITH-CERTS] The following patch configures the ServiceMonitor in ../prometheus
+# to securely reference certificates created and managed by cert-manager.
+# Additionally, ensure that you uncomment the [METRICS WITH CERTMANAGER] patch under config/default/kustomization.yaml
+# to mount the "metrics-server-cert" secret in the Manager Deployment.
+#patches:
+#- path: monitor_tls_patch.yaml
+#  target:
+#    kind: ServiceMonitor

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -1,0 +1,19 @@
+# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
+# using certificates managed by cert-manager
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/config/default/cert_metrics_manager_patch.yaml
+++ b/config/default/cert_metrics_manager_patch.yaml
@@ -1,0 +1,25 @@
+# This patch adds the args, volumes, and ports to allow the manager to use the metrics-server certs.
+
+# Add the volumeMount for the metrics-server certs
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /tmp/k8s-metrics-server/serving-certs
+    name: metrics-cert
+    readOnly: true
+
+# Add the metrics-server certs volume configuration
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: metrics-cert
+    secret:
+      secretName: metrics-server-cert
+      optional: false
+      items:
+        - key: ca.crt
+          path: ca.crt
+        - key: tls.crt
+          path: tls.crt
+        - key: tls.key
+          path: tls.key

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../internalcert
+#- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -42,6 +43,13 @@ patches:
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
 #- path: webhookcainjection_patch.yaml
+
+# Uncomment the patches line if you enable Metrics and CertManager
+# [CERTMANAGER] To enable metrics protected with certManager, uncomment the following line.
+# This patch will protect the metrics with certManager self-signed certs.
+# - path: cert_metrics_manager_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
@@ -118,6 +126,7 @@ patches:
 #          kind: Certificate
 #          group: cert-manager.io
 #          version: v1
+#          name: serving-cert
 #        fieldPaths:
 #          - .spec.dnsNames.0
 #          - .spec.dnsNames.1
@@ -135,6 +144,7 @@ patches:
 #          kind: Certificate
 #          group: cert-manager.io
 #          version: v1
+#          name: serving-cert
 #        fieldPaths:
 #          - .spec.dnsNames.0
 #          - .spec.dnsNames.1
@@ -142,3 +152,62 @@ patches:
 #          delimiter: '.'
 #          index: 1
 #          create: true
+#  - source: # Add cert-manager annotation to the webhook Service
+#      kind: Service
+#      version: v1
+#      name: controller-manager-metrics-service
+#      fieldPath: .metadata.name # name of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#          name: metrics-cert
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#      - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#        fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#        options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: controller-manager-metrics-service
+#      fieldPath: .metadata.namespace # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#          name: metrics-cert
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: ServiceMonitor
+#          group: monitoring.coreos.com
+#          version: v1
+#          name: controller-manager-metrics-monitor
+#        fieldPaths:
+#          - spec.endpoints.0.tlsConfig.serverName
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true
+


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it
ServiceMonitor resource is configured to serve TLS with `insecureSkipVerify: true` . However, this is not recommended for production use cases. This PR injects the appropriate certificates to the ServiceMonitor to serve from the trusted certificates within the cluster, when cert-manager (or another external certificate management tool) is enabled.

This PR configures kustomize and helm charts according to this. 

There is no functional change, when internal cert management is enabled (which is the default setting).

This PR is inspired by https://github.com/kubernetes-sigs/kueue/pull/4385

#### Does this PR introduce a user-facing change?
```release-note
Injecting certificates to ServiceMonitor in order to serve securely, when cert-manager is enabled
```
