### PR TITLE
docs: remove the use of Downward API for LWS_WORKER_INDEX

### DIFF
--- a/docs/examples/sglang/lws.yaml
+++ b/docs/examples/sglang/lws.yaml
@@ -18,10 +18,6 @@ spec:
             env:
               - name: HUGGING_FACE_HUB_TOKEN
                 value: <your-hf-token>
-              - name: LWS_WORKER_INDEX
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
             command:
               - python3
               - -m
@@ -53,7 +49,7 @@ spec:
               periodSeconds: 10
             volumeMounts:
               - mountPath: /dev/shm
-                name: dshm    
+                name: dshm
         volumes:
           - name: dshm
             emptyDir:
@@ -66,10 +62,6 @@ spec:
             env:
             - name: HUGGING_FACE_HUB_TOKEN
               value: <your-hf-token>
-            - name: LWS_WORKER_INDEX
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
             command:
               - python3
               - -m

--- a/site/content/en/docs/reference/labels-annotations-and-environment-variables.md
+++ b/site/content/en/docs/reference/labels-annotations-and-environment-variables.md
@@ -7,39 +7,39 @@ description:  A reference for all labels, annotations, and environment variables
 
 # Labels
 
-| Key                                        | Description                                                       | Example                        | Applies to                   |
-|--------------------------------------------|----------------------------------------------------------------------|--------------------------------|------------------------------|
-| leaderworkerset.sigs.k8s.io/name           | The name of the LeaderWorkerSet object to which these resources belong. | leaderworkerset-multi-template | Pod, Statefulset, Service             |
-| leaderworkerset.sigs.k8s.io/template-revision-hash | Hash used to track the controller revision that matches a LeaderWorkerSet object. | 5c5fcdfb44                     | Pod, Statefulset             |
-| leaderworkerset.sigs.k8s.io/group-index    | The group to which it belongs.                                       | 0                              | Pod, Statefulset (only worker) |
-| leaderworkerset.sigs.k8s.io/group-key      | Unique key identifying the group.                                    | 689ce1b5...b07                 | Pod, Statefulset (only worker) |
-| leaderworkerset.sigs.k8s.io/worker-index   | The index or identity of the pod within the group.                   | 0                              | Pod                          |
-| leaderworkerset.sigs.k8s.io/subgroup-index | Tracks which subgroup the pod is part of.                            | 0                              | Pod (only if SubGroup is set) |
-| leaderworkerset.sigs.k8s.io/subgroup-key   | Pods that are part of the same subgroup will have the same unique hash value. | 92904e74...801                 | Pod (only if SubGroup is set) |
+| Key                                                  | Description                                                                       | Example                        | Applies to                     |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------ | ------------------------------ |
+| `leaderworkerset.sigs.k8s.io/name`                   | The name of the LeaderWorkerSet object to which these resources belong.           | leaderworkerset-multi-template | Pod, StatefulSet, Service      |
+| `leaderworkerset.sigs.k8s.io/template-revision-hash` | Hash used to track the controller revision that matches a LeaderWorkerSet object. | 5c5fcdfb44                     | Pod, StatefulSet               |
+| `leaderworkerset.sigs.k8s.io/group-index`            | The group to which it belongs.                                                    | 0                              | Pod, StatefulSet (only worker) |
+| `leaderworkerset.sigs.k8s.io/group-key`              | Unique key identifying the group.                                                 | 689ce1b5...b07                 | Pod, StatefulSet (only worker) |
+| `leaderworkerset.sigs.k8s.io/worker-index`           | The index or identity of the pod within the group.                                | 0                              | Pod                            |
+| `leaderworkerset.sigs.k8s.io/subgroup-index`         | Tracks which subgroup the pod is part of.                                         | 0                              | Pod (only if SubGroup is set)  |
+| `leaderworkerset.sigs.k8s.io/subgroup-key`           | Pods that are part of the same subgroup will have the same unique hash value.     | 92904e74...801                 | Pod (only if SubGroup is set)  |
 
 # Annotations
 
-| Key                                          | Description                                                       | Example                        | Applies to                   |
-|----------------------------------------------|----------------------------------------------------------------------|--------------------------------|------------------------------|
-| leaderworkerset.sigs.k8s.io/size             | The total number of pods in each group.      | 4                              | Pod                          |
-| leaderworkerset.sigs.k8s.io/replicas         | Replicas Number of leader-workers groups.                        | 3                              | Statefulset (only leader)    |
-| leaderworkerset.sigs.k8s.io/leader-name      | The name of the leader pod.                                          | leaderworkerset-multi-template-0 | Pod (only worker)            |
-| leaderworkerset.sigs.k8s.io/exclusive-topology | Specifies the topology for exclusive 1:1 scheduling.                 | cloud.google.com/gke-nodepool  | LeaderWorkerSet, Pod (only if exclusive-topology is used) |
-| leaderworkerset.sigs.k8s.io/subdomainPolicy  | Determines what type of domain will be injected.   | UniquePerReplica               | Pod (only if leader and subdomainPolicy set to UniquePerReplica) |
-| leaderworkerset.sigs.k8s.io/subgroup-size    | The number of pods per subgroup.                                     | 2                              | Pod (only if SubGroup is set) |
-| leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology | Specifies the topology for exclusive 1:1 scheduling within a subgroup. | topologyKey                    | LeaderWorkerSet, Pod (only if SubGroup is set and subgroup-exclusive-topology is used) |
-| leaderworkerset.sigs.k8s.io/leader-requests-tpus | Indicates if the leader pod requests TPU.                            | true                           | Pod (only if leader pod requests TPU) |
+| Key                                                       | Description                                                            | Example                          | Applies to                                                                             |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
+| `leaderworkerset.sigs.k8s.io/size`                        | The total number of pods in each group.                                | 4                                | Pod                                                                                    |
+| `leaderworkerset.sigs.k8s.io/replicas`                    | Replicas Number of leader-workers groups.                              | 3                                | StatefulSet (only leader)                                                              |
+| `leaderworkerset.sigs.k8s.io/leader-name`                 | The name of the leader pod.                                            | leaderworkerset-multi-template-0 | Pod (only worker)                                                                      |
+| `leaderworkerset.sigs.k8s.io/exclusive-topology`          | Specifies the topology for exclusive 1:1 scheduling.                   | cloud.google.com/gke-nodepool    | LeaderWorkerSet, Pod (only if exclusive-topology is used)                              |
+| `leaderworkerset.sigs.k8s.io/subdomainPolicy`             | Determines what type of domain will be injected.                       | UniquePerReplica                 | Pod (only if leader and subdomainPolicy set to UniquePerReplica)                       |
+| `leaderworkerset.sigs.k8s.io/subgroup-size`               | The number of pods per subgroup.                                       | 2                                | Pod (only if SubGroup is set)                                                          |
+| `leaderworkerset.sigs.k8s.io/subgroup-exclusive-topology` | Specifies the topology for exclusive 1:1 scheduling within a subgroup. | topologyKey                      | LeaderWorkerSet, Pod (only if SubGroup is set and subgroup-exclusive-topology is used) |
+| `leaderworkerset.sigs.k8s.io/leader-requests-tpus`        | Indicates if the leader pod requests TPU.                              | true                             | Pod (only if leader pod requests TPU)                                                  |
 
 # Environment Variables
 
-| Key              | Description                                                       | Example                                                                                       | Applies to |
-|------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|------------|
-| LWS_LEADER_ADDRESS | The address of the leader via the headless service.                  | leaderworkerset-multi-template-0.leaderworkerset-multi-template.default                       | Pod        |
-| LWS_GROUP_SIZE     | Tracks the size of the LWS group.                                    | 4                                                                                             | Pod        |
-| LWS_WORKER_INDEX   | The index or identity of the pod within the group.                   | 2                                                                                             | Pod        |
-| TPU_WORKER_HOSTNAMES | Hostnames of TPU workers only in the same subgroup.                | test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default,test-sample-1-8.default | Pod (only if TPU enabled) |
-| TPU_WORKER_ID      | ID of the TPU worker.                                                | 0                                                                                             | Pod (only if TPU enabled) |
-| TPU_NAME          | Name of the TPU.                                                     | test-sample-1                                                                                 | Pod (only if TPU enabled) |
+| Key                    | Description                                         | Example                                                                                         | Applies to                |
+| ---------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------- |
+| `LWS_LEADER_ADDRESS`   | The address of the leader via the headless service. | leaderworkerset-multi-template-0.leaderworkerset-multi-template.default                         | Pod                       |
+| `LWS_GROUP_SIZE`       | Tracks the size of the LWS group.                   | 4                                                                                               | Pod                       |
+| `LWS_WORKER_INDEX`     | The index or identity of the pod within the group.  | 2                                                                                               | Pod                       |
+| `TPU_WORKER_HOSTNAMES` | Hostnames of TPU workers only in the same subgroup. | test-sample-1-5.default,test-sample-1-6.default,test-sample-1-7.default,test-sample-1-8.default | Pod (only if TPU enabled) |
+| `TPU_WORKER_ID`        | ID of the TPU worker.                               | 0                                                                                               | Pod (only if TPU enabled) |
+| `TPU_NAME`             | Name of the TPU.                                    | test-sample-1                                                                                   | Pod (only if TPU enabled) |
 
-If you want to use more environment variables, they are available in the labels or annotations but not listed in the Environment Variables section. 
+If you want to use more environment variables, they are available in the labels or annotations but not listed in the Environment Variables section.
 We can obtain the index by using the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to pass the Pod's label as an environment variable to the container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Remove the use of Downward API for `LWS_WORKER_INDEX` since it's injected by LWS automatically since v0.6.0.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #427

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
docs: remove the use of Downward API for LWS_WORKER_INDEX
```
