### PR TITLE
Update helm install documentation

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -118,9 +118,11 @@ Finally, install the cert manager follwing the link: https://cert-manager.io/doc
 and apply these configurations to your cluster with ``kubectl apply --server-side -k config/default``.
 
 ## Install with Helm chart
-See [lws/charts](https://github.com/kubernetes-sigs/lws/tree/main/charts/lws)
+
+Please refer to the release page for [helm charts][helm_charts].
 
 [feature_gate]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 [start_ordinal]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#start-ordinal
 [max_unavailable]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
 [max_unavailable_enhancement]: https://github.com/kubernetes/enhancements/issues/961
+[helm_charts]: https://github.com/kubernetes-sigs/lws/releases

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -114,7 +114,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 Next, in the file ``lws/config/default/kustomization.yaml`` replace ``../internalcert`` with
 ``../certmanager`` then uncomment all the lines beginning with ``[CERTMANAGER]``.
 
-Finally, install the cert manager follwing the link: https://cert-manager.io/docs/installation/#default-static-install
+Finally, install the cert manager following the link: https://cert-manager.io/docs/installation/#default-static-install
 and apply these configurations to your cluster with ``kubectl apply --server-side -k config/default``.
 
 ## Install with Helm chart


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

We restructured the helm charts path before releasing v0.6.0 in k8s-infra, see kueue  for example: https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-kueue/images.yaml#L1. For lws, we have to release another version like v0.6.1, then we can access the helm chart via commands like `helm push artifacts/lws-chart-v0.6.1.tgz oci://us-central1-docker.pkg.dev/k8s-staging-images/lws/charts`. However, I'm not going to release another version  since we just published one, and people can actually access the helm chart via our release page, see https://github.com/kubernetes-sigs/lws/releases/tag/v0.6.0. 

Let's make it happen at next release and we can see that the helm chart is pushed successfully here: https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/lws/charts%2Flws?invt=Abt2Vg

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/lws/pull/487, https://github.com/kubernetes-sigs/lws/issues/425

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
