### PR TITLE
Introduce env variable to modify ns in metrics tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -314,6 +314,9 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 	serviceAccountName := "lws-controller-manager"
 	metricsServiceName := "lws-controller-manager-metrics-service"
 	namespace := "lws-system"
+	if ns := os.Getenv("LWS_NAMESPACE"); ns != "" {
+		namespace = ns
+	}
 	var controllerPodName string
 
 	ginkgo.It("should ensure the metrics endpoint is serving metrics", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
`should ensure the metrics endpoint is serving metrics` test strictly rely on `lws-system` namespace while checking the resources. However, this test should also work on the environments that LWS is deployed to another namespaces. 

This PR introduces `LWS_NAMESPACE` environment variable. If it is not set, default `lws-system` will be used.

#### Does this PR introduce a user-facing change?
```release-note
None
```
