### PR TITLE
Fix UpdateInProgress conditions for newly created LWS

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -389,9 +389,6 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 		if err != nil {
 			return false, false, err
 		}
-		if index < int(*lws.Spec.Replicas) {
-			currentNonBurstWorkerCount++
-		}
 
 		var sts appsv1.StatefulSet
 		if !noWorkerSts {
@@ -402,6 +399,10 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 				}
 				continue
 			}
+		}
+
+		if index < int(*lws.Spec.Replicas) {
+			currentNonBurstWorkerCount++
 		}
 
 		var ready, updated bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

**Fixes #400**  

**Bug Scenario**:  
A condition occurs where the LWS worker StatefulSet has not yet been properly initialized.  

**Root Cause**:  
In  https://github.com/kubernetes-sigs/lws/pull/298/files#diff-636763c4aab72861dbe05856e71e11abf551830d79fdcd848f3133ffc9c2d6e1R386 , the introduction of the `continue` keyword causes `currentNonBurstWorkerCount++` to execute prematurely.  

This leads to the condition `updatedNonBurstWorkerCount < currentNonBurstWorkerCount` at https://github.com/kubernetes-sigs/lws/blob/v0.6.0/pkg/controllers/leaderworkerset_controller.go#L441 , triggering the bug.  

**Fix**:  
Simply move `currentNonBurstWorkerCount++` **below** the `continue` statement to resolve the issue.  


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix UpdateInProgress conditions for newly created LWS
```
