### PR TITLE
Add documentation for the installation of cert-manager, monitoring

### DIFF
--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -46,6 +46,21 @@ NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
 lws-system-controller-manager   1/1     1            1           14s
 ```
 
+##### Cert Manager
+
+LWS has support for third-party certificates.
+One can enable this by setting `enableCertManager` to true.
+This will use certManager to generate a secret, inject the CABundles and set up the tls.
+
+Check out the [site](https://lws.sigs.k8s.io/docs/manage/cert_manager/)
+for more information on installing cert manager with our Helm chart.
+
+##### Prometheus
+
+LWS supports prometheus metrics.
+Check out the [site](https://lws.sigs.k8s.io/docs/manage/prometheus/)
+for more information on installing LWS with metrics using our Helm chart.
+
 ### Configuration
 
 The following table lists the configurable parameters of the LWS chart and their default values.

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -139,20 +139,7 @@ namespace: <your-namespace>
 
 ## Optional: Use cert manager instead of internal cert
 The webhooks use an internal certificate by default. However, if you wish to use cert-manager (which
-supports cert rotation), instead of internal cert, you can by performing the following steps.
-
-First, install cert-manager on your cluster by running the following command:
-
-```shell
-CERT_MANAGER_VERSION=v1.17.1
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cert-manager.yaml
-```
-
-Next, in the file ``lws/config/default/kustomization.yaml`` replace ``../internalcert`` with
-``../certmanager`` then uncomment all the lines beginning with ``[CERTMANAGER]``.
-
-Finally, install the cert manager following the link: https://cert-manager.io/docs/installation/#default-static-install
-and apply these configurations to your cluster with ``kubectl apply --server-side -k config/default``.
+supports cert rotation), instead of internal cert, follow the [cert manage guide](/docs/manage/cert_manager).
 
 ## Install with Helm chart
 

--- a/site/content/en/docs/manage/_index.md
+++ b/site/content/en/docs/manage/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Management of LWS"
+weight: 7
+description: >
+  This section contains the LWS management information.
+---

--- a/site/content/en/docs/manage/cert_manager.md
+++ b/site/content/en/docs/manage/cert_manager.md
@@ -1,0 +1,40 @@
+---
+title: "Configure external cert-manager"
+date: 2025-04-28
+weight: 1
+description: >
+  Cert Manager Support
+---
+
+This page shows how you can a third party certificate authority solution like
+Cert Manager.
+
+## Before you begin
+
+Make sure you the following conditions are set:
+
+- A Kubernetes cluster is running.
+- The kubectl command-line tool has communication with your cluster.
+- Cert Manager is [installed](https://cert-manager.io/docs/installation/)
+
+LWS supports either Kustomize or installation via a Helm chart.
+
+### Internal Certificate management
+
+In all cases, LWS's internal certificate management must be turned off
+if one wants to use CertManager.
+
+### Kustomize Installation
+
+1. Set `internalCertManagement.enable` to `false` in the LWS configuration.
+2. Comment out the `../internalcert` folder in `config/default/kustomization.yaml`.
+3. Uncomment `../certmanager` folder in `config/default/kustomization.yaml`.
+4. Enable `cert-manager` in `config/default/kustomization.yaml` and uncomment all sections with 'CERTMANAGER'.
+5. Apply these configurations to your cluster with ``kubectl apply --server-side -k config/default``.
+
+### Helm Installation
+
+LWS can also support optional helm values for Cert Manager enablement.
+
+1. Disable `internalCertManager` in the LWS configuration.
+2. set `enableCertManager` in your values.yaml file to true.

--- a/site/content/en/docs/manage/prometheus.md
+++ b/site/content/en/docs/manage/prometheus.md
@@ -1,0 +1,75 @@
+---
+title: "Configure Prometheus"
+date: 2025-04-28
+weight: 2
+description: >
+  Prometheus Support
+---
+
+
+This page shows how you configure LWS to use prometheus metrics.
+
+## Before you begin
+
+Make sure you the following conditions are set:
+
+- A Kubernetes cluster is running.
+- The kubectl command-line tool has communication with your cluster.
+- Prometheus is [installed](https://prometheus-operator.dev/docs/getting-started/installation/)
+- Cert Manager can be optionally [installed](https://cert-manager.io/docs/installation/)
+
+LWS supports either Kustomize or installation via a Helm chart.
+
+### Kustomize Installation
+
+1. Enable `prometheus` in `config/default/kustomization.yaml` and uncomment all sections with 'PROMETHEUS'.
+
+#### Kustomize Prometheus with certificates
+
+If you want to enable TLS verification for the metrics endpoint, follow the directions below.
+
+1. Set `internalCertManagement.enable` to `false` in the LWS configuration.
+2. Comment out the `internalcert` folder in `config/default/kustomization.yaml`.
+3. Enable `cert-manager` in `config/default/kustomization.yaml` and uncomment all sections with 'CERTMANAGER'.
+4. To enable secure metrics with TLS protection, uncomment all sections with 'PROMETHEUS-WITH-CERTS'.
+
+### Helm Installation
+
+#### Prometheus installation
+
+LWS can also supports helm deployment for Prometheus.
+
+1. Set `enablePrometheus` in your values.yaml file to true.
+
+#### Helm Prometheus with certificates
+
+If you want to secure the metrics endpoints with external certificates:
+
+1. Set `internalCertManagement.enable` to `false` in the LWS configuration.
+2. Set both `enableCertManager` and `enablePrometheus` to true.
+3. Provide values for the tlsConfig, see the example below:
+
+An example for your tlsConfig in the helm chart could be as follows:
+
+```yaml
+...
+metrics:
+  prometheusNamespace: monitoring
+# tls configs for serviceMonitor
+  serviceMonitor:
+    tlsConfig:
+      serverName: lws-controller-manager-metrics-service.lws-system.svc
+      ca:
+        secret:
+          name: lws-metrics-server-cert
+          key: ca.crt
+      cert:
+        secret:
+          name: lws-metrics-server-cert
+          key: tls.crt
+      keySecret:
+        name: lws-metrics-server-cert
+        key: tls.key
+```
+
+The secrets must reference the cert manager generated secrets.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it
As promised in https://github.com/kubernetes-sigs/lws/pull/478#issuecomment-2771358282 to add documentation with respect to TLS configured Prometheus settings for https://github.com/kubernetes-sigs/lws/pull/478, this PR adds these documentations mimicking from https://github.com/kubernetes-sigs/kueue/pull/4598

#### Does this PR introduce a user-facing change?
```release-note
Updating website about how to configure cert-manager and prometheus.
```
