### PR TITLE
Add LWS configuration in Helm Charts

### DIFF
--- a/charts/lws/templates/manager/configmap.yaml
+++ b/charts/lws/templates/manager/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lws.fullname" . }}-manager-config
+  namespace: {{ .Release.Namespace}}
+  labels:
+    {{- include "lws.labels" . | nindent 4 }}
+data:
+  controller_manager_config.yaml: |2
+
+    apiVersion: config.jobset.x-k8s.io/v1alpha1
+    kind: Configuration
+    leaderElection:
+      leaderElect: true
+    internalCertManagement:
+      enable: {{ not .Values.certManager.enable }}

--- a/charts/lws/templates/manager/deployment.yaml
+++ b/charts/lws/templates/manager/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - args:
-          - --leader-elect
+          - --config=/controller_manager_config.yaml
           - --zap-log-level=2
           command:
           - /manager
@@ -68,6 +68,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            - name: manager-config
+              subPath: controller_manager_config.yaml
+              mountPath: /controller_manager_config.yaml
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
@@ -89,6 +92,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: manager-config
+          configMap:
+            name: {{ include "lws.fullname" . }}-manager-config
         - name: cert
           secret:
             defaultMode: 420

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -2,3 +2,5 @@ apiVersion: config.lws.x-k8s.io/v1alpha1
 kind: Configuration
 leaderElection:
   leaderElect: true
+internalCertManagement:
+  enable: true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
Helm chart does not support configuring LWS configuration like Kustomize. This PR defines this configuration as configmap and binds it to deployment as a volume to be used by the application. 

#### Which issue(s) this PR fixes
Fixes https://github.com/kubernetes-sigs/lws/issues/514

#### Does this PR introduce a user-facing change?
```release-note
None
```
