### PR TITLE
Use correct lws apigroup name

### DIFF
--- a/charts/lws/templates/manager/configmap.yaml
+++ b/charts/lws/templates/manager/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   controller_manager_config.yaml: |2
 
-    apiVersion: config.jobset.x-k8s.io/v1alpha1
+    apiVersion: config.lws.x-k8s.io/v1alpha1
     kind: Configuration
     leaderElection:
       leaderElect: true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
There is an incorrect config name which is actually for JobSet not LWS. This PR updates it to LWS config api group.

#### Does this PR introduce a user-facing change?
```release-note
None
```
