### PR TITLE
fix: check optional field not nil before reference

### DIFF
--- a/charts/lws/templates/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/templates/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -8097,6 +8097,15 @@ spec:
                         SubGroupPolicy describes the policy that will be applied when creating subgroups
                         in each replica.
                       properties:
+                        subGroupPolicyType:
+                          default: LeaderWorker
+                          description: |-
+                            Defines what type of Subgroups to create. Defaults to
+                            LeaderWorker
+                          enum:
+                          - LeaderWorker
+                          - LeaderExcluded
+                          type: string
                         subGroupSize:
                           description: |-
                             The number of pods per subgroup. This value is immutable,
@@ -16126,6 +16135,9 @@ spec:
                       description: |-
                         SubdomainPolicy determines the policy that will be used when creating
                         the headless service, defaults to shared
+                      enum:
+                      - Shared
+                      - UniquePerReplica
                       type: string
                   required:
                     - subdomainPolicy

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -245,7 +245,9 @@ func validateUpdateSubGroupPolicy(specPath *field.Path, lws *v1.LeaderWorkerSet)
 	if size < subGroupSize {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "subGroupSize cannot be larger than size"))
 	}
-	if (*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type == v1.SubGroupPolicyTypeLeaderExcluded) && ((size-1)%subGroupSize != 0) {
+	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type != nil &&
+		(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type == v1.SubGroupPolicyTypeLeaderExcluded) &&
+		((size-1)%subGroupSize != 0) {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "size-1 must be divisible by subGroupSize when using LeaderExcluded"))
 	}
 	return allErrs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

1) check optional field not nil which may come from older CRD
2) modify the CRD file in charts sub-folder ( copy that part from `config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml` generated by `make artifacts`)


NOTE: the "charts/" folder seems being manually maintained,  I cannot directly override the files under `charts` folder , with kustomize generated `config/`  files.


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #529 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
