### PR TITLE
fix: update the subgroup-index caculation

### DIFF
--- a/keps/115-Subgroup-support/README.md
+++ b/keps/115-Subgroup-support/README.md
@@ -166,6 +166,8 @@ In order to mitigate the problem described above, if the leader does not request
 With the new values, this is how the placement will look like
 ![Leader doesn't request TPU resources](https://github.com/kubernetes-sigs/lws/assets/86417275/2d22fb99-2e41-463f-a7f6-40e4925ede7f)
 
+NOTE: Since LWS v0.6.2, the subgroup-index formula will be changed to `leaderworkerset.sigs.k8s.io/subgroup-index = workerIndex % subGroupSize` , the same way as `TPU_WORKER_ID` above.
+
 ### Test Plan
 
 <!--

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -149,7 +149,7 @@ func (p *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 				return err
 			}
 			leaderName := pod.Annotations[leaderworkerset.LeaderPodNameAnnotationKey]
-			subGroupIndexKey := getSubGroupIndex(podCount, subGroupSizeInt, workerIndex)
+			subGroupIndexKey := getSubGroupIndex(subGroupSizeInt, workerIndex)
 			pod.Labels[leaderworkerset.SubGroupIndexLabelKey] = subGroupIndexKey
 			subGroupUniqueKey := genGroupUniqueKey(leaderName, subGroupIndexKey)
 			pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] = subGroupUniqueKey
@@ -242,10 +242,6 @@ func exclusiveAffinityApplied(pod corev1.Pod, topologyKey string) bool {
 	return hasAffinity && hasAntiAffinity
 }
 
-func getSubGroupIndex(podCount int, subGroupSize int, workerIndex int) string {
-	if (podCount-1)%subGroupSize == 0 {
-		// Leader is considered as extra pod, it is part of the first group
-		return fmt.Sprint((workerIndex - 1) / subGroupSize)
-	}
-	return fmt.Sprint(workerIndex / subGroupSize)
+func getSubGroupIndex(subGroupSize int, workerIndex int) string {
+	return fmt.Sprint(workerIndex % subGroupSize)
 }

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -278,25 +278,67 @@ func TestGetSubGroupIndex(t *testing.T) {
 		leaderOnly            bool
 		expectedSubGroupIndex string
 	}{
+		// | workerId |  subGroup |
+		// | -------- | --------- |
+		// | 0        | 0         |
+		// | 1        | 1         |
+		// | 2        | 0        |
+		// | 3        | 1         |
 		{
-			name:                  "Even number of pods",
+			name:                  "Even number of pods, worker 1 belongs to subGroup 1",
 			podCount:              4,
 			subGroupSize:          2,
-			workerIndex:           2,
+			workerIndex:           1,
 			expectedSubGroupIndex: "1",
 		},
 		{
-			name:                  "Odd number of pods, first subgroup has an extra pod",
+			name:                  "Even number of pods, worker 2 belongs to subGroup 0",
+			podCount:              4,
+			subGroupSize:          2,
+			workerIndex:           2,
+			expectedSubGroupIndex: "0",
+		},
+		// | workerId |  subGroup |
+		// | -------- | --------- |
+		// | 0        | 0         |
+		// | 1        | 1         |
+		// | 2        | 0         |
+		// | 3        | 1         |
+		// | 4        | 0         |
+		// ID 0 is the leader, per KEP 115 , the TPU request by pods in subGroup 0 is actually 2, so reach the balance
+		{
+			name:                  "Odd number of pods, first subgroup has an extra pod, worker 2 belongs to subGroup 0",
 			podCount:              5,
 			subGroupSize:          2,
 			workerIndex:           2,
 			expectedSubGroupIndex: "0",
 		},
+		{
+			name:                  "Odd number of pods, first subgroup has an extra pod, worker 4 belongs to subGroup 0",
+			podCount:              5,
+			subGroupSize:          2,
+			workerIndex:           4,
+			expectedSubGroupIndex: "0",
+		},
+		{
+			name:                  "Odd number of pods, worker 1 belongs to subGroup 1 ",
+			podCount:              5,
+			subGroupSize:          2,
+			workerIndex:           1,
+			expectedSubGroupIndex: "1",
+		},
+		{
+			name:                  "Odd number of pods, worker 3 belongs to subGroup 1 ",
+			podCount:              5,
+			subGroupSize:          2,
+			workerIndex:           3,
+			expectedSubGroupIndex: "1",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			subGroupIndex := getSubGroupIndex(tc.podCount, tc.subGroupSize, tc.workerIndex)
+			subGroupIndex := getSubGroupIndex(tc.subGroupSize, tc.workerIndex)
 			if tc.expectedSubGroupIndex != subGroupIndex {
 				t.Errorf("Expected subGroupIndex to be %s, got %s", tc.expectedSubGroupIndex, subGroupIndex)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

refer to #533  for explanation 

There's flaw for original subgroup calculation .
So make the calculation more accurate. 


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #533

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
