### PR TITLE
Fix lws chart: the webhook service selects unexpected pods when it is  introduced as a dependency

### DIFF
--- a/charts/lws/templates/webhook/service.yaml
+++ b/charts/lws/templates/webhook/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
+    {{- include "lws.selectorLabels" . | nindent 4 }}
     control-plane: controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

FYI: https://llmaz.inftyai.com/docs/getting-started/installation/

```
(base) ➜  llmaz git:(main) kubectl -n llmaz-system  get ep
NAME                                       ENDPOINTS                                                          AGE
ai-gateway-controller                      10.244.0.16:9090,10.244.0.16:1063                                  62s
envoy-gateway                              10.244.0.15:18000,10.244.0.15:18001,10.244.0.15:9443 + 2 more...   62s
llmaz-controller-manager-metrics-service   10.244.0.17:8443                                                   62s
llmaz-webhook-service                      10.244.0.17:9443                                                   62s
lws-webhook-service                        10.244.0.14:9443,10.244.0.17:9443                                  62s
open-webui                                 10.244.0.13:8080                                                   62s
```

The `lws-webhook-service` selects unexpected endpoint `10.244.0.17:9443 `.   

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix lws chart: the webhook service selects unexpected pods when it is  introduced as a dependency
```
