### PR TITLE
fix: exclusive topology only affect inside LWS instance

### DIFF
--- a/test/integration/webhooks/pod_test.go
+++ b/test/integration/webhooks/pod_test.go
@@ -705,7 +705,7 @@ var _ = ginkgo.Describe("leaderworkerset pod defaulting, creation and update", f
 					},
 					Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
 				}
-				webhooks.SetExclusiveAffinities(pod, "uniquehash", "topologyKey", leaderworkerset.GroupUniqueHashLabelKey)
+				webhooks.SetExclusiveAffinities(pod, "uniquehash", "topologyKey", leaderworkerset.GroupUniqueHashLabelKey, leaderworkerset.GroupIndexLabelKey, "4")
 				return *pod
 			},
 			checkExpectedPod: func(expected corev1.Pod, got corev1.Pod) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it


---------
**NOTE: this is another implementation  of  PR https://github.com/kubernetes-sigs/lws/pull/540** 
--------

say, we have two LWS instance on the same nodes,
LWS-1 requires CPU
LWS-2 requires GPU
they should share the same topology , and the exclusive policy should apply inside LWS-1 and LWS-2 respectively.

But now, if LWS-1 occupied the nodes, the LWS-2 will be pending   


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #539

#### Special notes for your reviewer

assuming LWS name: A, replicas=2, size=2
our expectation is : Pod `A-0-x` should have anti-affinity with those Pods `A-1-x`, 
but  can co-locate with other LWS like `B-0-x`
also can co-locate with same LWS name in other NS,  like `A-0-x` in namespace 2.

so The anti-affinity condition should be: 
- (1)same namespace 
- (2) same LWS set name 
- (3) different group/replica ID




#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
