### PR TITLE
Automated cherry pick of #536: Fix lws chart: the webhook service selects unexpected pods when it is  introduced as a dependency

### DIFF
--- a/charts/lws/templates/webhook/service.yaml
+++ b/charts/lws/templates/webhook/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
+    {{- include "lws.selectorLabels" . | nindent 4 }}
     control-plane: controller-manager


### PR DESCRIPTION
Cherry pick of #536 on release-0.6.0.

#536: Fix lws chart: the webhook service selects unexpected pods when it is  introduced as a dependency

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix lws chart: the webhook service selects unexpected pods when it is  introduced as a dependency
```