### PR TITLE
Increase timeout time

### DIFF
--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	Timeout  = 30 * time.Second
+	Timeout  = 100 * time.Second
 	Interval = time.Millisecond * 250
 )
 


### PR DESCRIPTION
 What type of PR is this?
/kind bug

What this PR does / why we need it
e2e test failed with  default timeout: 
```
leaderWorkerSet e2e tests [It] Can delete a lws with foreground
/home/wewang/lws/test/e2e/e2e_test.go:119

  Timeline >>
  2025-06-18T15:03:40+08:00	INFO	unknown field "spec.leaderWorkerTemplate.leaderTemplate.metadata.creationTimestamp"
  2025-06-18T15:03:40+08:00	INFO	unknown field "spec.leaderWorkerTemplate.workerTemplate.metadata.creationTimestamp"
  STEP: checking leaderworkerset status(Available) is true @ 06/18/25 15:03:40.504
  [FAILED] in [It] - /home/wewang/lws/test/testutils/validators.go:404 @ 06/18/25 15:04:12.003
  << Timeline

  [FAILED] Timed out after 30.001s.
  Expected
      <bool>: false
  to equal
      <bool>: true
  In [It] at: /home/wewang/lws/test/testutils/validators.go:404 @ 06/18/25 15:04:12.003
------------------------------

Summarizing 1 Failure:
  [FAIL] leaderWorkerSet e2e tests [It] Can delete a lws with foreground
  /home/wewang/lws/test/testutils/validators.go:404
Ran 1 of 13 Specs in 37.934 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 12 Skipped
--- FAIL: TestE2E (37.93s)
FAIL
```
```
leaderWorkerSet e2e tests [It] Can delete a lws with foreground
/home/wewang/lws/test/e2e/e2e_test.go:119

  Timeline >>
  2025-06-18T15:05:17+08:00	INFO	unknown field "spec.leaderWorkerTemplate.leaderTemplate.metadata.creationTimestamp"
  2025-06-18T15:05:17+08:00	INFO	unknown field "spec.leaderWorkerTemplate.workerTemplate.metadata.creationTimestamp"
  STEP: checking leaderworkerset status(Available) is true @ 06/18/25 15:05:18.198
  [FAILED] in [It] - /home/wewang/lws/test/testutils/validators.go:404 @ 06/18/25 15:06:19.922
  << Timeline

  [FAILED] Timed out after 60.094s.
  Expected
      <bool>: false
  to equal
      <bool>: true
  In [It] at: /home/wewang/lws/test/testutils/validators.go:404 @ 06/18/25 15:06:19.922
------------------------------
Summarizing 1 Failure:
  [FAIL] leaderWorkerSet e2e tests [It] Can delete a lws with foreground
  /home/wewang/lws/test/testutils/validators.go:404

Ran 1 of 13 Specs in 67.801 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 12 Skipped
--- FAIL: TestE2E (67.80s)
```
 Which issue(s) this PR fixes
when set timeout=100 * time.Second, the test passed:
```
[PASS] in [It] - /home/wewang/lws/test/testutils/validators.go:404
Running Suite: E2E Suite - /home/wewang/lws/test/e2e
====================================================
Random Seed: 1750230437

Will run 1 of 13 specs
SS•SSSSSSSSSS

Ran 1 of 13 Specs in 20.197 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 12 Skipped
PASS

Ginkgo ran 1 suite in 21.226713514s
Test Suite Passed
```
