### PR TITLE
fix rolling update stuck that when old pods were not ready

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -611,7 +611,7 @@ func rollingUpdatePartition(states []replicaState, stsReplicas int32, rollingSte
 	// (for example, all replicas are not ready when rolling update is started).
 	// Note that we never drop the partition below rolliingStepPartition.
 	for idx := min(partition, stsReplicas-1); idx >= rolliingStepPartition; idx-- {
-		if !states[idx].ready {
+		if !states[idx].ready || states[idx].updated {
 			partition = idx
 		} else {
 			break

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -530,6 +530,18 @@ func UpdateLeaderTemplate(ctx context.Context, k8sClient client.Client, leaderWo
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func UpdateWorkerTemplateImage(ctx context.Context, k8sClient client.Client, leaderWorkerSet *leaderworkerset.LeaderWorkerSet) {
+	gomega.Eventually(func() error {
+		var lws leaderworkerset.LeaderWorkerSet
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: leaderWorkerSet.Name, Namespace: leaderWorkerSet.Namespace}, &lws); err != nil {
+			return err
+		}
+
+		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "nginxinc/nginx-unprivileged:1.27"
+		return k8sClient.Update(ctx, &lws)
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func UpdateWorkerTemplate(ctx context.Context, k8sClient client.Client, leaderWorkerSet *leaderworkerset.LeaderWorkerSet) {
 	gomega.Eventually(func() error {
 		var lws leaderworkerset.LeaderWorkerSet

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -59,6 +59,11 @@ func (lwsWrapper *LeaderWorkerSetWrapper) Size(count int) *LeaderWorkerSetWrappe
 	return lwsWrapper
 }
 
+func (lwsWrapper *LeaderWorkerSetWrapper) LeaderTemplate(template *corev1.PodTemplateSpec) *LeaderWorkerSetWrapper {
+	lwsWrapper.Spec.LeaderWorkerTemplate.LeaderTemplate = template
+	return lwsWrapper
+}
+
 func (lwsWrapper *LeaderWorkerSetWrapper) WorkerTemplateSpec(spec corev1.PodSpec) *LeaderWorkerSetWrapper {
 	lwsWrapper.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = spec
 	return lwsWrapper


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

fix rolling update stuck that when old pods were not ready


#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #567 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
