### PR TITLE
test: fix race condition in worker StatefulSet deletion test case

### DIFF
--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -217,6 +217,14 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			},
 			updates: []*update{
 				{
+					// First, wait for the worker StatefulSet to be created
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+					},
+				},
+				{
+					// Delete one worker StatefulSet and verify it is recreated
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
 						var statefulsetToDelete appsv1.StatefulSet
 						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name + "-0", Namespace: lws.Namespace}, &statefulsetToDelete)).To(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it

This PR fixes a race condition in the integration test "Deleted worker statefulSet will be recreated" by adding a verification step to ensure worker StatefulSets are properly created before attempting to delete them.

error log:

```
LeaderWorkerSet controller leaderWorkerSet creating or updating [It] Deleted worker statefulSet will be recreated
/home/prow/go/src/sigs.k8s.io/lws/test/integration/controllers/leaderworkerset_test.go:214
  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0xc0006335e0>: 
      statefulsets.apps "test-sample-0" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
2148 skipped lines...
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.026 seconds]
------------------------------
Summarizing 1 Failure:
  [FAIL] LeaderWorkerSet controller leaderWorkerSet creating or updating [It] Deleted worker statefulSet will be recreated
  /home/prow/go/src/sigs.k8s.io/lws/test/integration/controllers/leaderworkerset_test.go:222
Ran 42 of 42 Specs in 138.669 seconds
FAIL! -- 41 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestControllers (138.70s)
FAIL
Ginkgo ran 2 suites in 2m59.299252719s
```

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
