### PR TITLE
Remove workaround for code-generator

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,17 +26,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
-# TODO: remove the workaround when the issue is solved in the code-generator
-# (https://github.com/kubernetes/code-generator/issues/165).
-# Here, we create the soft link named "x-k8s.io" to the parent directory of
-# LeaderWorkerSet to ensure the layout required by the kube_codegen.sh script.
-ln -s .. sigs.k8s.io
-trap "rm sigs.k8s.io" EXIT
-
-kube::codegen::gen_helpers sigs.k8s.io/lws/api \
+kube::codegen::gen_helpers ${REPO_ROOT}/api \
     --boilerplate "${REPO_ROOT}/hack/boilerplate.go.txt"
 
-kube::codegen::gen_client sigs.k8s.io/lws/api \
+kube::codegen::gen_client ${REPO_ROOT}/api \
     --with-watch \
     --with-applyconfig \
     --applyconfig-externals "k8s.io/api/core/v1.PodTemplateSpec:k8s.io/client-go/applyconfigurations/core/v1" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it

The  https://github.com/kubernetes/code-generator/issues/165 has been resolved in  v0.30.0

Removes the unneeded workaround from the hack/update-codegen.sh script , like kueue at: https://github.com/kubernetes-sigs/kueue/commit/c03277c969f4682cdaf119a2133664d9e76b95db#diff-149dfe7bb29d1191dceae3a52915e750e64b7f87257a5fb309c29d3056e2a95dL30

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
