### PR TITLE
fix: correct typo in rollingUpdatePartition variable name

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -594,23 +594,23 @@ func rollingUpdatePartition(states []replicaState, stsReplicas int32, rollingSte
 	continuousReadyReplicas := calculateContinuousReadyReplicas(states)
 
 	// Update up to rollingStep replicas at once.
-	var rolliingStepPartition = utils.NonZeroValue(stsReplicas - continuousReadyReplicas - rollingStep)
+	var rollingStepPartition = utils.NonZeroValue(stsReplicas - continuousReadyReplicas - rollingStep)
 
 	// rollingStepPartition calculation above disregards the state of replicas with idx<rollingStepPartition.
 	// To prevent violating the maxUnavailable, we have to account for these replicas and increase the partition if some are not ready.
 	var unavailable int32
-	for idx := 0; idx < int(rolliingStepPartition); idx++ {
+	for idx := 0; idx < int(rollingStepPartition); idx++ {
 		if !states[idx].ready {
 			unavailable++
 		}
 	}
-	var partition = rolliingStepPartition + unavailable
+	var partition = rollingStepPartition + unavailable
 
 	// Reduce the partition if replicas are continously not ready. It is safe since updating these replicas does not impact
 	// the availability of the LWS. This is important to prevent update from getting stuck in case maxUnavailable is already violated
 	// (for example, all replicas are not ready when rolling update is started).
 	// Note that we never drop the partition below rolliingStepPartition.
-	for idx := min(partition, stsReplicas-1); idx >= rolliingStepPartition; idx-- {
+	for idx := min(partition, stsReplicas-1); idx >= rollingStepPartition; idx-- {
 		if !states[idx].ready || states[idx].updated {
 			partition = idx
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it

Fix typo in variable name `rolliingStepPartition` to `rollingStepPartition` in the rollingUpdatePartition function.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
