### PR TITLE
Default Partition in RollingUpdateConfiguration to 0 to align with spec

### DIFF
--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -69,6 +70,7 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, obj runtime.Object
 		lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &v1.RollingUpdateConfiguration{
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt32(0),
+			Partition:      ptr.To[int32](0),
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it

With this PR https://github.com/kubernetes-sigs/lws/pull/563, new `Partition` field is defined in `RollingUpdateConfiguration`. However, controller assumes that this field is non-empty which consequently leads to a panic.

This PR defaults Partition field in RollingUpdateConfiguration to 0 as defined in the spec https://github.com/kubernetes-sigs/lws/blob/af5d4295972e4647acbd2da8c4b2be7080893d24/api/leaderworkerset/v1/leaderworkerset_types.go#L277

#### Which issue(s) this PR fixes
Fixes https://github.com/kubernetes-sigs/lws/issues/593

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
```release-note
None
```
