### PR TITLE
Fix: use the main image in helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ artifacts: kustomize helm yq
 	$(KUSTOMIZE) build config/default -o artifacts/manifests.yaml
 	@$(call clean-manifests)
 	# Update the image tag and policy
-	$(YQ)  e  '.image.repository = "$(IMAGE_REPO)" | .image.tag = "$(GIT_TAG)" | .image.pullPolicy = "IfNotPresent"' -i charts/lws/values.yaml
+	$(YQ)  e  '.image.manager.repository = "$(IMAGE_REPO)" | .image.manager.tag = "$(GIT_TAG)" | .image.manager.pullPolicy = "IfNotPresent"' -i charts/lws/values.yaml
 	# create the package. TODO: consider signing it
 	$(HELM) package --version $(GIT_TAG) --app-version $(GIT_TAG) charts/lws -d artifacts/
 	mv artifacts/lws-$(GIT_TAG).tgz artifacts/lws-chart-$(GIT_TAG).tgz

--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets: []
 # Customize controlerManager
 image:
   manager:
-    repository: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
+    repository: registry.k8s.io/lws/lws
     # tag, if defined will use the given image tag, else Chart.AppVersion will be used
     pullPolicy: Always
     tag: main

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
+  newName: registry.k8s.io/lws/lws
   newTag: main


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

fix: https://github.com/kubernetes-sigs/lws/issues/596

Only happened in branch: release-0.6.0

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

After running:
- make artifacts IMAGE_REGISTRY=registry.k8s.io/lws GIT_TAG=0.6.3
- ./bin/helm template lws ./artifacts/lws-chart-0.6.3.tgz | grep -A 50 "kind: Deployment"

Get the result:

```yaml
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: controller-manager
      app.kubernetes.io/name: lws
      app.kubernetes.io/instance: lws
  template:
    metadata:
      labels:
        control-plane: controller-manager
        app.kubernetes.io/name: lws
        app.kubernetes.io/instance: lws
    spec:
      serviceAccountName: lws-controller-manager
      securityContext:
        runAsNonRoot: true
      terminationGracePeriodSeconds: 10
      containers:
        - args:
          - --leader-elect
          - --zap-log-level=2
          command:
          - /manager
          name: manager
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
          image: "registry.k8s.io/lws/lws:0.6.3"
          imagePullPolicy: IfNotPresent
          ports:
            - name: webhook-server
```

I think the bug is fixed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
