### PR TITLE
fix: disable CURL to resolve libcurl dependency issues in llamacpp example

### DIFF
--- a/docs/examples/llamacpp/images/llamacpp-leader/Dockerfile
+++ b/docs/examples/llamacpp/images/llamacpp-leader/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM debian:bullseye AS builder
 
-RUN apt-get update && apt-get install --yes git cmake g++ libcurl4-openssl-dev
+RUN apt-get update && apt-get install --yes git cmake g++
 
 RUN mkdir /workspace
 WORKDIR /workspace
@@ -11,7 +11,7 @@ WORKDIR /workspace/llama.cpp
 
 # GGML_RPC=ON: Builds RPC support
 # BUILD_SHARED_LIBS=OFF: Don't rely on shared libraries like libggml
-RUN cmake . -DGGML_RPC=ON -DBUILD_SHARED_LIBS=OFF -DGGML_DEBUG=1
+RUN cmake . -DGGML_RPC=ON -DBUILD_SHARED_LIBS=OFF -DGGML_DEBUG=1 -DLLAMA_CURL=OFF
 RUN cmake --build . --config Release --parallel 8
 
 

--- a/docs/examples/llamacpp/images/llamacpp-worker/Dockerfile
+++ b/docs/examples/llamacpp/images/llamacpp-worker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM debian:bullseye AS builder
 
-RUN apt-get update && apt-get install --yes git cmake g++ libcurl4-openssl-dev
+RUN apt-get update && apt-get install --yes git cmake g++
 
 RUN mkdir /workspace
 WORKDIR /workspace
@@ -11,7 +11,7 @@ WORKDIR /workspace/llama.cpp
 
 # GGML_RPC=ON: Builds RPC support
 # BUILD_SHARED_LIBS=OFF: Don't rely on shared libraries like libggml
-RUN cmake . -DGGML_RPC=ON -DBUILD_SHARED_LIBS=OFF -DGGML_DEBUG=1
+RUN cmake . -DGGML_RPC=ON -DBUILD_SHARED_LIBS=OFF -DGGML_DEBUG=1 -DLLAMA_CURL=OFF
 RUN cmake --build . --config Release --parallel 8
 
 RUN ldd bin/rpc-server


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it

After PR #559 resolved the compilation issue, a runtime error still occurs due to the missing libcurl.so.4 shared library.
As referenced in https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md?plain=1#L70, compiling without CURL resolves this problem.

Successful run screenshot:

![img_v3_02oo_bd1f6efc-d9ad-4a5f-9360-fdaf74b5e32g](https://github.com/user-attachments/assets/90b444af-c1dd-4b02-983c-8db04ff99513)

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #598

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
