### PR TITLE
fix: LLM endpoint port update

### DIFF
--- a/docs/examples/llamacpp/dev/tasks/run-in-kind
+++ b/docs/examples/llamacpp/dev/tasks/run-in-kind
@@ -17,4 +17,4 @@ kind load docker-image clichat:latest
 
 kubectl apply --server-side -f k8s/
 
-kubectl run clichat --image=clichat:latest --rm=true -it --image-pull-policy=IfNotPresent --env=LLM_ENDPOINT=http://llamacpp:80
+kubectl run clichat --image=clichat:latest --rm=true -it --image-pull-policy=IfNotPresent --env=LLM_ENDPOINT=http://llamacpp:8080


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
When llm endpoint port is 80, met issues:
```
[wewang@ llamacpp]$ oc  run clichat --image=quay.io/wewang58/clichat:latest  --rm=true -it --image-pull-policy=IfNotPresent --env=LLM_ENDPOINT=http://llamacpp:80 --env=DEBUG=true
If you don't see a command prompt, try pressing enter.
generating with llama.cpp: making HTTP request: Post "http://llamacpp:80/completion": dial tcp 10.xx.xx.xxx:80: connect: connection refused
Session ended, resume using 'oc attach clichat -c clichat -i -t' command when the pod is running
pod "clichat" deleted
```

After update port to 8080, the endpoint can be visited:
```
[wewang@ llamacpp]$ oc  run clichat --image=quay.io/wewang58/clichat:latest  --rm=true -it --image-pull-policy=IfNotPresent --env=LLM_ENDPOINT=http://llamacpp:8080 --env=DEBUG=true
If you don't see a command prompt, try pressing enter.
What is the capital of France?
	Paris
```
```
[wewang@ llamacpp]$ oc get endpoints
Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
llamacpp                                     10.xxx.xxx.xxx:8080                                    159m
llamacpp-llama3-8b-instruct-bartowski-q5km   10.xxx.xxx.xxx,10.xxx.2.xxx,10.xxx.2.xxx + 2 more...   159m

```
#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

