### PR TITLE
chore: add buildDate in driver init logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,12 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
 version_pkg = sigs.k8s.io/lws/pkg/version
 LD_FLAGS += -X '$(version_pkg).GitVersion=$(GIT_TAG)'
 LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
+LD_FLAGS += -X '$(version_pkg).BuildDate=$(BUILD_DATE)'
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ARTIFACTS ?= $(PROJECT_DIR)/bin

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -139,7 +139,7 @@ func main() {
 	if kubeConfig.UserAgent == "" {
 		kubeConfig.UserAgent = useragent.Default()
 	}
-	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit, "userAgent", kubeConfig.UserAgent)
+	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "buildDate", version.BuildDate, "gitCommit", version.GitCommit, "userAgent", kubeConfig.UserAgent)
 
 	mgr, err := ctrl.NewManager(kubeConfig, options)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,4 +19,5 @@ package version
 var (
 	GitVersion string = "v0.0.0-main"
 	GitCommit  string = "abcd01234" //sha1 from git, output of $(git rev-parse HEAD)
+	BuildDate  string = "N/A"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
chore: add buildDate in driver init logs

this would be easier for troubleshooting especially in local testing
```
2025-09-09T13:18:46Z    INFO    setup   Initializing    {"gitVersion": "v0.6.1-65-geedb14a-dirty", "buildDate": "2025-09-09T13:15:18Z", "gitCommit": "eedb14a617651fbdf3c3db90c71acc079dded959", "userAgent": "lws/v0.6.1-65-geedb14a-dirty (linux/amd64) eedb14a"}
```

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
