### PR TITLE
Run make generate and make manifests to update CRD

### DIFF
--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -8876,15 +8876,13 @@ spec:
                                 volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                 If specified, the CSI driver will create or update the volume with the attributes defined
                                 in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                will be set by the persistentvolume controller if it exists.
+                                it can be changed after the claim is created. An empty string or nil value indicates that no
+                                VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                this field can be reset to its previous value (including nil) to cancel the modification.
                                 If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                 set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                 exists.
                                 More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                               type: string
                             volumeMode:
                               description: |-
@@ -9052,13 +9050,11 @@ spec:
                               description: |-
                                 currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                                 When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
-                                This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                               type: string
                             modifyVolumeStatus:
                               description: |-
                                 ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                                 When this is unset, there is no ModifyVolume operation being attempted.
-                                This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                               properties:
                                 status:
                                   description: "status is the status of the ControllerModifyVolume


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
It looks like `make manifests` and `make generate` were missed to call. So that these targets create unexpected diff. This PR updates the code base to synchronize manifests with the latest changes in the code.

Probably originated from https://github.com/kubernetes-sigs/lws/pull/633

#### Does this PR introduce a user-facing change?
```release-note
None
```
