### PR TITLE
docs: expand SubGroup section with size and LeaderOnly type

### DIFF
--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -130,7 +130,9 @@ The `size` of a SubGroup determines how many Pods it contains. For example, if a
 
 #### SubGroupType: LeaderOnly
 
-The `LeaderOnly` type enforces an ordering constraint within a SubGroup:
+- The LeaderOnly type means that a SubGroup is created exclusively for the leader.
+Workers are placed into separate subgroups according to the configured size, rather than being included with the leader.
+- This ensures that leader pods remain isolated in their own subgroup, while workers are organized independently.
 
 - This enables heterogeneous scheduling — for example, placing the leader Pod on CPU nodes while placing all worker Pods on GPU nodes, with exclusive placement to ensure they land on the same GPU rack.
 

--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -132,8 +132,6 @@ The `size` of a SubGroup determines how many Pods it contains. For example, if a
 
 The `LeaderOnly` type enforces an ordering constraint within a SubGroup:
 
-- The leader Pod is scheduled first and guaranteed placement.
-- Worker Pods in the same SubGroup are scheduled only after the leader succeeds.
 - This enables heterogeneous scheduling — for example, placing the leader Pod on CPU nodes while placing all worker Pods on GPU nodes, with exclusive placement to ensure they land on the same GPU rack.
 
 For more details, see:


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does
Expands the SubGroup section in the Concepts docs:

Added explanation of subgroup size
Documented the LeaderOnly subgroup type
Linked to [KEP-257](https://github.com/kubernetes-sigs/lws/blob/main/keps/257-Subgroup-leader-only/README.md) for more details
Why this is needed
Clarifies how SubGroups work and introduces LeaderOnly for users of distributed/HPC workloads.

Closes https://github.com/kubernetes-sigs/lws/issues/654