### PR TITLE
feat: Enable certain features of the scheduler using annotations (#669)

### DIFF
--- a/pkg/schedulerprovider/volcano_provider.go
+++ b/pkg/schedulerprovider/volcano_provider.go
@@ -63,6 +63,7 @@ func (v *VolcanoProvider) CreatePodGroupIfNotExists(ctx context.Context, lws *le
 					leaderworkerset.GroupIndexLabelKey: leaderPod.Labels[leaderworkerset.GroupIndexLabelKey],
 					leaderworkerset.RevisionKey:        leaderPod.Labels[leaderworkerset.RevisionKey],
 				},
+				Annotations: utils.InheritVolcanoAnnotations(lws),
 			},
 			Spec: volcanov1beta1.PodGroupSpec{
 				// Default startupPolicy is LeaderCreated, Leader and Workers Pods are scheduled together, so MinAvailable is set to size

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	defaultNamespace = "lws-system"
+	AnnotationPrefix = "volcano.sh/"
 )
 
 // Sha1Hash accepts an input string and returns the 40 character SHA1 hash digest of the input string.
@@ -100,4 +101,14 @@ func CalculatePGMinResources(lws *leaderworkerset.LeaderWorkerSet) corev1.Resour
 	}
 
 	return totalResources
+}
+
+func InheritVolcanoAnnotations(lws *leaderworkerset.LeaderWorkerSet) map[string]string {
+	res := map[string]string{}
+	for k, v := range lws.Annotations {
+		if strings.HasPrefix(k, AnnotationPrefix) {
+			res[k] = v
+		}
+	}
+	return res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
