### PR TITLE
Use explicit nginx image path instead of ambiguous shortname

### DIFF
--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -114,7 +114,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -183,7 +183,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -252,7 +252,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
 							},
@@ -318,7 +318,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -389,7 +389,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("leader"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
 							},
@@ -475,7 +475,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -114,7 +114,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -191,7 +191,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -269,7 +269,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},
@@ -364,7 +364,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 							Containers: []coreapplyv1.ContainerApplyConfiguration{
 								{
 									Name:      ptr.To[string]("worker"),
-									Image:     ptr.To[string]("nginxinc/nginx-unprivileged:1.27"),
+									Image:     ptr.To[string]("docker.io/nginxinc/nginx-unprivileged:1.27"),
 									Ports:     []coreapplyv1.ContainerPortApplyConfiguration{{ContainerPort: ptr.To[int32](8080), Protocol: ptr.To[corev1.Protocol](corev1.ProtocolTCP)}},
 									Resources: &coreapplyv1.ResourceRequirementsApplyConfiguration{},
 								},

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -926,7 +926,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
 								return err
 							}
-							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "nginxinc/nginx-unprivileged:1.26"
+							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "docker.io/nginxinc/nginx-unprivileged:1.26"
 							return k8sClient.Update(ctx, &leaderworkerset)
 						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
 					},

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -602,7 +602,7 @@ func UpdateWorkerTemplateImage(ctx context.Context, k8sClient client.Client, lea
 			return err
 		}
 
-		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "nginxinc/nginx-unprivileged:1.27"
+		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "docker.io/nginxinc/nginx-unprivileged:1.27"
 		return k8sClient.Update(ctx, &lws)
 	}, Timeout, Interval).Should(gomega.Succeed())
 }

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -232,7 +232,7 @@ func MakeWorkerPodSpec() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "worker",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -287,7 +287,7 @@ func MakeWorkerPodSpecWithTPUResource() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -313,7 +313,7 @@ func MakeLeaderPodSpec() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 			},
 		},
 	}
@@ -350,7 +350,7 @@ func MakeLeaderPodSpecWithTPUResourceMultipleContainers() corev1.PodSpec {
 			},
 			{
 				Name:  "leader",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -368,7 +368,7 @@ func MakeWorkerPodSpecWithVolume() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
@@ -390,7 +390,7 @@ func MakeWorkerPodSpecWithVolumeAndNilImage() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:  "leader",
-				Image: "nginxinc/nginx-unprivileged:1.27",
+				Image: "docker.io/nginxinc/nginx-unprivileged:1.27",
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`nginxinc/nginx-unprivileged` image is used in e2e tests heavily. However, these tests do not reliably work on the environments that do not allow ambiguous image registries (i.e. due to the enforced policy). For example, if `nginxinc/nginx-unprivileged` is hosted in multiple registries, node simply errors out without pulling the image. 

In order to fix this issue and make e2e tests working on all environment, this PR uses explicit image path.

This PR is mimicked from https://github.com/kubernetes-sigs/jobset/pull/1065

#### Does this PR introduce a user-facing change?
```release-note
None
```