### PR TITLE
Fix e2e test assertions and resource cleanup

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 			}
 
 			for _, expectedAnnotation := range expectedAnnotations {
-				gomega.Expect(pod.Labels[expectedAnnotation]).To(gomega.Not(gomega.BeNil()))
+				gomega.Expect(pod.Annotations[expectedAnnotation]).To(gomega.Not(gomega.BeNil()))
 			}
 		}
 
@@ -203,7 +203,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 			}
 
 			for _, expectedAnnotation := range expectedAnnotations {
-				gomega.Expect(pod.Labels[expectedAnnotation]).To(gomega.Not(gomega.BeNil()))
+				gomega.Expect(pod.Annotations[expectedAnnotation]).To(gomega.Not(gomega.BeNil()))
 			}
 
 		}
@@ -260,7 +260,7 @@ var _ = ginkgo.Describe("leaderWorkerSet e2e tests", func() {
 		for _, p := range lwsPods.Items {
 			gomega.Expect(testing.CheckAnnotation(p, leaderworkerset.SizeAnnotationKey, strconv.Itoa(newSize))).To(gomega.Succeed())
 		}
-		gomega.Expect(len(lwsPods.Items) == newSize*replicas).To(gomega.BeTrue())
+		gomega.Expect(len(lwsPods.Items)).To(gomega.Equal(newSize * replicas))
 	})
 
 	ginkgo.It("When changing subdomainPolicy, adds correct env vars", func() {
@@ -476,6 +476,7 @@ func serviceAccountToken(serviceAccountName, namespace string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer os.Remove(tokenRequestFile)
 
 	var out string
 	verifyTokenCreation := func(g gomega.Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

This PR fixes several issues in the e2e test suite:

- Fix incorrect field access in pod annotation validation (was using `pod.Labels` instead of `pod.Annotations`)
- Improve pod count assertion using `gomega.Equal()` for better error messages
- Add missing cleanup for temporary token request file with `defer os.Remove()`

These changes ensure tests validate the correct fields and prevent potential resource leaks during test execution.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
