### PR TITLE
[bugfix] fix StatefulsetReady check

### DIFF
--- a/pkg/utils/statefulset/statefulset_utils.go
+++ b/pkg/utils/statefulset/statefulset_utils.go
@@ -46,6 +46,6 @@ func GetParentNameAndOrdinal(name string) (string, int) {
 
 // StatefulsetReady checks whether a sts is ready.
 func StatefulsetReady(sts appsv1.StatefulSet) bool {
-	return *sts.Spec.Replicas == sts.Status.Replicas &&
+	return *sts.Spec.Replicas == sts.Status.AvailableReplicas &&
 		sts.Status.CurrentRevision == sts.Status.UpdateRevision
 }

--- a/pkg/utils/statefulset/statefulset_utils.go
+++ b/pkg/utils/statefulset/statefulset_utils.go
@@ -46,6 +46,6 @@ func GetParentNameAndOrdinal(name string) (string, int) {
 
 // StatefulsetReady checks whether a sts is ready.
 func StatefulsetReady(sts appsv1.StatefulSet) bool {
-	return *sts.Spec.Replicas == sts.Status.ReadyReplicas &&
+	return *sts.Spec.Replicas == sts.Status.AvailableReplicas &&
 		sts.Status.CurrentRevision == sts.Status.UpdateRevision
 }

--- a/pkg/utils/statefulset/statefulset_utils.go
+++ b/pkg/utils/statefulset/statefulset_utils.go
@@ -46,6 +46,6 @@ func GetParentNameAndOrdinal(name string) (string, int) {
 
 // StatefulsetReady checks whether a sts is ready.
 func StatefulsetReady(sts appsv1.StatefulSet) bool {
-	return *sts.Spec.Replicas == sts.Status.AvailableReplicas &&
+	return *sts.Spec.Replicas == sts.Status.ReadyReplicas &&
 		sts.Status.CurrentRevision == sts.Status.UpdateRevision
 }

--- a/pkg/utils/statefulset/statefulset_utils_test.go
+++ b/pkg/utils/statefulset/statefulset_utils_test.go
@@ -86,29 +86,29 @@ func TestStatefulsetReady(t *testing.T) {
 		wantBool bool
 	}{
 		{
-			name: "statefulset is ready when ReadyReplicas equals Spec.Replicas and revisions match",
+			name: "statefulset is ready when AvailableReplicas equals Spec.Replicas and revisions match",
 			sts: appsv1.StatefulSet{
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:   3,
-					CurrentRevision: "rev-1",
-					UpdateRevision:  "rev-1",
+					AvailableReplicas: 3,
+					CurrentRevision:   "rev-1",
+					UpdateRevision:    "rev-1",
 				},
 			},
 			wantBool: true,
 		},
 		{
-			name: "statefulset is not ready when ReadyReplicas less than Spec.Replicas",
+			name: "statefulset is not ready when AvailableReplicas less than Spec.Replicas",
 			sts: appsv1.StatefulSet{
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:   2,
-					CurrentRevision: "rev-1",
-					UpdateRevision:  "rev-1",
+					AvailableReplicas: 2,
+					CurrentRevision:   "rev-1",
+					UpdateRevision:    "rev-1",
 				},
 			},
 			wantBool: false,
@@ -120,9 +120,9 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:   3,
-					CurrentRevision: "rev-1",
-					UpdateRevision:  "rev-2",
+					AvailableReplicas: 3,
+					CurrentRevision:   "rev-1",
+					UpdateRevision:    "rev-2",
 				},
 			},
 			wantBool: false,
@@ -134,9 +134,9 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:   2,
-					CurrentRevision: "rev-1",
-					UpdateRevision:  "rev-2",
+					AvailableReplicas: 2,
+					CurrentRevision:   "rev-1",
+					UpdateRevision:    "rev-2",
 				},
 			},
 			wantBool: false,

--- a/pkg/utils/statefulset/statefulset_utils_test.go
+++ b/pkg/utils/statefulset/statefulset_utils_test.go
@@ -92,7 +92,7 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:  3,
+					ReadyReplicas:   3,
 					CurrentRevision: "rev-1",
 					UpdateRevision:  "rev-1",
 				},
@@ -106,7 +106,7 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:  2,
+					ReadyReplicas:   2,
 					CurrentRevision: "rev-1",
 					UpdateRevision:  "rev-1",
 				},
@@ -120,7 +120,7 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:  3,
+					ReadyReplicas:   3,
 					CurrentRevision: "rev-1",
 					UpdateRevision:  "rev-2",
 				},
@@ -134,7 +134,7 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas:  2,
+					ReadyReplicas:   2,
 					CurrentRevision: "rev-1",
 					UpdateRevision:  "rev-2",
 				},

--- a/pkg/utils/statefulset/statefulset_utils_test.go
+++ b/pkg/utils/statefulset/statefulset_utils_test.go
@@ -86,29 +86,29 @@ func TestStatefulsetReady(t *testing.T) {
 		wantBool bool
 	}{
 		{
-			name: "statefulset is ready when AvailableReplicas equals Spec.Replicas and revisions match",
+			name: "statefulset is ready when ReadyReplicas equals Spec.Replicas and revisions match",
 			sts: appsv1.StatefulSet{
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					AvailableReplicas: 3,
-					CurrentRevision:   "rev-1",
-					UpdateRevision:    "rev-1",
+					ReadyReplicas:  3,
+					CurrentRevision: "rev-1",
+					UpdateRevision:  "rev-1",
 				},
 			},
 			wantBool: true,
 		},
 		{
-			name: "statefulset is not ready when AvailableReplicas less than Spec.Replicas",
+			name: "statefulset is not ready when ReadyReplicas less than Spec.Replicas",
 			sts: appsv1.StatefulSet{
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					AvailableReplicas: 2,
-					CurrentRevision:   "rev-1",
-					UpdateRevision:    "rev-1",
+					ReadyReplicas:  2,
+					CurrentRevision: "rev-1",
+					UpdateRevision:  "rev-1",
 				},
 			},
 			wantBool: false,
@@ -120,9 +120,9 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					AvailableReplicas: 3,
-					CurrentRevision:   "rev-1",
-					UpdateRevision:    "rev-2",
+					ReadyReplicas:  3,
+					CurrentRevision: "rev-1",
+					UpdateRevision:  "rev-2",
 				},
 			},
 			wantBool: false,
@@ -134,9 +134,9 @@ func TestStatefulsetReady(t *testing.T) {
 					Replicas: &replicas,
 				},
 				Status: appsv1.StatefulSetStatus{
-					AvailableReplicas: 2,
-					CurrentRevision:   "rev-1",
-					UpdateRevision:    "rev-2",
+					ReadyReplicas:  2,
+					CurrentRevision: "rev-1",
+					UpdateRevision:  "rev-2",
 				},
 			},
 			wantBool: false,

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -370,6 +370,7 @@ func SetPodGroupToReady(ctx context.Context, k8sClient client.Client, statefulse
 		}
 
 		sts.Status.ReadyReplicas = *sts.Spec.Replicas
+		sts.Status.AvailableReplicas = *sts.Spec.Replicas
 		sts.Status.Replicas = *sts.Spec.Replicas
 		sts.Status.CurrentRevision = ""
 		sts.Status.UpdateRevision = ""
@@ -656,6 +657,7 @@ func SetLeaderPodsToReady(ctx context.Context, k8sClient client.Client, lws *lea
 			return err
 		}
 		sts.Status.ReadyReplicas = *sts.Spec.Replicas
+		sts.Status.AvailableReplicas = *sts.Spec.Replicas
 		sts.Status.Replicas = *sts.Spec.Replicas
 		sts.Status.CurrentRevision = ""
 		sts.Status.UpdateRevision = ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

We noticed that when the pods in the worker StatefulSet (sts) have been created but are not yet ready, the sts is still considered "ready", which doesn't match the expected behavior. We found that the sts has three parameters used to determine its readiness status(/go/pkg/mod/k8s.io/api@v0.34.2/apps/v1/types.go) :
- `Replicas`: The number of Pods created by the StatefulSet controller. This includes pods in all states (Running, Pending, Unknown, etc.) and does not consider whether the pods are ready or available.
- `ReadyReplicas`: The number of pods created for this StatefulSet with a Ready Condition. This requires the pods to be in the Running state and for all their containers to have passed the readiness probe.
- `AvailableReplicas`: Total number of available pods (ready for at least minReadySeconds) targeted by this statefulset. In addition to being "ready" (as defined by ReadyReplicas), the pods must have been running for at least the duration specified by minReadySeconds. The minReadySeconds defaults to 0s, which makes it behave the same as ReadyReplicas. However, when a specific value is set, it provides the Pod with a sufficient stable running time

 Based on the current situation, using AvailableReplicas may be a better choice to determine the ready status of a StatefulSet
cc @Edwinhr716 @kerthcet 