### PR TITLE
Upgrade Go to 1.25 to fix Trivy CVEs

### DIFF
--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.3
+        go-version: 1.25
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.3
+          go-version: 1.25
         id: go
 
       - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
           docker buildx build --no-cache --output=type=docker -t test/lws:latest \
              --platform=linux/amd64 \
              --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot \
-             --build-arg BUILDER_IMAGE=golang:1.25.3 \
+             --build-arg BUILDER_IMAGE=golang:1.25 \
              --build-arg CGO_ENABLED=0 \
              -f ./Dockerfile .
 


### PR DESCRIPTION
…e latest patch release.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it

This PR updates the Go version in GitHub workflows and the Dockerfile builder image from 1.25.3 to 1.25. This ensures the project uses the latest available patch version of Go 1.25, which includes fixes for security vulnerabilities (CVEs) detected by Trivy scans.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #712

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Upgrade Go to 1.25 to fix Trivy CVEs
```
