### PR TITLE
Enable certs manager readiness check

### DIFF
--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -57,5 +57,6 @@ func CertsManager(mgr ctrl.Manager, namespace string, configServiceName string, 
 				Name: mutatingWebhookConfName,
 			},
 		},
+		EnableReadinessCheck: true,
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Enable readiness check to avoid such logs during startup:
```
2026-01-20T07:01:03Z    ERROR   cert-rotation   could not refresh CA and server certs   {"error": "Operation cannot be fulfilled on secrets \"lws-webhook-server-cert\": 
the object has been modified; please apply your changes to the latest version and try again"}                                                                            github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).refreshCertIfNeeded.func1
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.13.0/pkg/rotator/rotator.go:336                                                                      k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection
        /go/pkg/mod/k8s.io/apimachinery@v0.33.3/pkg/util/wait/wait.go:150                                                                                                k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff
        /go/pkg/mod/k8s.io/apimachinery@v0.33.3/pkg/util/wait/backoff.go:477                                                                                             
github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).refreshCertIfNeeded                                                            
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.13.0/pkg/rotator/rotator.go:364                                                                      github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).Start
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.13.0/pkg/rotator/rotator.go:292                                                      
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1                                                                                              
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/manager/runnable_group.go:226
```

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable the certificate manager readiness check to prevent transient "object modified" error logs during the initial startup of the webhook server.
```
