### PR TITLE
Support building e2e Kind node images for Kubernetes patch releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ ARTIFACTS ?= $(PROJECT_DIR)/bin
 INTEGRATION_TARGET ?= ./test/integration/...
 
 E2E_KIND_VERSION ?= kindest/node:v1.35.0
+E2E_KIND_BUILD_NODE_IMAGE_VERSION ?=
 CERT_MANAGER_VERSION ?= v1.17.0
 USE_EXISTING_CLUSTER ?= false
 
@@ -167,18 +168,28 @@ kind-image-build: PLATFORMS=linux/amd64
 kind-image-build: IMAGE_BUILD_EXTRA_OPTS=--load
 kind-image-build: kind image-build
 
+.PHONY: kind-node-image-build
+kind-node-image-build: kind
+	@if [ -n "$(E2E_KIND_BUILD_NODE_IMAGE_VERSION)" ]; then \
+		if docker image inspect "$(E2E_KIND_VERSION)" >/dev/null 2>&1; then \
+			echo "Kind node image $(E2E_KIND_VERSION) already exists locally; skipping build."; \
+		else \
+			$(KIND) build node-image "$(E2E_KIND_BUILD_NODE_IMAGE_VERSION)" --image "$(E2E_KIND_VERSION)"; \
+		fi; \
+	fi
+
 .PHONY: test-integration
 test-integration: manifests fmt vet envtest ginkgo ## Run integration tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	$(GINKGO) --junit-report=junit.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 
 .PHONY: test-e2e
-test-e2e: kustomize manifests fmt vet envtest ginkgo kind-image-build
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
+test-e2e: kustomize manifests fmt vet envtest ginkgo kind-image-build kind-node-image-build
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) E2E_KIND_BUILD_NODE_IMAGE_VERSION=$(E2E_KIND_BUILD_NODE_IMAGE_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 .PHONY: test-e2e-cert-manager
-test-e2e-cert-manager: kustomize manifests fmt vet envtest ginkgo kind-image-build
-	USE_CERT_MANAGER=true CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
+test-e2e-cert-manager: kustomize manifests fmt vet envtest ginkgo kind-image-build kind-node-image-build
+	USE_CERT_MANAGER=true CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) E2E_KIND_BUILD_NODE_IMAGE_VERSION=$(E2E_KIND_BUILD_NODE_IMAGE_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 # Gang scheduling E2E tests with different schedulers
 VOLCANO_VERSION ?= v1.12.1
@@ -187,8 +198,8 @@ VOLCANO_VERSION ?= v1.12.1
 test-e2e-gang-scheduling: test-e2e-gang-scheduling-volcano ## Run all gang scheduling E2E tests
 
 .PHONY: test-e2e-gang-scheduling-volcano
-test-e2e-gang-scheduling-volcano: kustomize manifests fmt vet envtest ginkgo kind-image-build ## Run gang scheduling E2E tests with Volcano
-	SCHEDULER_PROVIDER=volcano VOLCANO_VERSION=$(VOLCANO_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
+test-e2e-gang-scheduling-volcano: kustomize manifests fmt vet envtest ginkgo kind-image-build kind-node-image-build ## Run gang scheduling E2E tests with Volcano
+	SCHEDULER_PROVIDER=volcano VOLCANO_VERSION=$(VOLCANO_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) E2E_KIND_BUILD_NODE_IMAGE_VERSION=$(E2E_KIND_BUILD_NODE_IMAGE_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter & yamllint

--- a/disaggregatedset/Makefile
+++ b/disaggregatedset/Makefile
@@ -67,18 +67,29 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # E2E tests using Kind cluster with LWS controller.
 KIND_CLUSTER_NAME ?= disaggregatedset-test-e2e
 E2E_KIND_VERSION ?= kindest/node:v1.32.2
+E2E_KIND_BUILD_NODE_IMAGE_VERSION ?=
 E2E_IMG ?= controller:e2e
 USE_EXISTING_CLUSTER ?= false
 ARTIFACTS ?= $(LOCALBIN)
 LWS_VERSION ?= v0.8.0
 
 .PHONY: test-e2e
-test-e2e: manifests generate kustomize ginkgo ## Run e2e tests using Kind cluster.
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) \
+test-e2e: manifests generate kustomize ginkgo kind-node-image-build ## Run e2e tests using Kind cluster.
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) E2E_KIND_BUILD_NODE_IMAGE_VERSION=$(E2E_KIND_BUILD_NODE_IMAGE_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) \
 		KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) \
 		USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(E2E_IMG) \
 		ARTIFACTS=$(ARTIFACTS) LWS_VERSION=$(LWS_VERSION) \
 		./hack/e2e-test.sh
+
+.PHONY: kind-node-image-build
+kind-node-image-build:
+	@if [ -n "$(E2E_KIND_BUILD_NODE_IMAGE_VERSION)" ]; then \
+		if docker image inspect "$(E2E_KIND_VERSION)" >/dev/null 2>&1; then \
+			echo "Kind node image $(E2E_KIND_VERSION) already exists locally; skipping build."; \
+		else \
+			$(KIND) build node-image "$(E2E_KIND_BUILD_NODE_IMAGE_VERSION)" --image "$(E2E_KIND_VERSION)"; \
+		fi; \
+	fi
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it

Adds a Makefile target and `E2E_KIND_BUILD_NODE_IMAGE_VERSION` knob so e2e jobs can build a Kind node image on demand via `kind build node-image`, mirroring Kueue's pattern.

This is needed because the StatefulSet `Parallel` regression in v1.35.0/v1.35.1 ([kubernetes/kubernetes#137409](https://github.com/kubernetes/kubernetes/issues/137409)) is fixed in v1.35.4, but `kindest/node:v1.35.4` is not published ([kubernetes-sigs/kind#4131](https://github.com/kubernetes-sigs/kind/issues/4131)). When the new var is unset, behavior is unchanged.

#### Which issue(s) this PR fixes

Part of #751

#### Special notes for your reviewer

Follow-up `kubernetes/test-infra` PR can set lws Prow jobs to:

\`\`\`yaml
- name: E2E_KIND_VERSION
  value: kindest/node:v1.35.4
- name: E2E_KIND_BUILD_NODE_IMAGE_VERSION
  value: v1.35.4
\`\`\`

Validated with \`make -n test-e2e\` (root and \`disaggregatedset\`) and a local \`kindest/node:v1.35.4\` build.

#### Does this PR introduce a user-facing change?

\`\`\`release-note
NONE
\`\`\`