### PR TITLE
Migrate to new events API

### DIFF
--- a/charts/lws/templates/rbac/clusterrole.yaml
+++ b/charts/lws/templates/rbac/clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/charts/lws/templates/rbac/role.yaml
+++ b/charts/lws/templates/rbac/role.yaml
@@ -33,6 +33,7 @@ rules:
       - delete
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -192,11 +192,10 @@ func setupControllers(mgr ctrl.Manager, certsReady chan struct{}, cfg configapi.
 	<-certsReady
 	setupLog.Info("certs ready")
 
-	// TODO: Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
 	if err := controllers.NewLeaderWorkerSetReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		mgr.GetEventRecorderFor("leaderworkerset"), //nolint
+		mgr.GetEventRecorder("leaderworkerset"),
 	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LeaderWorkerSet")
 		os.Exit(1)
@@ -213,8 +212,7 @@ func setupControllers(mgr ctrl.Manager, certsReady chan struct{}, cfg configapi.
 		setupLog.Info("Gang scheduling enabled", "provider", *cfg.GangSchedulingManagement.SchedulerProvider)
 	}
 	// Set up pod reconciler.
-	// TODO: Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
-	podController := controllers.NewPodReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorderFor("leaderworkerset"), sp) //nolint
+	podController := controllers.NewPodReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorder("leaderworkerset"), sp)
 	if err := podController.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -37,6 +37,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,17 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get
@@ -51,6 +40,18 @@ rules:
   verbs:
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -33,7 +33,7 @@ import (
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,7 +53,7 @@ import (
 type LeaderWorkerSetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
-	Record record.EventRecorder
+	Record events.EventRecorder
 }
 
 var (
@@ -72,9 +72,14 @@ const (
 	GroupsProgressing = "GroupsProgressing"
 	GroupsUpdating    = "GroupsUpdating"
 	CreatingRevision  = "CreatingRevision"
+
+	// Event actions
+	Create = "Create"
+	Update = "Update"
+	Delete = "Delete"
 )
 
-func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, record record.EventRecorder) *LeaderWorkerSetReconciler {
+func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, record events.EventRecorder) *LeaderWorkerSetReconciler {
 	return &LeaderWorkerSetReconciler{
 		Client: client,
 		Scheme: scheme,
@@ -82,7 +87,8 @@ func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, 
 	}
 }
 
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch;get;list
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch;get;list
 //+kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/finalizers,verbs=update
@@ -90,7 +96,6 @@ func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, 
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions/finalizers,verbs=update
@@ -140,7 +145,7 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			log.Error(err, "Creating revision for updated LWS")
 			return ctrl.Result{}, err
 		}
-		r.Record.Eventf(lws, corev1.EventTypeNormal, CreatingRevision, fmt.Sprintf("Creating revision with key %s for updated LWS", revisionutils.GetRevisionKey(revision)))
+		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, CreatingRevision, Create, fmt.Sprintf("Creating revision with key %s for updated LWS", revisionutils.GetRevisionKey(revision)))
 	}
 
 	partition, replicas, err := r.rollingUpdateParameters(ctx, lws, leaderSts, revisionutils.GetRevisionKey(revision), lwsUpdated)
@@ -151,24 +156,23 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if err := r.SSAWithStatefulset(ctx, lws, partition, replicas, revisionutils.GetRevisionKey(revision)); err != nil {
 		if leaderSts == nil {
-			r.Record.Eventf(lws, corev1.EventTypeWarning, FailedCreate, fmt.Sprintf("Failed to create leader statefulset %s", lws.Name))
+			r.Record.Eventf(lws, nil, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create leader statefulset %s", lws.Name))
 		}
 		return ctrl.Result{}, err
 	}
 
 	if leaderSts == nil {
 		// An event is logged to track sts creation.
-		r.Record.Eventf(lws, corev1.EventTypeNormal, GroupsProgressing, fmt.Sprintf("Created leader statefulset %s", lws.Name))
+		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created leader statefulset %s", lws.Name))
 	} else if !lwsUpdated && partition != *leaderSts.Spec.UpdateStrategy.RollingUpdate.Partition {
 		// An event is logged to track update progress.
-		r.Record.Eventf(lws, corev1.EventTypeNormal, GroupsUpdating, fmt.Sprintf("Updating replicas %d to %d", *leaderSts.Spec.UpdateStrategy.RollingUpdate.Partition, partition))
+		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsUpdating, Update, fmt.Sprintf("Updating replicas %d to %d", *leaderSts.Spec.UpdateStrategy.RollingUpdate.Partition, partition))
 	}
 
 	// Create headless service if it does not exist.
 	if err := r.reconcileHeadlessServices(ctx, lws); err != nil {
 		log.Error(err, "Creating headless service.")
-		r.Record.Eventf(lws, corev1.EventTypeWarning, FailedCreate,
-			fmt.Sprintf("Failed to create headless service for error: %v", err))
+		r.Record.Eventf(lws, nil, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create headless service for error: %v", err))
 		return ctrl.Result{}, err
 	}
 
@@ -291,7 +295,7 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 			// start to release the burst replica gradually for the accommodation of
 			// the unready ones.
 			finalReplicas := lwsReplicas + utils.NonZeroValue(int32(unreadyReplicas)-1)
-			r.Record.Eventf(lws, corev1.EventTypeNormal, GroupsProgressing, fmt.Sprintf("deleting surge replica %s-%d", lws.Name, finalReplicas))
+			r.Record.Eventf(lws, nil, corev1.EventTypeNormal, GroupsProgressing, Delete, fmt.Sprintf("deleting surge replica %s-%d", lws.Name, finalReplicas))
 			return finalReplicas
 		}
 		return burstReplicas
@@ -474,7 +478,7 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 	updateCondition := setConditions(lws, conditions)
 	// if condition changed, record events
 	if updateCondition {
-		r.Record.Eventf(lws, corev1.EventTypeNormal, conditions[0].Reason, conditions[0].Message+fmt.Sprintf(", with %d groups ready of total %d groups", readyCount, int(*lws.Spec.Replicas)))
+		r.Record.Eventf(lws, nil, corev1.EventTypeNormal, conditions[0].Reason, Update, conditions[0].Message+fmt.Sprintf(", with %d groups ready of total %d groups", readyCount, int(*lws.Spec.Replicas)))
 	}
 	return updateStatus || updateCondition, updateDone, nil
 }
@@ -672,7 +676,7 @@ func (r *LeaderWorkerSetReconciler) getLeaderStatefulSet(ctx context.Context, lw
 	return sts, nil
 }
 
-func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Context, sts *appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet, recorder record.EventRecorder) (*appsv1.ControllerRevision, error) {
+func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Context, sts *appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet, recorder events.EventRecorder) (*appsv1.ControllerRevision, error) {
 	revisionKey := ""
 	if sts != nil {
 		// Uses the hash in the leader sts to avoid detecting update in the case where LWS controller is upgraded from a version where
@@ -692,7 +696,7 @@ func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Co
 		if revisionKey != "" {
 			message = fmt.Sprintf("Creating missing revision with key %s for existing LeaderWorkerSet", revision.Labels[leaderworkerset.RevisionKey])
 		}
-		recorder.Eventf(lws, corev1.EventTypeNormal, CreatingRevision, message)
+		recorder.Eventf(lws, newRevision, corev1.EventTypeNormal, CreatingRevision, Create, message)
 	}
 	return newRevision, err
 }

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -32,7 +32,7 @@ import (
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,15 +52,16 @@ import (
 type PodReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
-	Record            record.EventRecorder
+	Record            events.EventRecorder
 	SchedulerProvider schedulerprovider.SchedulerProvider
 }
 
-func NewPodReconciler(client client.Client, schema *runtime.Scheme, record record.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
+func NewPodReconciler(client client.Client, schema *runtime.Scheme, record events.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
 	return &PodReconciler{Client: client, Scheme: schema, Record: record, SchedulerProvider: sp}
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
@@ -108,7 +109,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			pod.Name,
 			leaderworkerset.LeaderPodNameAnnotationKey)
 		log.Error(errors.New(errMsg), "validate leader's annotations")
-		r.Record.Eventf(&leaderWorkerSet, corev1.EventTypeWarning, FailedCreate, errMsg)
+		r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeWarning, FailedCreate, Create, errMsg)
 		return ctrl.Result{}, nil
 	}
 
@@ -189,10 +190,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, err
 		}
 		if err = r.Create(ctx, workerStatefulSet); err != nil {
-			r.Record.Eventf(&leaderWorkerSet, corev1.EventTypeWarning, FailedCreate, fmt.Sprintf("Failed to create worker statefulset for leader pod %s", pod.Name))
+			r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create worker statefulset for leader pod %s", pod.Name))
 			return ctrl.Result{}, client.IgnoreAlreadyExists(err)
 		}
-		r.Record.Eventf(&leaderWorkerSet, corev1.EventTypeNormal, GroupsProgressing, fmt.Sprintf("Created worker statefulset for leader pod %s", pod.Name))
+		r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created worker statefulset for leader pod %s", pod.Name))
 	}
 	log.V(2).Info("Worker Reconcile completed.")
 	return ctrl.Result{}, nil
@@ -249,7 +250,7 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 	}); err != nil {
 		return false, err
 	}
-	r.Record.Eventf(&leaderWorkerSet, corev1.EventTypeNormal, "RecreateGroup", fmt.Sprintf("Worker pod %s failed, deleted leader pod %s to recreate group %s", pod.Name, leader.Name, leader.Labels[leaderworkerset.GroupIndexLabelKey]))
+	r.Record.Eventf(&leaderWorkerSet, &leader, corev1.EventTypeNormal, "RecreateGroup", Delete, fmt.Sprintf("Worker pod %s failed, deleted leader pod %s to recreate group %s", pod.Name, leader.Name, leader.Labels[leaderworkerset.GroupIndexLabelKey]))
 	return true, nil
 }
 

--- a/test/integration/controllers/suite_test.go
+++ b/test/integration/controllers/suite_test.go
@@ -104,16 +104,14 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	// TODO: Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
-	lwsController := controllers.NewLeaderWorkerSetReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("leaderworkerset")) // nolint
+	lwsController := controllers.NewLeaderWorkerSetReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorder("leaderworkerset"))
 
 	err = controllers.SetupIndexes(k8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 	err = lwsController.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	// TODO: Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
-	podController = controllers.NewPodReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorderFor("pod"), nil) // nolint
+	podController = controllers.NewPodReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), k8sManager.GetEventRecorder("pod"), nil)
 	err = podController.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -470,7 +470,12 @@ func ValidateEvent(ctx context.Context, k8sClient client.Client, eventReason str
 			}
 		}
 
-		return fmt.Errorf("mismatch with the expected event: expected r:%v t:%v n:%v", eventReason, eventType, eventNote)
+		fmt.Printf("Events found in namespace %s:\n", namespace)
+		for _, item := range events.Items {
+			fmt.Printf("  Reason: %s, Type: %s, Note: %s\n", item.Reason, item.Type, item.Note)
+		}
+
+		return fmt.Errorf("mismatch with the expected event: expected r:%v t:%v n:%v; got r:%v t:%v n:%v", eventReason, eventType, eventNote, events.Items[0].Reason, events.Items[0].Type, events.Items[0].Note)
 
 	}, Timeout, Interval).Should(gomega.BeNil())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

With the upgrade to controller-runtime v0.23.0, the `mgr.GetEventRecorderFor()` method has been deprecated in favor of the new events API introduced in https://github.com/kubernetes-sigs/controller-runtime/pull/3262. See linked issue for details.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #742 

#### Special notes for your reviewer

Verified the events are still appearing as expected with `kubectl describe lws`:

<details>
<summary>Output</summary>

```
Events:
  Type     Reason             Age                From             Message
  ----     ------             ----               ----             -------
  Normal   CreatingRevision   28s                leaderworkerset  Creating revision with key 757864876d for a newly created LeaderWorkerSet
  Normal   CreatingRevision   28s                leaderworkerset  Creating revision with key 757864876d for a newly created LeaderWorkerSet
  Normal   GroupsProgressing  27s (x2 over 27s)  leaderworkerset  Replicas are progressing, with 0 groups ready of total 2 groups
  Normal   GroupsProgressing  27s                leaderworkerset  Created worker statefulset for leader pod test-sample-0
  Warning  FailedCreate       27s (x2 over 27s)  leaderworkerset  Failed to create worker statefulset for leader pod test-sample-0
  Normal   GroupsProgressing  27s                leaderworkerset  Created worker statefulset for leader pod test-sample-1
  Normal   AllGroupsReady     26s (x2 over 26s)  leaderworkerset  All replicas are ready, with 2 groups ready of total 2 groups
```
</details>

And likewise with `kubectl get events.events.k8s.io --sort-by=.metadata.creationTimestamp`:

<details>
<summary>Output</summary>

```
LAST SEEN   TYPE      REASON                   OBJECT                        MESSAGE
111s        Normal    Killing                  pod/test-sample-0             Stopping container leader
111s        Normal    DELETE                   service/test-sample           default/test-sample
111s        Normal    Killing                  pod/test-sample-1             Stopping container leader
110s        Normal    Killing                  pod/test-sample-0-2           Stopping container worker
110s        Normal    Killing                  pod/test-sample-1-3           Stopping container worker
110s        Normal    Killing                  pod/test-sample-1-2           Stopping container worker
110s        Normal    Killing                  pod/test-sample-0-1           Stopping container worker
110s        Normal    Killing                  pod/test-sample-1-1           Stopping container worker
110s        Normal    Killing                  pod/test-sample-0-3           Stopping container worker
107s        Normal    CreatingRevision         leaderworkerset/test-sample   Creating revision with key 757864876d for a newly created LeaderWorkerSet
107s        Normal    CreatingRevision         leaderworkerset/test-sample   Creating revision with key 757864876d for a newly created LeaderWorkerSet
107s        Normal    Started                  pod/test-sample-1-1           Started container worker
106s        Normal    Scheduled                pod/test-sample-1-3           Successfully assigned default/test-sample-1-3 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mluh
107s        Normal    Created                  pod/test-sample-0-3           Created container: worker
107s        Normal    Started                  pod/test-sample-0-3           Started container worker
106s        Normal    Scheduled                pod/test-sample-0-3           Successfully assigned default/test-sample-0-3 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mrv2
107s        Normal    Scheduled                pod/test-sample-0             Successfully assigned default/test-sample-0 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mrv2
107s        Normal    SuccessfulCreate         statefulset/test-sample-0     create Pod test-sample-0-1 in StatefulSet test-sample-0 successful
107s        Normal    SuccessfulCreate         statefulset/test-sample-0     create Pod test-sample-0-3 in StatefulSet test-sample-0 successful
107s        Normal    SuccessfulCreate         statefulset/test-sample-0     create Pod test-sample-0-2 in StatefulSet test-sample-0 successful
107s        Normal    Pulled                   pod/test-sample-0             Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Created                  pod/test-sample-0             Created container: leader
107s        Normal    Started                  pod/test-sample-0             Started container leader
107s        Normal    Started                  pod/test-sample-0-2           Started container worker
106s        Normal    Scheduled                pod/test-sample-1-1           Successfully assigned default/test-sample-1-1 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mrv2
107s        Normal    Pulled                   pod/test-sample-1-1           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Created                  pod/test-sample-1-1           Created container: worker
107s        Normal    Created                  pod/test-sample-0-2           Created container: worker
107s        Normal    Pulled                   pod/test-sample-0-2           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
106s        Normal    Scheduled                pod/test-sample-1-2           Successfully assigned default/test-sample-1-2 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mrv2
107s        Normal    Pulled                   pod/test-sample-1-2           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Created                  pod/test-sample-1-2           Created container: worker
106s        Normal    GroupsProgressing        leaderworkerset/test-sample   Created worker statefulset for leader pod test-sample-1
106s        Normal    Scheduled                pod/test-sample-0-2           Successfully assigned default/test-sample-0-2 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mluh
107s        Normal    Pulled                   pod/test-sample-0-3           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Pulled                   pod/test-sample-1-3           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Created                  pod/test-sample-1-3           Created container: worker
107s        Normal    Started                  pod/test-sample-1-3           Started container worker
107s        Normal    Started                  pod/test-sample-0-1           Started container worker
107s        Normal    Scheduled                pod/test-sample-1             Successfully assigned default/test-sample-1 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mluh
107s        Normal    SuccessfulCreate         statefulset/test-sample-1     create Pod test-sample-1-1 in StatefulSet test-sample-1 successful
107s        Normal    SuccessfulCreate         statefulset/test-sample-1     create Pod test-sample-1-3 in StatefulSet test-sample-1 successful
107s        Normal    SuccessfulCreate         statefulset/test-sample-1     create Pod test-sample-1-2 in StatefulSet test-sample-1 successful
107s        Normal    Pulled                   pod/test-sample-1             Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
107s        Normal    Created                  pod/test-sample-1             Created container: leader
107s        Normal    Started                  pod/test-sample-1             Started container leader
107s        Warning   FailedToCreateEndpoint   endpoints/test-sample         Failed to create endpoint for service default/test-sample: endpoints "test-sample" already exists
107s        Normal    Created                  pod/test-sample-0-1           Created container: worker
107s        Normal    Pulled                   pod/test-sample-0-1           Container image "docker.io/nginxinc/nginx-unprivileged:1.27" already present on machine
106s        Normal    Scheduled                pod/test-sample-0-1           Successfully assigned default/test-sample-0-1 to gke-llm-cluster-asia-sou-default-pool-89c5a69b-mluh
107s        Normal    GroupsProgressing        leaderworkerset/test-sample   Replicas are progressing, with 0 groups ready of total 2 groups
107s        Normal    ADD                      service/test-sample           default/test-sample
107s        Normal    SuccessfulCreate         statefulset/test-sample       create Pod test-sample-0 in StatefulSet test-sample successful
107s        Normal    GroupsProgressing        leaderworkerset/test-sample   Created worker statefulset for leader pod test-sample-0
107s        Normal    SuccessfulCreate         statefulset/test-sample       create Pod test-sample-1 in StatefulSet test-sample successful
106s        Warning   FailedCreate             leaderworkerset/test-sample   Failed to create worker statefulset for leader pod test-sample-0
107s        Normal    Started                  pod/test-sample-1-2           Started container worker
105s        Normal    AllGroupsReady           leaderworkerset/test-sample   All replicas are ready, with 2 groups ready of total 2 groups
```
</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
