### PR TITLE
Fix odd number of arguments in log call for pending pod skip

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -218,7 +218,7 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 	_, hasRecreateGroupAfterStartAnnotation := leaderWorkerSet.Annotations[leaderworkerset.RecreateGroupAfterStartAnnotationKey]
 
 	if pendingPods && (policy == leaderworkerset.RecreateGroupAfterStart || hasRecreateGroupAfterStartAnnotation) {
-		log.V(2).Info("Skipping group recreation because there is a pod pending: %s", pod.Name)
+		log.V(2).Info(fmt.Sprintf("Skipping group recreation because there is a pod pending: %s", pod.Name))
 		return false, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
Fixes an incorrect structured logging call in `pkg/controllers/pod_controller.go` that caused a DPANIC crash when `RecreateGroupAfterStart` or `RecreateGroupAfterRestart` was skipped due to a pending pod.

The `log.V(2).Info()` call was passing `pod.Name` as a separate argument instead of formatting it into the message string. Since `logr.Info()` treats extra arguments as structured key-value pairs, a single extra argument resulted in an odd number of key-value pairs, triggering the crash:



`2026-02-26T01:05:40Z	DPANIC	odd number of arguments passed as key-value pairs for logging	{"controller": "pod", "controllerGroup": "", "controllerKind": "Pod", "Pod": {"name":"wide-ep-llm-d-decode-0-1","namespace":"llm-d-wide-ep"}, "namespace": "llm-d-wide-ep", "name": "wide-ep-llm-d-decode-0-1", "reconcileID": "7c823ac3-960b-4ba5-915b-a493b371e8ab", "pod": {"name":"wide-ep-llm-d-decode-0-1","namespace":"llm-d-wide-ep"}, "ignored key": "wide-ep-llm-d-decode-0-1"}
`

The fix wraps the message with `fmt.Sprintf` to format the pod name into the message string before passing it to the logger, consistent with other similar calls in the same file (lines 153 and 165).

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #762


#### Special notes for your reviewer
This is a one-line change. The same `fmt.Sprintf` pattern is already used in other `log.V(2).Info()` calls within the same file. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
