### PR TITLE
Fix: staging image in production installation

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry.k8s.io/lws/lws
+  newName: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
   newTag: main


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it

When follow the doc, to downloading manifests from the release page and running:
```
kubectl apply -f https://github.com/kubernetes-sigs/lws/releases/download/$VERSION/manifests.yaml
```

The controller image points to the staging registry (`us-central1-docker.pkg.dev/k8s-staging-images/lws/lws:v0.8.0`) instead of the official `registry.k8s.io/lws/lws:v0.8.0`.

**Root cause:**

The `clean-manifests` function in the Makefile hardcodes the staging registry:
```makefile
clean-manifests = (cd config/manager && $(KUSTOMIZE) edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/lws/lws:$(RELEASE_BRANCH))
```

This function is called by both `prepare-release-branch` and `artifacts` targets. It reverts `config/manager/kustomization.yaml` to the staging image after building the release artifacts, and this gets committed to the release branch.

**Fix:**

Change `clean-manifests` to use `registry.k8s.io` with the default `main` tag:
```makefile
clean-manifests = (cd config/manager && $(KUSTOMIZE) edit set image controller=registry.k8s.io/lws/lws:main)
```

This ensures the kustomization file always points to the official registry after building artifacts.



**Test results:**

```bash
# Run: 

make artifacts IMG=registry.k8s.io/lws/lws:v0.8.0

# manifests.yaml correctly uses the release image:
$ grep "registry.k8s.io" artifacts/manifests.yaml
        image: registry.k8s.io/lws/lws:v0.8.0

# kustomization.yaml now points to official registry (not staging):
$ cat config/manager/kustomization.yaml
images:
- name: controller
  newName: registry.k8s.io/lws/lws
  newTag: main
```

This does not affect local development - developers still work with the staging registry by default when building locally.
