### PR TITLE
[WIP] Fix: prevent staging image leak in release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,9 +346,6 @@ site-server: hugo
 ##@ Release
 .PHONY: artifacts
 artifacts: kustomize helm yq
-ifeq ($(IMAGE_REGISTRY),$(STAGING_IMAGE_REGISTRY)/lws)
-	$(error IMAGE_REGISTRY must be overridden for release artifacts (e.g., IMAGE_REGISTRY=registry.k8s.io/lws))
-endif
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	if [ -d artifacts ]; then rm -rf artifacts; fi
 	mkdir -p artifacts


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes hardcoded values in the Makefile release targets:

1. `clean-manifests`: use `$(STAGING_IMAGE_REGISTRY)` and `$(IMAGE_NAME)` variables instead of hardcoding the staging registry URL.
2. `artifacts` revert line: use `$(RELEASE_BRANCH)` instead of hardcoded `"main"` for `values.yaml` tag, so it works correctly on release branches.
3. Add a guard in `artifacts` to error out if `IMAGE_REGISTRY` is not overridden.

#### How to reproduce

```bash
# Per NEW_RELEASE.md, run:
make artifacts IMAGE_REGISTRY=registry.k8s.io/lws GIT_TAG=v0.8.0

# Check values.yaml after completion — tag is hardcoded "main" even on release branches:
grep 'tag:' charts/lws/values.yaml
# tag: main  (should be $(RELEASE_BRANCH), e.g. "release-0.8")
```

Related: #784