### PR TITLE
fix: prevent spurious rolling updates from revision serialization differences due to 1.34 API modification

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -35,6 +35,7 @@ import (
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +55,8 @@ type LeaderWorkerSetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Record events.EventRecorder
+
+	revisionEqualityCache *lru.Cache
 }
 
 var (
@@ -79,11 +82,15 @@ const (
 	Delete = "Delete"
 )
 
+// maxRevisionEqualityCacheEntries is the cache size for semantic revision equality results.
+const maxRevisionEqualityCacheEntries = 10_000
+
 func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, record events.EventRecorder) *LeaderWorkerSetReconciler {
 	return &LeaderWorkerSetReconciler{
-		Client: client,
-		Scheme: scheme,
-		Record: record,
+		Client:                client,
+		Scheme:                scheme,
+		Record:                record,
+		revisionEqualityCache: lru.New(maxRevisionEqualityCacheEntries),
 	}
 }
 
@@ -740,6 +747,10 @@ func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, sts 
 	}
 
 	if !revisionutils.EqualRevision(currentRevision, revision) {
+		// If raw bytes differ but the revision is semantically equivalent, avoid triggering a spurious rolling update.
+		if revisionutils.SetMatchesRevision(lws, currentRevision, revision, r.revisionEqualityCache) {
+			return nil, nil
+		}
 		return currentRevision, nil
 	}
 

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,6 +32,7 @@ import (
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -1066,6 +1068,86 @@ func TestSetCondition(t *testing.T) {
 			shouldUpdate := setCondition(tc.lws, tc.condition)
 			if shouldUpdate != tc.expectedShouldUpdate {
 				t.Errorf("Expected value %t, got %t", tc.expectedShouldUpdate, shouldUpdate)
+			}
+		})
+	}
+}
+
+func TestGetUpdatedRevision(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+
+	tests := []struct {
+		name           string
+		sts            *appsv1.StatefulSet
+		lws            *leaderworkerset.LeaderWorkerSet
+		modifyRevision func(*appsv1.ControllerRevision)
+		expectUpdate   bool
+	}{
+		{
+			name:         "sts is nil, should return nil",
+			sts:          nil,
+			lws:          wrappers.BuildLeaderWorkerSet("default").Obj(),
+			expectUpdate: false,
+		},
+		{
+			name: "revision matches current spec, no update",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
+			},
+			lws:          wrappers.BuildLeaderWorkerSet("default").Obj(),
+			expectUpdate: false,
+		},
+		{
+			name: "revision has old serialization with creationTimestamp null, semantic match, no update",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
+			},
+			lws: wrappers.BuildLeaderWorkerSet("default").Obj(),
+			modifyRevision: func(rev *appsv1.ControllerRevision) {
+				// Simulate old (before v1.34) client-go serialization that includes "creationTimestamp":null
+				rev.Data.Raw = []byte(strings.ReplaceAll(string(rev.Data.Raw), `"metadata":{}`, `"metadata":{"creationTimestamp":null}`))
+			},
+			expectUpdate: false,
+		},
+		{
+			name: "revision has different spec, should trigger update",
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
+			},
+			lws: wrappers.BuildLeaderWorkerSet("default").Obj(),
+			modifyRevision: func(rev *appsv1.ControllerRevision) {
+				// Simulate a real spec change by modifying the container name
+				rev.Data.Raw = []byte(strings.ReplaceAll(string(rev.Data.Raw), `"name":"leader"`, `"name":"changed"`))
+			},
+			expectUpdate: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reconciler := &LeaderWorkerSetReconciler{
+				Client:                client,
+				Record:                fakeEventRecorder{},
+				revisionEqualityCache: lru.New(100),
+			}
+
+			revision, err := revisionutils.NewRevision(context.TODO(), client, tc.lws, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.modifyRevision != nil {
+				tc.modifyRevision(revision)
+			}
+
+			updatedRevision, err := reconciler.getUpdatedRevision(context.TODO(), tc.sts, tc.lws, revision)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gotUpdate := updatedRevision != nil
+			if gotUpdate != tc.expectUpdate {
+				t.Errorf("expected update=%t, got update=%t", tc.expectUpdate, gotUpdate)
 			}
 		})
 	}

--- a/pkg/utils/revision/revision_utils.go
+++ b/pkg/utils/revision/revision_utils.go
@@ -31,9 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/lru"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -188,6 +190,47 @@ func EqualRevision(lhs *appsv1.ControllerRevision, rhs *appsv1.ControllerRevisio
 	}
 
 	return bytes.Equal(lhs.Data.Raw, rhs.Data.Raw) && apiequality.Semantic.DeepEqual(lhs.Data.Object, rhs.Data.Object)
+}
+
+// revisionEqualityCacheKey is the cache key for remembering that a particular
+// revision ResourceVersion is semantically equal to the revision produced from
+// a particular LWS UID at a particular generation.
+type revisionEqualityCacheKey struct {
+	lwsUID                  types.UID
+	lwsGeneration           int64
+	revisionResourceVersion string
+}
+
+// SetMatchesRevision returns true if the proposedRevision (generated from the current LWS spec)
+// semantically matches the existingRevision, even when their raw bytes differ due to serialization
+// changes across LWS or client-go versions (e.g., "creationTimestamp": null vs omitted).
+// It works by applying the existing revision back to the LWS, re-generating a patch with the
+// current serialization format, and comparing the raw bytes.
+// Results are cached in the provided LRU cache to avoid expensive reconstruction on every reconcile.
+// This function adapts the approach in https://github.com/kubernetes/kubernetes/pull/135017.
+func SetMatchesRevision(lws *leaderworkerset.LeaderWorkerSet, proposedRevision *appsv1.ControllerRevision, existingRevision *appsv1.ControllerRevision, cache *lru.Cache) bool {
+	cacheKey := revisionEqualityCacheKey{
+		lwsUID:                  lws.UID,
+		lwsGeneration:           lws.Generation,
+		revisionResourceVersion: existingRevision.ResourceVersion,
+	}
+	if _, ok := cache.Get(cacheKey); ok {
+		return true
+	}
+
+	latestLws, err := ApplyRevision(lws, existingRevision)
+	if err != nil {
+		return false
+	}
+	reconstructedPatch, err := getPatch(latestLws)
+	if err != nil {
+		return false
+	}
+	if bytes.Equal(proposedRevision.Data.Raw, reconstructedPatch) {
+		cache.Add(cacheKey, struct{}{})
+		return true
+	}
+	return false
 }
 
 // TruncateRevisions cleans up all other controller revisions except the currentRevision.

--- a/pkg/utils/revision/revision_utils_test.go
+++ b/pkg/utils/revision/revision_utils_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/lru"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	"sigs.k8s.io/lws/test/wrappers"
@@ -174,6 +176,49 @@ func TestEqualRevision(t *testing.T) {
 				t.Errorf("Expected equality between controller revisions to be %t, but was %t", tc.equal, equal)
 			}
 		})
+	}
+}
+
+func TestSetMatchesRevision(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.UID = types.UID("test-uid")
+	lws.Generation = 1
+
+	revision, err := NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision.ResourceVersion = "100"
+
+	// Build proposed revision from the same LWS (should match).
+	proposed, err := NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := lru.New(10)
+
+	// First call: cache miss, should match via patch comparison and populate the cache.
+	if !SetMatchesRevision(lws, proposed, revision, cache) {
+		t.Fatal("expected SetMatchesRevision to return true on first call (cache miss path)")
+	}
+	if cache.Len() != 1 {
+		t.Fatalf("expected cache to have 1 entry after first call, got %d", cache.Len())
+	}
+
+	// Second call with the same inputs: should hit the cache and return true immediately.
+	proposed.Data.Raw = []byte(`{"spec":{"leaderWorkerTemplate":{"$patch":"replace"}}}`)
+	if !SetMatchesRevision(lws, proposed, revision, cache) {
+		t.Fatal("expected SetMatchesRevision to return true on second call (cache hit path)")
+	}
+
+	// Verify a different LWS generation produces a cache miss, and the mutated proposed
+	// revision correctly causes a mismatch.
+	lws.Generation = 2
+	if SetMatchesRevision(lws, proposed, revision, cache) {
+		t.Fatal("expected SetMatchesRevision to return false for different generation with mismatched proposed data")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it

When upgrading the LWS controller across client-go versions, `ControllerRevision.Data.Raw` can change in semantically irrelevant ways. The existing `EqualRevision` performs a raw-bytes comparison and treats these differences as spec changes, causing `getUpdatedRevision` to trigger unnecessary rolling updates.

This PR adds a semantic equivalence check as a fallback when raw-bytes comparison fails, adapting the approach from kubernetes/kubernetes#135017 for the upstream StatefulSet controller.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #797 

#### Special notes for your reviewer


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent spurious rolling updates from revision serialization differences due to 1.34 API modification.
```

/cc @Edwinhr716 @ahg-g @kerthcet 