### PR TITLE
fix(volcano): add missing PodGroup RBAC for kubectl-based installs

### DIFF
--- a/config/components/volcano/kustomization.yaml
+++ b/config/components/volcano/kustomization.yaml
@@ -4,5 +4,7 @@ kind: Component
 patches:
 - path: manager_role_patch.yaml
   target:
+    group: rbac.authorization.k8s.io
+    version: v1
     kind: ClusterRole
     name: manager-role

--- a/config/components/volcano/manager_role_patch.yaml
+++ b/config/components/volcano/manager_role_patch.yaml
@@ -1,14 +1,12 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: manager-role
-rules:
-- apiGroups:
-  - scheduling.volcano.sh
-  resources:
-  - podgroups
-  verbs:
-  - create
-  - get
-  - list
-  - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - scheduling.volcano.sh
+    resources:
+    - podgroups
+    verbs:
+    - create
+    - get
+    - list
+    - watch

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,6 +28,10 @@ resources:
 # [METRICS] Expose the controller manager metrics service.
 - manager_metrics_service.yaml
 
+# [VOLCANO] To enable Volcano gang scheduling RBAC, uncomment the following.
+# components:
+# - ../components/volcano
+
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/docs/examples/sample/gang-scheduling/README.md
+++ b/docs/examples/sample/gang-scheduling/README.md
@@ -52,9 +52,15 @@ To enable gang scheduling, you must enable the feature flag and specify `volcano
            schedulerProvider: volcano
      ```
 
-  2. **Apply the Volcano RBAC component** to grant the LWS controller permission to manage Volcano PodGroups:
+  2. **Enable the Volcano RBAC component** to grant the LWS controller permission to manage Volcano PodGroups. In `config/default/kustomization.yaml`, uncomment the `components` section:
+     ```yaml
+     # [VOLCANO] To enable Volcano gang scheduling RBAC, uncomment the following.
+     components:
+     - ../components/volcano
+     ```
+     Then re-apply the manifests:
      ```sh
-     kubectl apply -k config/components/volcano
+     kubectl apply -k config/default
      ```
 
   3. **Restart the lws-controller-manager** to apply the new configuration:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind documentation

#### What this PR does / why we need it

When LWS is installed via `kubectl` with Volcano gang scheduling enabled, the LWS controller automatically creates a `scheduling.volcano.sh/podgroups` resource for each LWS replica before pod scheduling. However, `config/rbac/role.yaml` is missing the RBAC permission for this resource, causing PodGroup creation to silently fail.

As a result, Volcano's admission webhook (`validatepod.volcano.sh`) denies pod creation because the expected PodGroup does not exist:

```
Warning  FailedCreate  statefulset-controller
  create Pod <name> in StatefulSet <name> failed:
  admission webhook "validatepod.volcano.sh" denied the request:
  failed to get PodGroup for pod <namespace/pod-name>:
  podgroups.scheduling.volcano.sh "<podgroup-name>" not found
```

Root cause confirmed via:
```sh
kubectl auth can-i create podgroups.scheduling.volcano.sh \
  --as=system:serviceaccount:lws-system:lws-controller-manager
# → no
```

The Helm chart already handles this correctly (see [`charts/lws/templates/rbac/clusterrole.yaml#L132-L142`](https://github.com/kubernetes-sigs/lws/blob/bcd37f46553449c14c69c772a586f7db05a8300d/charts/lws/templates/rbac/clusterrole.yaml#L132-L142)) with a conditional rule:
```yaml
{{- if eq .Values.gangSchedulingManagement.schedulerProvider "volcano" }}
- apiGroups: ["scheduling.volcano.sh"]
  resources: ["podgroups"]
  verbs: ["create", "get", "list", "watch"]
{{- end }}
```

This PR brings parity for `kubectl`-based installs by:
- Adding `config/components/volcano/` kustomize component that patches the existing `manager-role` with the required Volcano PodGroup rules (following the existing `config/components/prometheus/` pattern)
- Documenting the required RBAC step in the gang-scheduling README for `kubectl` users

#### Which issue(s) this PR fixes
N/A

#### Special notes for your reviewer

This RBAC is intentionally scoped to `scheduling.volcano.sh/podgroups` only — it is Volcano-specific and not needed for other gang scheduler integrations (e.g. Coscheduler uses `scheduling.sigs.k8s.io/podgroup`). Placing it under `config/components/` rather than `config/rbac/` keeps it opt-in, consistent with how the Helm chart conditionally includes it.

#### Does this PR introduce a user-facing change?
```release-note
Add `config/components/volcano` kustomize component with Volcano PodGroup RBAC for kubectl-based LWS installations with gang scheduling enabled.
```