### PR TITLE
perf(pod): optimize env var lookup

### DIFF
--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -106,23 +106,23 @@ func GetEnvVarValueIfInContainer(c *corev1.Container, envVarName string) (bool, 
 // ensuring that the 'firstEnv' and 'e' env vars maintain their order at the front.
 // The function then adds any existing env vars from 'c.Env' that are not in 'e' to the newEnvVars slice.
 func addEnvVarsIfNotExists(c *corev1.Container, firstEnv corev1.EnvVar, e ...corev1.EnvVar) {
-	newEnvVars := make([]corev1.EnvVar, 0)
+	envMap := make(map[string]struct{})
+	newEnvVars := make([]corev1.EnvVar, 0, len(c.Env)+len(e)+1)
 
 	// Add firstEnv to the beginning of the newEnvVars slice
 	newEnvVars = append(newEnvVars, firstEnv)
-	newEnvVars = append(newEnvVars, e...)
+	envMap[firstEnv.Name] = struct{}{}
 
-	// Add existing env vars from c.Env that are not in e to newEnvVars
+	for _, env := range e {
+		newEnvVars = append(newEnvVars, env)
+		envMap[env.Name] = struct{}{}
+	}
+
+	// Add existing env vars from c.Env that are not already added
 	for _, env := range c.Env {
-		exists := false
-		for _, newEnv := range newEnvVars {
-			if newEnv.Name == env.Name {
-				exists = true
-				break
-			}
-		}
-		if !exists {
+		if _, exists := envMap[env.Name]; !exists {
 			newEnvVars = append(newEnvVars, env)
+			envMap[env.Name] = struct{}{}
 		}
 	}
 	c.Env = newEnvVars


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Optimize the `addEnvVarsIfNotExists` function to use map-based lookup instead of nested loops.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
