### PR TITLE
fix: prevent leader pod from being recreated twice on background deletion

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -239,6 +239,15 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 		if revisionutils.GetRevisionKey(&leader) != revisionutils.GetRevisionKey(&pod) {
 			return false, nil
 		}
+		// Ignore worker pods from a stale worker StatefulSet (or test-owned direct pod) so
+		// background deletion of the previous group does not recreate the replacement leader again.
+		currentGroupWorkerPod, err := r.workerPodBelongsToLeader(ctx, pod, leader)
+		if err != nil {
+			return false, err
+		}
+		if !currentGroupWorkerPod {
+			return false, nil
+		}
 	} else {
 		leader = pod
 	}
@@ -254,6 +263,35 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 	}
 	r.Record.Eventf(&leaderWorkerSet, &leader, corev1.EventTypeNormal, "RecreateGroup", Delete, fmt.Sprintf("Worker pod %s failed, deleted leader pod %s to recreate group %s", pod.Name, leader.Name, leader.Labels[leaderworkerset.GroupIndexLabelKey]))
 	return true, nil
+}
+
+func (r *PodReconciler) workerPodBelongsToLeader(ctx context.Context, pod corev1.Pod, leader corev1.Pod) (bool, error) {
+	owner := metav1.GetControllerOf(&pod)
+	if owner == nil {
+		return false, nil
+	}
+
+	if owner.Kind == "Pod" {
+		return owner.Name == leader.Name && owner.UID == leader.UID, nil
+	}
+
+	if owner.Kind != "StatefulSet" {
+		return false, nil
+	}
+
+	var workerSts appsv1.StatefulSet
+	if err := r.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: pod.Namespace}, &workerSts); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	if workerSts.UID != owner.UID {
+		return false, nil
+	}
+
+	stsOwner := metav1.GetControllerOf(&workerSts)
+	if stsOwner == nil {
+		return false, nil
+	}
+	return stsOwner.Kind == "Pod" && stsOwner.Name == leader.Name && stsOwner.UID == leader.UID, nil
 }
 
 func (r *PodReconciler) setNodeSelectorForWorkerPods(ctx context.Context, pod *corev1.Pod, sts *appsapplyv1.StatefulSetApplyConfiguration, topologyKey string) error {

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -23,13 +23,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
@@ -416,6 +419,113 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantStatefulSetConfig, statefulSetConfig); diff != "" {
 				t.Errorf("unexpected StatefulSet apply operation %s", diff)
+			}
+		})
+	}
+}
+
+func TestHandleRestartPolicyUsesCurrentWorkerOwnership(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Replica(1).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj()
+	revisionKey := "revision-1"
+
+	makeLeaderPod := func(uid types.UID) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lws.Name + "-0",
+				Namespace: lws.Namespace,
+				UID:       uid,
+				Labels: map[string]string{
+					leaderworkerset.SetNameLabelKey:     lws.Name,
+					leaderworkerset.WorkerIndexLabelKey: "0",
+					leaderworkerset.GroupIndexLabelKey:  "0",
+					leaderworkerset.RevisionKey:         revisionKey,
+				},
+			},
+		}
+	}
+
+	makeWorkerStatefulSet := func(uid types.UID, leader *corev1.Pod) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            leader.Name,
+				Namespace:       leader.Namespace,
+				UID:             uid,
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(leader, corev1.SchemeGroupVersion.WithKind("Pod"))},
+			},
+		}
+	}
+
+	makeWorkerPod := func(owner metav1.OwnerReference) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lws.Name + "-0-1",
+				Namespace: lws.Namespace,
+				Labels: map[string]string{
+					leaderworkerset.SetNameLabelKey:     lws.Name,
+					leaderworkerset.WorkerIndexLabelKey: "1",
+					leaderworkerset.GroupIndexLabelKey:  "0",
+					leaderworkerset.RevisionKey:         revisionKey,
+				},
+				OwnerReferences: []metav1.OwnerReference{owner},
+			},
+		}
+	}
+
+	deletingWorker := func(w *corev1.Pod) corev1.Pod {
+		p := w.DeepCopy()
+		now := v1.Now()
+		p.DeletionTimestamp = &now
+		return *p
+	}
+
+	stsRef := func(s *appsv1.StatefulSet) metav1.OwnerReference {
+		return *metav1.NewControllerRef(s, appsv1.SchemeGroupVersion.WithKind("StatefulSet"))
+	}
+
+	currentLeader := makeLeaderPod("leader-current")
+	currentSts := makeWorkerStatefulSet("sts-current", currentLeader)
+	staleSts := makeWorkerStatefulSet("sts-stale", currentLeader)
+
+	tests := []struct {
+		name              string
+		objects           []client.Object
+		reconciledPod     corev1.Pod
+		wantLeaderDeleted bool
+	}{
+		{
+			name:              "current worker statefulset owner triggers group recreation",
+			objects:           []client.Object{currentLeader, currentSts, makeWorkerPod(stsRef(currentSts))},
+			reconciledPod:     deletingWorker(makeWorkerPod(stsRef(currentSts))),
+			wantLeaderDeleted: true,
+		},
+		{
+			name:              "stale worker statefulset owner is ignored",
+			objects:           []client.Object{currentLeader, currentSts, makeWorkerPod(stsRef(staleSts))},
+			reconciledPod:     deletingWorker(makeWorkerPod(stsRef(staleSts))),
+			wantLeaderDeleted: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(tc.objects...).Build()
+			reconciler := PodReconciler{Client: fakeClient, Record: fakeEventRecorder{}}
+
+			leaderDeleted, err := reconciler.handleRestartPolicy(context.Background(), tc.reconciledPod, *lws.DeepCopy())
+			if err != nil {
+				t.Fatalf("handleRestartPolicy() error = %v", err)
+			}
+			if leaderDeleted != tc.wantLeaderDeleted {
+				t.Fatalf("handleRestartPolicy() leaderDeleted = %t, want %t", leaderDeleted, tc.wantLeaderDeleted)
+			}
+
+			var leader corev1.Pod
+			err = fakeClient.Get(context.Background(), client.ObjectKey{Name: lws.Name + "-0", Namespace: lws.Namespace}, &leader)
+			if tc.wantLeaderDeleted && !apierrors.IsNotFound(err) {
+				t.Fatalf("leader pod still exists after recreation trigger, err = %v", err)
+			}
+			if !tc.wantLeaderDeleted && err != nil {
+				t.Fatalf("leader pod should still exist, err = %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it

When a leader pod is deleted with background propagation (the default for `kubectl delete pod`) and the restart policy is `RecreateGroupOnPodRestart`, the leader pod gets recreated **twice**. This happens because during garbage collection of the old group, the terminating worker pods trigger `handleRestartPolicy` which looks up the leader pod by name — finding the **newly recreated** leader instead of the old one. Since only the revision key was checked (not the ownership chain), the stale worker pod was mistakenly treated as belonging to the new leader, causing the new leader to be deleted and recreated a second time.

This PR adds `workerPodBelongsToLeader` to verify that the worker pod's owner reference chain (either direct Pod owner or StatefulSet → Pod) actually matches the current leader's UID before triggering group recreation.

## Which issue(s) this PR fixes

Fixes https://github.com/kubernetes-sigs/lws/issues/804

## Special notes for your reviewer

The race condition only manifests with **background** deletion propagation. Foreground propagation blocks until all dependents are gone, so the StatefulSet does not recreate the leader until the old worker pods are fully cleaned up.

## Does this PR introduce a user-facing change?

```release-note
Fix leader pod being recreated twice when deleted with background propagation and RecreateGroupOnPodRestart restart policy.
```

/kind bug