### PR TITLE
add status.observedGeneration field for lws

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -383,6 +383,10 @@ type LeaderWorkerSetStatus struct {
 	// we only select the leader pods.
 	// +optional
 	HPAPodSelector string `json:"hpaPodSelector,omitempty"`
+
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type LeaderWorkerSetConditionType string

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -384,8 +384,8 @@ type LeaderWorkerSetStatus struct {
 	// +optional
 	HPAPodSelector string `json:"hpaPodSelector,omitempty"`
 
+	// observedGeneration is the most recent generation observed for this LeaderWorkerSet.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 

--- a/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -16892,6 +16892,10 @@ spec:
                     needed for HPA to know what pods belong to the LeaderWorkerSet object. Here
                     we only select the leader pods.
                   type: string
+                observedGeneration:
+                  description: observedGeneration is the most recent generation observed for this LeaderWorkerSet.
+                  format: int64
+                  type: integer
                 readyReplicas:
                   description: readyReplicas track the number of groups that are in ready state (updated or not).
                   format: int32

--- a/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -16892,10 +16892,6 @@ spec:
                     needed for HPA to know what pods belong to the LeaderWorkerSet object. Here
                     we only select the leader pods.
                   type: string
-                observedGeneration:
-                  description: observedGeneration is the most recent generation observed for this LeaderWorkerSet.
-                  format: int64
-                  type: integer
                 readyReplicas:
                   description: readyReplicas track the number of groups that are in ready state (updated or not).
                   format: int32

--- a/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetstatus.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetstatus.go
@@ -38,6 +38,8 @@ type LeaderWorkerSetStatusApplyConfiguration struct {
 	// needed for HPA to know what pods belong to the LeaderWorkerSet object. Here
 	// we only select the leader pods.
 	HPAPodSelector *string `json:"hpaPodSelector,omitempty"`
+	// observedGeneration is the most recent generation observed for this LeaderWorkerSet.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
 // LeaderWorkerSetStatusApplyConfiguration constructs a declarative configuration of the LeaderWorkerSetStatus type for use with
@@ -88,5 +90,13 @@ func (b *LeaderWorkerSetStatusApplyConfiguration) WithReplicas(value int32) *Lea
 // If called multiple times, the HPAPodSelector field is set to the value of the last call.
 func (b *LeaderWorkerSetStatusApplyConfiguration) WithHPAPodSelector(value string) *LeaderWorkerSetStatusApplyConfiguration {
 	b.HPAPodSelector = &value
+	return b
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *LeaderWorkerSetStatusApplyConfiguration) WithObservedGeneration(value int64) *LeaderWorkerSetStatusApplyConfiguration {
+	b.ObservedGeneration = &value
 	return b
 }

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -17880,6 +17880,11 @@ spec:
                   needed for HPA to know what pods belong to the LeaderWorkerSet object. Here
                   we only select the leader pods.
                 type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this LeaderWorkerSet.
+                format: int64
+                type: integer
               readyReplicas:
                 description: readyReplicas track the number of groups that are in
                   ready state (updated or not).

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -486,12 +486,12 @@ func (r *LeaderWorkerSetReconciler) updateConditions(ctx context.Context, lws *l
 	if partitionedUpdatedNonBurstCount < partitionedCurrentNonBurstCount {
 		// upgradeInProgress is true when the upgrade replicas is smaller than the expected
 		// number of total replicas not including the burst replicas
-		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetUpdateInProgress))
-		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing))
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetUpdateInProgress, lws))
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing, lws))
 	} else if readyNonBurstWorkerCount == int(*lws.Spec.Replicas) && partitionedUpdatedAndReadyCount == partitionedCurrentNonBurstCount {
-		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetAvailable))
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetAvailable, lws))
 	} else {
-		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing))
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing, lws))
 	}
 
 	// updateDone is true when all replicas are updated and ready
@@ -521,6 +521,11 @@ func (r *LeaderWorkerSetReconciler) updateStatus(ctx context.Context, lws *leade
 	replicas := int(sts.Status.Replicas)
 	if lws.Status.Replicas != int32(replicas) {
 		lws.Status.Replicas = int32(replicas)
+		updateStatus = true
+	}
+
+	if lws.Status.ObservedGeneration != lws.Generation {
+		lws.Status.ObservedGeneration = lws.Generation
 		updateStatus = true
 	}
 
@@ -859,7 +864,7 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 	return statefulSetConfig, nil
 }
 
-func makeCondition(conditionType leaderworkerset.LeaderWorkerSetConditionType) metav1.Condition {
+func makeCondition(conditionType leaderworkerset.LeaderWorkerSetConditionType, lws *leaderworkerset.LeaderWorkerSet) metav1.Condition {
 	var condtype, reason, message string
 	switch conditionType {
 	case leaderworkerset.LeaderWorkerSetAvailable:
@@ -880,6 +885,7 @@ func makeCondition(conditionType leaderworkerset.LeaderWorkerSetConditionType) m
 		Type:               condtype,
 		Status:             metav1.ConditionStatus(corev1.ConditionTrue),
 		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: lws.Generation,
 		Reason:             reason,
 		Message:            message,
 	}
@@ -903,7 +909,8 @@ func setCondition(lws *leaderworkerset.LeaderWorkerSet, newCondition metav1.Cond
 	// Precondition: newCondition has status true.
 	for i, curCondition := range lws.Status.Conditions {
 		if newCondition.Type == curCondition.Type {
-			if newCondition.Status != curCondition.Status {
+			if newCondition.Status != curCondition.Status ||
+				newCondition.ObservedGeneration != curCondition.ObservedGeneration {
 				// the conditions match but one is true and one is false. Update the stored condition
 				// with the new condition.
 				lws.Status.Conditions[i] = newCondition
@@ -918,6 +925,12 @@ func setCondition(lws *leaderworkerset.LeaderWorkerSet, newCondition metav1.Cond
 				(newCondition.Status == metav1.ConditionTrue) && (curCondition.Status == metav1.ConditionTrue) {
 				// Progressing is true and Available is true. Prevent this.
 				lws.Status.Conditions[i].Status = metav1.ConditionFalse
+
+				lws.Status.Conditions[i].LastTransitionTime = metav1.Now()
+				lws.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
+				lws.Status.Conditions[i].Reason = newCondition.Reason
+				lws.Status.Conditions[i].Message = newCondition.Message
+
 				shouldUpdate = true
 			}
 		}

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -898,6 +898,13 @@ func setConditions(lws *leaderworkerset.LeaderWorkerSet, conditions []metav1.Con
 		shouldUpdate = shouldUpdate || setCondition(lws, condition)
 	}
 
+	for i := range lws.Status.Conditions {
+		if lws.Status.Conditions[i].ObservedGeneration != lws.Generation {
+			lws.Status.Conditions[i].ObservedGeneration = lws.Generation
+			shouldUpdate = true
+		}
+	}
+
 	return shouldUpdate
 }
 
@@ -923,14 +930,9 @@ func setCondition(lws *leaderworkerset.LeaderWorkerSet, newCondition metav1.Cond
 			// Available and both are true. Must be mutually exclusive.
 			if exclusiveConditionTypes(curCondition, newCondition) &&
 				(newCondition.Status == metav1.ConditionTrue) && (curCondition.Status == metav1.ConditionTrue) {
-				// Progressing is true and Available is true. Prevent this.
 				lws.Status.Conditions[i].Status = metav1.ConditionFalse
-
 				lws.Status.Conditions[i].LastTransitionTime = metav1.Now()
 				lws.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
-				lws.Status.Conditions[i].Reason = newCondition.Reason
-				lws.Status.Conditions[i].Message = newCondition.Message
-
 				shouldUpdate = true
 			}
 		}

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -1018,41 +1018,28 @@ func TestSetCondition(t *testing.T) {
 		expectedShouldUpdate bool
 	}{
 		{
-			name:      "Different condition type, same condition status",
-			condition: metav1.Condition{Type: "Progressing", Status: "True"},
-			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
-				Conditions([]metav1.Condition{{Type: "Available", Status: "True"}}).
-				Obj(),
-			expectedShouldUpdate: true,
-		},
-		{
 			name:      "Same condition type, different condition status",
-			condition: metav1.Condition{Type: "Progressing", Status: "True"},
+			condition: metav1.Condition{Type: "Progressing", Status: "True", ObservedGeneration: 1},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
-				Conditions([]metav1.Condition{{Type: "Progressing", Status: "False"}}).
+				Generation(1).
+				Conditions([]metav1.Condition{{Type: "Progressing", Status: "False", ObservedGeneration: 1}}).
 				Obj(),
 			expectedShouldUpdate: true,
 		},
 		{
-			name:      "Different conditio type, new condition status is true",
-			condition: metav1.Condition{Type: "Progressing", Status: "True"},
+			name:      "Different condition type, new condition status is true",
+			condition: metav1.Condition{Type: "Progressing", Status: "True", ObservedGeneration: 1},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
-				Conditions([]metav1.Condition{{Type: "Available", Status: "False"}}).
+				Generation(1).
+				Conditions([]metav1.Condition{{Type: "Available", Status: "False", ObservedGeneration: 1}}).
 				Obj(),
 			expectedShouldUpdate: true,
 		},
 		{
 			name:                 "No initial condition",
-			condition:            metav1.Condition{Type: "Progressing", Status: "True"},
-			lws:                  wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Obj(),
+			condition:            metav1.Condition{Type: "Progressing", Status: "True", ObservedGeneration: 1},
+			lws:                  wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Generation(1).Obj(),
 			expectedShouldUpdate: true,
-		},
-		{
-			name:      "Different condition type, new condition status is false",
-			condition: metav1.Condition{Type: "Progressing", Status: "False"},
-			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
-				Conditions([]metav1.Condition{{Type: "Available", Status: "True"}}).
-				Obj(),
 		},
 		{
 			name:      "Same condition type, Same condition status",
@@ -1060,6 +1047,15 @@ func TestSetCondition(t *testing.T) {
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Conditions([]metav1.Condition{{Type: "Progressing", Status: "False"}}).
 				Obj(),
+		},
+		{
+			name:      "Same condition type, same status, but generation advanced",
+			condition: metav1.Condition{Type: "Available", Status: "True", ObservedGeneration: 2},
+			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+				Generation(2).
+				Conditions([]metav1.Condition{{Type: "Available", Status: "True", ObservedGeneration: 1}}).
+				Obj(),
+			expectedShouldUpdate: true,
 		},
 	}
 

--- a/site/content/en/docs/reference/leaderworkerset.v1.md
+++ b/site/content/en/docs/reference/leaderworkerset.v1.md
@@ -169,6 +169,13 @@ needed for HPA to know what pods belong to the LeaderWorkerSet object. Here
 we only select the leader pods.</p>
 </td>
 </tr>
+<tr><td><code>observedGeneration</code><br/>
+<code>int64</code>
+</td>
+<td>
+   <p>observedGeneration is the most recent generation observed for this LeaderWorkerSet.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -414,6 +414,9 @@ func CheckLeaderWorkerSetHasCondition(ctx context.Context, k8sClient client.Clie
 	}
 	for _, c := range fetchedLWS.Status.Conditions {
 		if c.Type == condition.Type && c.Status == condition.Status {
+			if c.ObservedGeneration != fetchedLWS.Generation {
+				return false, nil
+			}
 			if condition.Message != "" {
 				return condition.Message == c.Message, nil
 			}

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -173,6 +173,11 @@ func (lwsWrapper *LeaderWorkerSetWrapper) PersistentVolumeClaimRetentionPolicy(p
 	return lwsWrapper
 }
 
+func (b *LeaderWorkerSetWrapper) Generation(generation int64) *LeaderWorkerSetWrapper {
+	b.LeaderWorkerSet.Generation = generation
+	return b
+}
+
 func BuildBasicLeaderWorkerSet(name, ns string) *LeaderWorkerSetWrapper {
 	return &LeaderWorkerSetWrapper{
 		leaderworkerset.LeaderWorkerSet{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it

This PR introduces the `status.observedGeneration` field to the LeaderWorkerSet API. 



#### Which issue(s) this PR fixes

Fixes #698
