### PR TITLE
Allow github actions follow Security policy

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@19bb51245e9c80abacb2e91cc42b33fa478b8639  # v4.3.0
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -9,13 +9,14 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  #v6.4.0
       with:
         go-version: 1.25
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
+      uses: actions/checkout@40f1582b2485089dde7abd97c1529aa768e1baff  #v5.6.0
+
 
     - name: Build Test
       run: go test -race -covermode=atomic -coverprofile=profile.cov ./pkg/... ./cmd/...

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  #v6.4.0
         with:
           go-version: 1.25
         id: go
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@40f1582b2485089dde7abd97c1529aa768e1baff  #v5.6.0
       
       - name: Build an image from Dockerfile
         run: |
@@ -39,3 +39,5 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide:
   https://git.k8s.io/community/contributors/devel/development.md#development-guide

2. Please label this pull request according to what type of issue you are addressing.

3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md

4. If you want faster PR reviews, read:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

5. If the PR is unfinished, see:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug



#### What this PR does 

This PR enforces a security policy in GitHub Actions by replacing mutable version tags (e.g., `@v5`) with immutable commit SHAs.



#### Which issue(s) this PR fixes

Fixes #814

