### PR TITLE
Upgrade Go to 1.26

### DIFF
--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  #v6.4.0
       with:
-        go-version: 1.25
+        go-version: 1.26
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  #v6.4.0
         with:
-          go-version: 1.25
+          go-version: 1.26
         id: go
 
       - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
           docker buildx build --no-cache --output=type=docker -t test/lws:latest \
              --platform=linux/amd64 \
              --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot \
-             --build-arg BUILDER_IMAGE=golang:1.25 \
+             --build-arg BUILDER_IMAGE=golang:1.26 \
              --build-arg CGO_ENABLED=0 \
              -f ./Dockerfile .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.25
+ARG BUILDER_IMAGE=golang:1.26
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ ginkgo: ## Download ginkgo locally if necessary.
 GOLANGCI_LINT_KAL = $(shell pwd)/bin/golangci-lint-kube-api-linter
 .PHONY: golangci-lint-kal
 golangci-lint-kal: golangci-lint ## Build golangci-lint-kal from custom configuration.
-	cd $(PROJECT_DIR)/hack; $(GOLANGCI_LINT) custom; mv bin/golangci-lint-kube-api-linter $(PROJECT_DIR)/bin/
+	cd $(PROJECT_DIR)/hack; GOTOOLCHAIN=go1.26.0 $(GOLANGCI_LINT) custom; mv bin/golangci-lint-kube-api-linter $(PROJECT_DIR)/bin/
 
 GOTESTSUM = $(shell pwd)/bin/gotestsum
 .PHONY: gotestsum

--- a/disaggregatedset/Dockerfile
+++ b/disaggregatedset/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/disaggregatedset/go.mod
+++ b/disaggregatedset/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/disaggregatedset
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/olekukonko/tablewriter v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/lws
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module sigs.k8s.io/lws/site
 
-go 1.25.0
+go 1.26.0
 
 require github.com/google/docsy v0.13.0 // indirect


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
Bump Go from 1.25.0 to 1.26.0 to align with sibling SIG projects (jobset, kueue) and clear stdlib CVEs reported against Go 1.25.0 (including CVE-2026-27144).

Mirrors kubernetes-sigs/jobset#1210.

#### Which issue(s) this PR fixes
Fixes #822

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
