### PR TITLE
chore: reduce dependabot PR noise via grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       kubernetes:
         patterns:
           - "k8s.io/*"
+          - "sigs.k8s.io/*"
     ignore:
       # Ignore major and minor versions for dependencies updates
       # Allow patches and security updates.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reduce weekly dependabot PR noise by adding `sigs.k8s.io/*` to the existing `kubernetes` group, modeled after [jobset's config](https://github.com/kubernetes-sigs/jobset/blob/main/.github/dependabot.yml). Packages like `controller-runtime` and `structured-merge-diff` will land in the existing weekly kubernetes group PR instead of one PR each.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

An earlier revision also added `/disaggregatedset` via `directories:`. Dropped per [reviewer feedback](https://github.com/kubernetes-sigs/lws/pull/829#discussion_r3162389430) — that directory will go away once #789 lands, so the extra config isn't needed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```