### PR TITLE
fix: flaky 'Test default progressing state' integration test

### DIFF
--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -600,8 +600,11 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			updates: []*update{
 				{
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						lws.Status.Conditions = []metav1.Condition{}
-						gomega.Eventually(k8sClient.Status().Update(ctx, lws), testing.Timeout, testing.Interval).Should(gomega.Succeed())
+						gomega.Eventually(func(g gomega.Gomega) {
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), lws)).To(gomega.Succeed())
+							lws.Status.Conditions = []metav1.Condition{}
+							g.Expect(k8sClient.Status().Update(ctx, lws)).To(gomega.Succeed())
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -402,9 +402,12 @@ func SetPodGroupToReady(ctx context.Context, k8sClient client.Client, statefulse
 
 // SetStatefulsetToUnReady set statefulset to unready.
 func SetStatefulsetToUnReady(ctx context.Context, k8sClient client.Client, sts *appsv1.StatefulSet) {
-	sts.Status.CurrentRevision = "fuz"
-	sts.Status.UpdateRevision = "bar"
-	gomega.Expect(k8sClient.Status().Update(ctx, sts)).Should(gomega.Succeed())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), sts)).To(gomega.Succeed())
+		sts.Status.CurrentRevision = "fuz"
+		sts.Status.UpdateRevision = "bar"
+		g.Expect(k8sClient.Status().Update(ctx, sts)).To(gomega.Succeed())
+	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 func CheckLeaderWorkerSetHasCondition(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, condition metav1.Condition) (bool, error) {


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

Two related 409-Conflict races in integration test status updates.

**1. `Test default progressing state` (the one in #830)**

Misuses `gomega.Eventually` by passing the result of `Status().Update(...)` directly:

```go
lws.Status.Conditions = []metav1.Condition{}
gomega.Eventually(k8sClient.Status().Update(ctx, lws), testing.Timeout, testing.Interval).Should(gomega.Succeed())
```

`Update` is invoked only once; `Eventually` then re-checks the same already-resolved error. When the reconciler updates LWS status concurrently, the single attempt hits a 409 Conflict and the test times out after 120s.

**2. `SetStatefulsetToUnReady` test helper (`test/testutils/util.go`)**

Same class of bug, just split across functions. Callers do a `Get` first and then this helper issues a single `Status().Update` on the potentially-stale object, so any concurrent reconciler write produces a 409. It uses `gomega.Expect` (not `Eventually`), so it fails immediately rather than timing out — but still flaky.

**Fix**

Wrap both updates in an `Eventually` polling closure that re-`Get`s the latest object on every retry and re-issues `Status().Update`, matching the canonical pattern used in [kueue](https://github.com/kubernetes-sigs/kueue/blob/main/test/integration/singlecluster/scheduler/workload_controller_test.go) and [jobset](https://github.com/kubernetes-sigs/jobset/blob/main/test/integration/controller/jobset_controller_test.go).

#### Which issue(s) this PR fixes:

Fixes #830

#### Special notes for your reviewer:

Failure example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_lws/829/pull-lws-test-integration-main/2049365879791030272

#### Does this PR introduce a user-facing change?

```release-note
NONE
```