### PR TITLE
(disaggregatedset): Fix DisaggregatedSet rolling update drain ordering and maxSurge=0 handling

### DIFF
--- a/disaggregatedset/hack/e2e-test.sh
+++ b/disaggregatedset/hack/e2e-test.sh
@@ -86,7 +86,7 @@ function run_tests {
     # Set LWS_INSTALL_SKIP since we already installed LWS
     # Set KIND_CLUSTER for the test code (it expects KIND_CLUSTER, not KIND_CLUSTER_NAME)
     # Use --tags=e2e to include files with //go:build e2e constraint
-    LWS_INSTALL_SKIP=true KIND_CLUSTER="$KIND_CLUSTER_NAME" $GINKGO --tags=e2e --junit-report=junit.xml --output-dir="$ARTIFACTS" -v "$CWD/test/e2e/..."
+    LWS_INSTALL_SKIP=true KIND_CLUSTER="$KIND_CLUSTER_NAME" $GINKGO --tags=e2e --junit-report=junit.xml --output-dir="$ARTIFACTS" -v ${GINKGO_FOCUS:+--focus="$GINKGO_FOCUS"} "$CWD/test/e2e/..."
 }
 
 trap cleanup EXIT

--- a/disaggregatedset/internal/controller/executor.go
+++ b/disaggregatedset/internal/controller/executor.go
@@ -265,14 +265,23 @@ func isWorkloadStable(workload GroupedWorkload, roleNames []string) bool {
 	return true
 }
 
-func sortByOldestTimestamp(workloads GroupedWorkloads, roleNames []string) GroupedWorkloads {
+func maxTimestamp(wl GroupedWorkload) time.Time {
+	var maxTS time.Time
+	for _, info := range wl.Roles {
+		if info.CreationTimestamp.After(maxTS) {
+			maxTS = info.CreationTimestamp
+		}
+	}
+	return maxTS
+}
+
+func sortByNewestTimestamp(workloads GroupedWorkloads, roleNames []string) GroupedWorkloads {
 	if len(roleNames) == 0 {
 		return workloads
 	}
 	sorted := slices.Clone(workloads)
-	firstRole := roleNames[0]
 	slices.SortFunc(sorted, func(a, b GroupedWorkload) int {
-		return a.Roles[firstRole].CreationTimestamp.Compare(b.Roles[firstRole].CreationTimestamp)
+		return maxTimestamp(b).Compare(maxTimestamp(a))
 	})
 	return sorted
 }
@@ -316,7 +325,7 @@ func (executor *RollingUpdateExecutor) scaleDownOld(
 	}
 
 	log := logf.FromContext(ctx)
-	for _, wl := range sortByOldestTimestamp(oldWorkloads, roleNames) {
+	for _, wl := range sortByNewestTimestamp(oldWorkloads, roleNames) {
 		if allZero(budget) {
 			break
 		}

--- a/disaggregatedset/internal/controller/executor.go
+++ b/disaggregatedset/internal/controller/executor.go
@@ -235,11 +235,13 @@ func extractRollingUpdateConfig(ds *disaggv1alpha1.DisaggregatedSet, allRoleName
 	for _, role := range ds.Spec.Roles {
 		if rc := role.RolloutStrategy.RollingUpdateConfiguration; rc != nil {
 			i := roleIndex[role.Name]
-			if v := rc.MaxSurge.IntValue(); v > 0 {
-				config[i].MaxSurge = v
-			}
-			if v := rc.MaxUnavailable.IntValue(); v > 0 {
-				config[i].MaxUnavailable = v
+			surge := rc.MaxSurge.IntValue()
+			unavail := rc.MaxUnavailable.IntValue()
+			if unavail > 0 {
+				config[i].MaxUnavailable = unavail
+				config[i].MaxSurge = surge
+			} else if surge > 0 {
+				config[i].MaxSurge = surge
 			}
 		}
 	}

--- a/disaggregatedset/internal/controller/executor_test.go
+++ b/disaggregatedset/internal/controller/executor_test.go
@@ -622,6 +622,8 @@ func TestExtractRollingUpdateConfig(t *testing.T) {
 		{"custom decode only", nil, nil, ptr.To(2), ptr.To(0), 1, 0, 2, 0},
 		{"partial prefill (surge only)", ptr.To(5), ptr.To(0), nil, nil, 5, 0, 1, 0},
 		{"both custom", ptr.To(2), ptr.To(1), ptr.To(3), ptr.To(2), 2, 1, 3, 2},
+		{"surge=0 with unavail allows zero surge", ptr.To(0), ptr.To(4), ptr.To(0), ptr.To(2), 0, 4, 0, 2},
+		{"surge=0 without unavail keeps default", ptr.To(0), ptr.To(0), ptr.To(0), ptr.To(0), 1, 0, 1, 0},
 	}
 
 	for _, tc := range testCases {

--- a/disaggregatedset/internal/controller/executor_test.go
+++ b/disaggregatedset/internal/controller/executor_test.go
@@ -501,10 +501,10 @@ func TestReconcilerIntegration(t *testing.T) {
 }
 
 // =============================================================================
-// Unit Tests for sortByOldestTimestamp
+// Unit Tests for sortByNewestTimestamp
 // =============================================================================
 
-func TestSortByOldestTimestamp(t *testing.T) {
+func TestSortByNewestTimestamp(t *testing.T) {
 	baseTime := time.Now()
 	roleNames := testRoleNames()
 
@@ -522,14 +522,14 @@ func TestSortByOldestTimestamp(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		inputHashes   []string // hash names with implicit order by offset (0, 60, 120, ...)
-		inputOffsets  []int    // offset in minutes from baseTime
+		inputHashes   []string
+		inputOffsets  []int
 		expectedOrder []string
 	}{
 		{"empty list", nil, nil, nil},
 		{"single workload", []string{"hash1"}, []int{0}, []string{"hash1"}},
-		{"three workloads unsorted", []string{"newest", "oldest", "middle"}, []int{120, 0, 60}, []string{"oldest", "middle", "newest"}},
-		{"four workloads unsorted", []string{"d", "a", "c", "b"}, []int{30, 0, 20, 10}, []string{"a", "b", "c", "d"}},
+		{"three workloads unsorted", []string{"newest", "oldest", "middle"}, []int{120, 0, 60}, []string{"newest", "middle", "oldest"}},
+		{"four workloads unsorted", []string{"d", "a", "c", "b"}, []int{30, 0, 20, 10}, []string{"d", "c", "b", "a"}},
 	}
 
 	for _, tc := range testCases {
@@ -538,7 +538,7 @@ func TestSortByOldestTimestamp(t *testing.T) {
 			for i, hash := range tc.inputHashes {
 				workloads = append(workloads, makeWorkload(hash, tc.inputOffsets[i]))
 			}
-			result := sortByOldestTimestamp(workloads, roleNames)
+			result := sortByNewestTimestamp(workloads, roleNames)
 			require.Len(t, result, len(tc.expectedOrder))
 			for i, expected := range tc.expectedOrder {
 				assert.Equal(t, expected, result[i].Revision)
@@ -548,8 +548,27 @@ func TestSortByOldestTimestamp(t *testing.T) {
 
 	t.Run("does not modify original slice", func(t *testing.T) {
 		workloads := GroupedWorkloads{makeWorkload("second", 60), makeWorkload("first", 0)}
-		_ = sortByOldestTimestamp(workloads, roleNames)
+		_ = sortByNewestTimestamp(workloads, roleNames)
 		assert.Equal(t, "second", workloads[0].Revision, "original slice should not be modified")
+	})
+
+	t.Run("uses max timestamp across roles", func(t *testing.T) {
+		ts1 := baseTime
+		ts2 := baseTime.Add(10 * time.Minute)
+		ts3 := baseTime.Add(20 * time.Minute)
+		workloads := GroupedWorkloads{
+			{Revision: "A", Roles: map[string]WorkloadInfo{
+				testRolePrefill: {CreationTimestamp: ts1},
+				testRoleDecode:  {CreationTimestamp: ts3},
+			}},
+			{Revision: "B", Roles: map[string]WorkloadInfo{
+				testRolePrefill: {CreationTimestamp: ts2},
+				testRoleDecode:  {CreationTimestamp: ts2},
+			}},
+		}
+		result := sortByNewestTimestamp(workloads, roleNames)
+		assert.Equal(t, "A", result[0].Revision, "A has max ts=20min, should come first (newest)")
+		assert.Equal(t, "B", result[1].Revision, "B has max ts=10min, should come second")
 	})
 }
 
@@ -711,10 +730,10 @@ func TestScaleDownOld(t *testing.T) {
 			prefillBudget: 2, decodeBudget: 2,
 		},
 		{
-			name: "multiple workloads drain oldest first",
+			name: "multiple workloads drain newest first",
 			workloads: []workloadDef{
-				{revision: "oldest", prefill: 2, decode: 2, ageHours: 0, expectedPrefill: 0, expectedDecode: 0},
-				{revision: "newer", prefill: 2, decode: 2, ageHours: 1, expectedPrefill: 2, expectedDecode: 2},
+				{revision: "oldest", prefill: 2, decode: 2, ageHours: 0, expectedPrefill: 2, expectedDecode: 2},
+				{revision: "newer", prefill: 2, decode: 2, ageHours: 1, expectedPrefill: 0, expectedDecode: 0},
 			},
 			prefillBudget: 2, decodeBudget: 2,
 		},
@@ -729,27 +748,27 @@ func TestScaleDownOld(t *testing.T) {
 			prefillBudget: 2, decodeBudget: 2,
 		},
 		{
-			name: "three workloads drain oldest then middle",
+			name: "three workloads drain newest then middle",
 			workloads: []workloadDef{
-				{revision: "oldest", prefill: 2, decode: 2, ageHours: 0, expectedPrefill: 0, expectedDecode: 0},
+				{revision: "oldest", prefill: 2, decode: 2, ageHours: 0, expectedPrefill: 2, expectedDecode: 2},
 				{revision: "middle", prefill: 2, decode: 2, ageHours: 1, expectedPrefill: 0, expectedDecode: 0},
-				{revision: "newest", prefill: 2, decode: 2, ageHours: 2, expectedPrefill: 2, expectedDecode: 2},
+				{revision: "newest", prefill: 2, decode: 2, ageHours: 2, expectedPrefill: 0, expectedDecode: 0},
 			},
 			prefillBudget: 4, decodeBudget: 4,
 		},
 		{
-			name: "coordinated drain with budget recycling",
+			name: "partial drain of newest without coordinated trigger",
 			workloads: []workloadDef{
-				{revision: "hashA", prefill: 1, decode: 2, ageHours: 0, expectedPrefill: 0, expectedDecode: 0},
-				{revision: "hashB", prefill: 3, decode: 3, ageHours: 1, expectedPrefill: 3, expectedDecode: 2},
+				{revision: "hashA", prefill: 1, decode: 2, ageHours: 0, expectedPrefill: 1, expectedDecode: 2},
+				{revision: "hashB", prefill: 3, decode: 3, ageHours: 1, expectedPrefill: 2, expectedDecode: 2},
 			},
 			prefillBudget: 1, decodeBudget: 1,
 		},
 		{
-			name: "drain oldest then spill to newer",
+			name: "drains newest without spilling to older",
 			workloads: []workloadDef{
-				{revision: "oldest", prefill: 1, decode: 1, ageHours: 0, expectedPrefill: 0, expectedDecode: 0},
-				{revision: "newer", prefill: 3, decode: 3, ageHours: 1, expectedPrefill: 2, expectedDecode: 2},
+				{revision: "oldest", prefill: 1, decode: 1, ageHours: 0, expectedPrefill: 1, expectedDecode: 1},
+				{revision: "newer", prefill: 3, decode: 3, ageHours: 1, expectedPrefill: 1, expectedDecode: 1},
 			},
 			prefillBudget: 2, decodeBudget: 2,
 		},
@@ -1047,12 +1066,16 @@ func TestReconcileRollingUpdateABCScenario(t *testing.T) {
 
 	testCases := []abcExecutorScenario{
 		{
-			name: "drains oldest first", aPrefill: 2, aDecode: 2, bPrefill: 2, bDecode: 2, cPrefill: 0, cDecode: 0,
+			name: "first step scales up C without drain", aPrefill: 2, aDecode: 2, bPrefill: 2, bDecode: 2, cPrefill: 0, cDecode: 0,
 			expectedA: [2]int32{2, 2}, expectedB: [2]int32{2, 2}, expectedC: [2]int32{1, 1},
 		},
 		{
 			name: "C scales up while B stays", aPrefill: 0, aDecode: 0, bPrefill: 2, bDecode: 2, cPrefill: 2, cDecode: 2,
 			expectedA: [2]int32{0, 0}, expectedB: [2]int32{2, 2}, expectedC: [2]int32{3, 3},
+		},
+		{
+			name: "drains newest old workload first", aPrefill: 2, aDecode: 2, bPrefill: 2, bDecode: 2, cPrefill: 2, cDecode: 2,
+			expectedA: [2]int32{2, 2}, expectedB: [2]int32{1, 1}, expectedC: [2]int32{2, 2},
 		},
 	}
 

--- a/disaggregatedset/internal/controller/planner.go
+++ b/disaggregatedset/internal/controller/planner.go
@@ -268,13 +268,15 @@ func tryScaleUp(currentOld, currentNew, nextNew RoleReplicaState, source, target
 }
 
 // tryProportionalDrain attempts to drain old replicas using linear interpolation.
-func tryProportionalDrain(source, currentOld, currentNew RoleReplicaState, minOld []int, totalSteps int) *UpdateStep {
+func tryProportionalDrain(source, currentOld, currentNew, targetNew RoleReplicaState, minOld []int, totalSteps int, config []RollingUpdateConfig) *UpdateStep {
 	nextOld := computeNextOldReplicas(source, currentOld, totalSteps)
 
 	// Apply maxUnavailable floor
 	for i := range nextOld {
 		nextOld[i] = max(nextOld[i], minOld[i])
 	}
+
+	applyOrphanPrevention(nextOld, currentNew, source, targetNew, config)
 
 	needsScaleDown := false
 	for i := range nextOld {
@@ -289,14 +291,73 @@ func tryProportionalDrain(source, currentOld, currentNew RoleReplicaState, minOl
 	return &UpdateStep{Past: nextOld, New: currentNew}
 }
 
-// tryForceDrain drains exactly enough old replicas to unblock the next scale-up.
-func tryForceDrain(currentOld, currentNew, nextNew RoleReplicaState, source, targetNew RoleReplicaState, config []RollingUpdateConfig, minOld []int) *UpdateStep {
+// canDrainAllToZero checks if all roles have sufficient new replicas to satisfy
+// maxUnavailable after draining all old replicas to 0.
+func canDrainAllToZero(nextNew, source, target RoleReplicaState, config []RollingUpdateConfig) bool {
+	for i := range target {
+		if source[i] >= target[i] {
+			minRequired := target[i] - config[i].MaxUnavailable
+			if nextNew[i] < minRequired {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// applyOrphanPrevention adjusts nextOld to prevent orphan situations where one role
+// drains to 0 while others still have old replicas. If any role would drain to 0:
+//   - If all roles can safely drain (satisfy maxUnavailable): drain all to 0
+//   - Otherwise: keep would-be-zero roles at 1 until safe to drain together
+func applyOrphanPrevention(nextOld, currentNew, source, target RoleReplicaState, config []RollingUpdateConfig) {
+	anyDrainsToZero := false
+	allDrainToZero := true
+	for i := range nextOld {
+		if source[i] == 0 {
+			continue
+		}
+		if nextOld[i] == 0 {
+			anyDrainsToZero = true
+		} else {
+			allDrainToZero = false
+		}
+	}
+
+	// No orphan situation
+	if !anyDrainsToZero || allDrainToZero {
+		return
+	}
+
+	// Orphan detected: some roles drain to 0 but not all
+	if canDrainAllToZero(currentNew, source, target, config) {
+		for i := range nextOld {
+			nextOld[i] = 0
+		}
+		return
+	}
+
+	// Can't drain all yet - keep would-be-zero roles at 1
+	for i := range nextOld {
+		if nextOld[i] == 0 && source[i] > 0 {
+			nextOld[i] = 1
+		}
+	}
+}
+
+// tryForceDrain drains exactly enough old replicas to unblock the next scale-up,
+// and performs the scale-up in the same step to avoid capacity dips.
+func tryForceDrain(currentOld, currentNew, nextNew RoleReplicaState, source, targetNew RoleReplicaState, config []RollingUpdateConfig) *UpdateStep {
 	drainedOld := make([]int, len(currentOld))
 	needsDrain := false
+
 	for i := range currentOld {
 		maxOld := targetNew[i] + config[i].MaxSurge - nextNew[i]
 		drainedOld[i] = max(0, min(currentOld[i], maxOld))
-		drainedOld[i] = max(drainedOld[i], minOld[i]) // Enforce maxUnavailable
+		// Compute minOld using nextNew to ensure maxUnavailable is respected
+		if source[i] >= targetNew[i] {
+			minOldForRole := max(0, targetNew[i]-config[i].MaxUnavailable-nextNew[i])
+			drainedOld[i] = max(drainedOld[i], minOldForRole)
+		}
 		if drainedOld[i] < currentOld[i] {
 			needsDrain = true
 		}
@@ -304,12 +365,16 @@ func tryForceDrain(currentOld, currentNew, nextNew RoleReplicaState, source, tar
 	if !needsDrain {
 		return nil
 	}
-	return &UpdateStep{Past: drainedOld, New: currentNew}
+
+	applyOrphanPrevention(drainedOld, nextNew, source, targetNew, config)
+
+	return &UpdateStep{Past: drainedOld, New: nextNew}
 }
 
 // ComputeNextStep computes the next step in the rolling update.
 // Returns nil when no more steps are needed (current state equals target).
-// Each step changes EITHER old OR new replicas, not both (decoupled steps).
+// Steps are generally decoupled (change old OR new), but when maxSurge=0 forces
+// a drain before scale-up, both are combined to avoid capacity dips.
 func ComputeNextStep(source, currentOld, currentNew, targetNew RoleReplicaState, config []RollingUpdateConfig) *UpdateStep {
 	if isComplete(currentOld, currentNew, targetNew) {
 		return nil
@@ -335,10 +400,10 @@ func ComputeNextStep(source, currentOld, currentNew, targetNew RoleReplicaState,
 	if step := tryScaleUp(currentOld, currentNew, nextNew, source, targetNew, config); step != nil {
 		return step
 	}
-	if step := tryProportionalDrain(source, currentOld, currentNew, minOld, totalSteps); step != nil {
+	if step := tryProportionalDrain(source, currentOld, currentNew, targetNew, minOld, totalSteps, config); step != nil {
 		return step
 	}
-	if step := tryForceDrain(currentOld, currentNew, nextNew, source, targetNew, config, minOld); step != nil {
+	if step := tryForceDrain(currentOld, currentNew, nextNew, source, targetNew, config); step != nil {
 		return step
 	}
 

--- a/disaggregatedset/internal/controller/planner_test.go
+++ b/disaggregatedset/internal/controller/planner_test.go
@@ -288,6 +288,7 @@ func TestComputeAllSteps_ExactSequence(t *testing.T) {
 		{
 			// Surge constraint: old + new <= 10 + 3 = 13
 			// Interleaves scale-up and scale-down to respect surge
+			// When surge blocks scale-up, drain+scale-up are combined to avoid capacity dips
 			name:        "large_10_10_surge3",
 			sourceRole0: 10, sourceRole1: 10, targetRole0: 10, targetRole1: 10,
 			config: []RollingUpdateConfig{{MaxSurge: 3}, {MaxSurge: 3}},
@@ -296,8 +297,7 @@ func TestComputeAllSteps_ExactSequence(t *testing.T) {
 				step([]int{10, 10}, []int{3, 3}), // scale up (10+3=13)
 				step([]int{8, 8}, []int{3, 3}),   // scale down
 				step([]int{8, 8}, []int{5, 5}),   // scale up (8+5=13)
-				step([]int{5, 5}, []int{5, 5}),   // scale down (to allow 8)
-				step([]int{5, 5}, []int{8, 8}),   // scale up (5+8=13)
+				step([]int{5, 5}, []int{8, 8}),   // drain+scale combined (5+8=13)
 				step([]int{3, 3}, []int{8, 8}),   // scale down (to allow 10)
 				step([]int{3, 3}, []int{10, 10}), // scale up (3+10=13)
 				step([]int{0, 0}, []int{10, 10}), // final drain
@@ -339,6 +339,7 @@ func TestComputeAllSteps_ExactSequence(t *testing.T) {
 		{
 			// Scale up 4→6 with surge=1: max total = 6+1 = 7
 			// Interleaves scale-up and scale-down to respect surge
+			// When surge blocks scale-up, drain+scale-up are combined to avoid capacity dips
 			name:        "scale_up_4_4_to_6_6",
 			sourceRole0: 4, sourceRole1: 4, targetRole0: 6, targetRole1: 6,
 			config: DefaultRollingUpdateConfig(2),
@@ -347,12 +348,9 @@ func TestComputeAllSteps_ExactSequence(t *testing.T) {
 				step([]int{4, 4}, []int{1, 1}), // scale up (4+1=5)
 				step([]int{4, 4}, []int{2, 2}), // scale up (4+2=6)
 				step([]int{4, 4}, []int{3, 3}), // scale up (4+3=7)
-				step([]int{3, 3}, []int{3, 3}), // scale down (to allow 4)
-				step([]int{3, 3}, []int{4, 4}), // scale up (3+4=7)
-				step([]int{2, 2}, []int{4, 4}), // scale down (to allow 5)
-				step([]int{2, 2}, []int{5, 5}), // scale up (2+5=7)
-				step([]int{1, 1}, []int{5, 5}), // scale down (to allow 6)
-				step([]int{1, 1}, []int{6, 6}), // scale up (1+6=7)
+				step([]int{3, 3}, []int{4, 4}), // drain+scale combined (3+4=7)
+				step([]int{2, 2}, []int{5, 5}), // drain+scale combined (2+5=7)
+				step([]int{1, 1}, []int{6, 6}), // drain+scale combined (1+6=7)
 				step([]int{0, 0}, []int{6, 6}), // final drain
 			},
 		},
@@ -952,6 +950,9 @@ func TestNRole_RolloutCompletes(t *testing.T) {
 		{"scale_down_prefill_up_decode", []int{10, 2}, []int{6, 8}, []int{2, 2}, []int{0, 0}},
 		{"scale_down_both", []int{10, 10}, []int{4, 4}, []int{2, 2}, []int{0, 0}},
 		{"scale_down_asymmetric", []int{8, 4}, []int{3, 2}, []int{1, 1}, []int{0, 0}},
+
+		// maxUnavailable constraint regression test (asymmetric roles)
+		{"unavail_asymmetric_5_2", []int{5, 2}, []int{5, 2}, []int{0, 0}, []int{1, 1}},
 	}
 
 	for _, tc := range testCases {
@@ -1004,6 +1005,49 @@ func TestNRole_SurgeConstraint(t *testing.T) {
 						"step %d, role %d: old(%d) + new(%d) = %d exceeds target(%d) + surge(%d) = %d",
 						stepIdx, roleIdx, s.Past[roleIdx], s.New[roleIdx], actual,
 						tc.target[roleIdx], tc.surge[roleIdx], maxAllowed)
+				}
+			}
+		})
+	}
+}
+
+func TestNRole_UnavailableConstraint(t *testing.T) {
+	testCases := []struct {
+		name    string
+		source  []int
+		target  []int
+		unavail []int
+	}{
+		{"symmetric_4_4", []int{4, 4}, []int{4, 4}, []int{1, 1}},
+		{"asymmetric_5_2", []int{5, 2}, []int{5, 2}, []int{1, 1}},
+		{"asymmetric_2_5", []int{2, 5}, []int{2, 5}, []int{1, 1}},
+		{"3role_symmetric", []int{3, 3, 3}, []int{3, 3, 3}, []int{1, 1, 1}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := make([]RollingUpdateConfig, len(tc.source))
+			for i := range cfg {
+				cfg[i] = RollingUpdateConfig{MaxUnavailable: tc.unavail[i]}
+			}
+			steps := ComputeAllSteps(tc.source, tc.target, cfg)
+
+			// Verify rollout completes
+			require.True(t, completes(steps, tc.target), "rollout should complete")
+
+			// Verify per-role maxUnavailable constraint: old[i] + new[i] >= target[i] - unavail[i]
+			// Only enforced when source[i] >= target[i] (system had enough replicas)
+			for stepIdx, s := range steps {
+				for roleIdx := range tc.target {
+					if tc.source[roleIdx] < tc.target[roleIdx] {
+						continue // Scale-up scenario, maxUnavailable not enforced
+					}
+					minRequired := tc.target[roleIdx] - tc.unavail[roleIdx]
+					actual := s.Past[roleIdx] + s.New[roleIdx]
+					assert.GreaterOrEqual(t, actual, minRequired,
+						"step %d, role %d: old(%d) + new(%d) = %d below target(%d) - unavail(%d) = %d",
+						stepIdx, roleIdx, s.Past[roleIdx], s.New[roleIdx], actual,
+						tc.target[roleIdx], tc.unavail[roleIdx], minRequired)
 				}
 			}
 		})

--- a/disaggregatedset/test/e2e/e2e_test.go
+++ b/disaggregatedset/test/e2e/e2e_test.go
@@ -963,6 +963,122 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 		})
 	})
 
+	Context("Mid-rollout A→B→C (newest-first drain)", func() {
+		const deploymentName = "test-abc-drain"
+
+		AfterEach(func() {
+			kubectl.CleanupDeployment(deploymentName)
+		})
+
+		It("should drain B (broken intermediate) before A (stable original)", func() {
+			By("creating initial deployment A (6 replicas per role)")
+			yamlA := fixtures.PrefillDecode(deploymentName,
+				fixtures.Role{Replicas: 6, HasRollout: true, MaxSurge: 1},
+				fixtures.Role{Replicas: 6, HasRollout: true, MaxSurge: 1},
+			).YAML()
+			Expect(applyYAML(yamlA)).To(Succeed())
+			kubectl.ForRunningPodCountWithTimeout(deploymentName, 12, 3*time.Minute)
+			revisionA := kubectl.GetRevision(deploymentName)
+			Expect(revisionA).NotTo(BeEmpty())
+			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Revision A (stable original): %s ===\n", revisionA)
+
+			By("triggering update B (simulates bad deploy)")
+			yamlB := fixtures.PrefillDecode(deploymentName,
+				fixtures.Role{Replicas: 6, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: 1},
+				fixtures.Role{Replicas: 6, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: 1},
+			).YAML()
+			Expect(applyYAML(yamlB)).To(Succeed())
+
+			By("waiting for B rollout to start (new LWS created)")
+			Eventually(func() int {
+				return kubectl.CountLWS(deploymentName)
+			}, 30*time.Second, time.Second).Should(BeNumerically(">", 2))
+
+			// Find revision B
+			revisionB := ""
+			Eventually(func(g Gomega) {
+				output, err := kubectl.LWS(deploymentName).
+					JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/revision}{"\n"}{end}`).
+					RunQuiet()
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, rev := range kubectl.GetNonEmptyLines(output) {
+					if rev != revisionA {
+						revisionB = rev
+					}
+				}
+				g.Expect(revisionB).NotTo(BeEmpty())
+			}, 30*time.Second, time.Second).Should(Succeed())
+			_, _ = fmt.Fprintf(GinkgoWriter, "=== Revision B (bad intermediate): %s ===\n", revisionB)
+
+			By("waiting for B to partially roll out (at least 3 prefill ready)")
+			Eventually(func() int {
+				output, _ := kubectl.LWSByRevision(deploymentName, revisionB).
+					JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/role} {.status.readyReplicas}{"\n"}{end}`).
+					RunQuiet()
+				for _, line := range kubectl.GetNonEmptyLines(output) {
+					parts := strings.Fields(line)
+					if len(parts) == 2 && parts[0] == "prefill" {
+						n, _ := strconv.Atoi(parts[1])
+						return n
+					}
+				}
+				return 0
+			}, 3*time.Minute, time.Second).Should(BeNumerically(">=", 3), "B prefill should have at least 3 ready replicas")
+
+			By("triggering update C (the fix) mid-rollout")
+			yamlC := fixtures.PrefillDecode(deploymentName,
+				fixtures.Role{Replicas: 6, Image: "registry.k8s.io/pause:3.8", HasRollout: true, MaxSurge: 1},
+				fixtures.Role{Replicas: 6, Image: "registry.k8s.io/pause:3.8", HasRollout: true, MaxSurge: 1},
+			).YAML()
+			Expect(applyYAML(yamlC)).To(Succeed())
+
+			// Find revision C
+			revisionC := ""
+			Eventually(func(g Gomega) {
+				output, err := kubectl.LWS(deploymentName).
+					JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/revision}{"\n"}{end}`).
+					RunQuiet()
+				g.Expect(err).NotTo(HaveOccurred())
+				for _, rev := range kubectl.GetNonEmptyLines(output) {
+					if rev != revisionA && rev != revisionB {
+						revisionC = rev
+					}
+				}
+				g.Expect(revisionC).NotTo(BeEmpty())
+			}, 30*time.Second, time.Second).Should(Succeed())
+			_, _ = fmt.Fprintf(GinkgoWriter, "=== Revision C (the fix / target): %s ===\n\n", revisionC)
+
+			By("tracking drain order: B must drain to 0 before A")
+			bDrainedFirst := false
+			aDrainedBeforeB := false
+
+			Eventually(func(g Gomega) bool {
+				aTotal := kubectl.GetTotalReplicas(deploymentName, revisionA)
+				bTotal := kubectl.GetTotalReplicas(deploymentName, revisionB)
+				cTotal := kubectl.GetTotalReplicas(deploymentName, revisionC)
+
+				_, _ = fmt.Fprintf(GinkgoWriter, "A(%s)=%d  B(%s)=%d  C(%s)=%d\n",
+					revisionA[:8], aTotal, revisionB[:8], bTotal, revisionC[:8], cTotal)
+
+				if bTotal == 0 && aTotal > 0 {
+					bDrainedFirst = true
+				}
+				if aTotal == 0 && bTotal > 0 {
+					aDrainedBeforeB = true
+				}
+
+				return aTotal == 0 && bTotal == 0
+			}, 5*time.Minute, 500*time.Millisecond).Should(BeTrue(), "both A and B should fully drain")
+
+			Expect(bDrainedFirst).To(BeTrue(), "B (newer intermediate) should drain to 0 before A (stable original)")
+			Expect(aDrainedBeforeB).To(BeFalse(), "A should NOT drain to 0 while B still has replicas")
+
+			By("verifying final state: only C at target replicas")
+			kubectl.ForSingleActiveRevision(deploymentName)
+			kubectl.ForRunningPodCount(deploymentName, 12)
+		})
+	})
+
 	Context("Rename role with rolling update ", func() {
 		const deploymentName = "test-rename-role"
 

--- a/disaggregatedset/test/e2e/e2e_test.go
+++ b/disaggregatedset/test/e2e/e2e_test.go
@@ -568,7 +568,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 				TargetDecode:  8,
 				PrefillSurge:  2,
 				DecodeSurge:   2,
-				// Expected steps from: go run ./cmd/plan-steps --source-role0 10 --source-role1 2 --target-role0 6 --target-role1 8 --role0-surge 2 --role1-surge 2
+				// Expected steps from: go run ./hack/plan-steps --source '{"prefill":10,"decode":2}' --target '{"prefill":6,"decode":8}' --surge '{"prefill":2,"decode":2}'
 				ExpectedSteps: []rolloutState{
 					{OldPrefill: 10, OldDecode: 2, NewPrefill: 0, NewDecode: 0}, // step 0: initial
 					{OldPrefill: 8, OldDecode: 2, NewPrefill: 0, NewDecode: 0},  // step 1: old role0 -2
@@ -581,6 +581,25 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 					{OldPrefill: 2, OldDecode: 1, NewPrefill: 5, NewDecode: 7},  // step 8: new role0 +1, new role1 +2
 					{OldPrefill: 2, OldDecode: 1, NewPrefill: 6, NewDecode: 8},  // step 9: new role0 +1, new role1 +1
 					{OldPrefill: 0, OldDecode: 0, NewPrefill: 6, NewDecode: 8},  // step 10: old role0 -2, old role1 -1
+				},
+			},
+			{
+				Name:           "surge-0-unavail-2-batches-by-unavailable",
+				SourcePrefill:  4,
+				SourceDecode:   4,
+				TargetPrefill:  4,
+				TargetDecode:   4,
+				PrefillSurge:   0,
+				DecodeSurge:    0,
+				PrefillUnavail: 2,
+				DecodeUnavail:  2,
+				// Expected steps from: go run ./hack/plan-steps --source '{"prefill":4,"decode":4}' --target '{"prefill":4,"decode":4}' --surge '{"prefill":0,"decode":0}' --unavailable '{"prefill":2,"decode":2}'
+				ExpectedSteps: []rolloutState{
+					{OldPrefill: 4, OldDecode: 4, NewPrefill: 0, NewDecode: 0}, // step 0: initial
+					{OldPrefill: 2, OldDecode: 2, NewPrefill: 0, NewDecode: 0}, // step 1: drain 2 each
+					{OldPrefill: 2, OldDecode: 2, NewPrefill: 2, NewDecode: 2}, // step 2: scale up 2 each
+					{OldPrefill: 0, OldDecode: 0, NewPrefill: 2, NewDecode: 2}, // step 3: drain 2 each
+					{OldPrefill: 0, OldDecode: 0, NewPrefill: 4, NewDecode: 4}, // step 4: scale up 2 each
 				},
 			},
 		}
@@ -597,8 +616,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			It(fmt.Sprintf("should track rollout steps for %s", tc.Name), func() {
 				By("creating initial DisaggregatedSet with source replicas")
 				initialYaml := fixtures.PrefillDecode(deploymentName,
-					fixtures.Role{Replicas: tc.SourcePrefill, HasRollout: true, MaxSurge: tc.PrefillSurge},
-					fixtures.Role{Replicas: tc.SourceDecode, HasRollout: true, MaxSurge: tc.DecodeSurge},
+					fixtures.Role{Replicas: tc.SourcePrefill, HasRollout: true, MaxSurge: tc.PrefillSurge, MaxUnavailable: tc.PrefillUnavail},
+					fixtures.Role{Replicas: tc.SourceDecode, HasRollout: true, MaxSurge: tc.DecodeSurge, MaxUnavailable: tc.DecodeUnavail},
 				).YAML()
 				Expect(applyYAML(initialYaml)).To(Succeed())
 
@@ -617,8 +636,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 				By("triggering rolling update by changing image and target replicas")
 				updatedYaml := fixtures.PrefillDecode(deploymentName,
-					fixtures.Role{Replicas: tc.TargetPrefill, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: tc.PrefillSurge},
-					fixtures.Role{Replicas: tc.TargetDecode, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: tc.DecodeSurge},
+					fixtures.Role{Replicas: tc.TargetPrefill, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: tc.PrefillSurge, MaxUnavailable: tc.PrefillUnavail},
+					fixtures.Role{Replicas: tc.TargetDecode, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: tc.DecodeSurge, MaxUnavailable: tc.DecodeUnavail},
 				).YAML()
 				Expect(applyYAML(updatedYaml)).To(Succeed())
 
@@ -1017,14 +1036,16 @@ func (s rolloutState) Equals(other rolloutState) bool {
 
 // rolloutTestCase defines a rolling update scenario to test
 type rolloutTestCase struct {
-	Name          string
-	SourcePrefill int
-	SourceDecode  int
-	TargetPrefill int
-	TargetDecode  int
-	PrefillSurge  int
-	DecodeSurge   int
-	ExpectedSteps []rolloutState
+	Name            string
+	SourcePrefill   int
+	SourceDecode    int
+	TargetPrefill   int
+	TargetDecode    int
+	PrefillSurge    int
+	DecodeSurge     int
+	PrefillUnavail  int
+	DecodeUnavail   int
+	ExpectedSteps   []rolloutState
 }
 
 // getCurrentRolloutState queries the cluster for current LWS replica counts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it
  - Fix coordinated drain: combine drain + scale-up in a single step when maxSurge=0 to avoid capacity dips; add orphan prevention so all roles drain to 0 together
  - Drain newest-first: when multiple old revisions exist (A→B→C), drain the newest old revision (B, the broken intermediate) before the stable original (A), preserving capacity safety
  - Fix maxSurge=0 ignored: extractRollingUpdateConfig couldn't distinguish "not set" from "set to 0", silently defaulting to maxSurge=1 and causing 1-by-1 draining instead of batched.


#### Special notes for your reviewer
This PR doesn't need to be merged.

#### Does this PR introduce a user-facing change?
No.
