### PR TITLE
Bump gcb-docker-gcloud image to v20260127-c1affcc8de

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3000s
 # For each build step, Prow executes a job.
 steps:
 # see https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de
     entrypoint: make
     args:
       - image-push


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it

The pinned builder image tag was deleted from gcr.io, breaking every `post-lws-push-images` run:

```
gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
manifest unknown: Failed to fetch
```

Failed build: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-lws-push-images/2050277944814735360

Bump to `v20260127-c1affcc8de`, the tag currently used by Kueue.

#### Which issue(s) this PR fixes

Fixes #834

#### Does this PR introduce a user-facing change?

```release-note
NONE
```