### PR TITLE
fix: include underlying error in worker statefulset FailedCreate event

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -191,7 +191,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		if err = r.Create(ctx, workerStatefulSet); err != nil {
 			if client.IgnoreAlreadyExists(err) != nil {
-				r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create worker statefulset for leader pod %s", pod.Name))
+				r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create worker statefulset for leader pod %s: %v", pod.Name, err))
 			}
 			return ctrl.Result{}, client.IgnoreAlreadyExists(err)
 		}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

The worker statefulset `FailedCreate` event currently logs only the leader pod name and drops the underlying error from `r.Create(...)`. Operators inspecting `kubectl describe leaderworkerset` therefore see that a worker statefulset failed to create without any actionable information about *why* (missing volumes, quota exceeded, webhook rejections, etc.).

This change appends \`: %v\` with the error to the existing format string so the warning event is self-contained, mirroring:
- The leader statefulset path that PR #851 is currently updating.
- The headless service path that already formats the error (\`leaderworkerset_controller.go\`).

### Before

\`\`\`
Warning  FailedCreate  10s  leaderworkerset  Failed to create worker statefulset for leader pod lws-sample-0
\`\`\`

### After

\`\`\`
Warning  FailedCreate  10s  leaderworkerset  Failed to create worker statefulset for leader pod lws-sample-0: admission webhook \"validation.lws.x-k8s.io\" denied the request: spec.template.spec.containers[0].volumeMounts[1].name: Not found: \"hf-cache\"
\`\`\`

Verified locally with \`go build ./...\`, \`go vet ./...\`, and the existing unit tests in \`pkg/controllers/\`.

## Which issue(s) this PR fixes:

Partially addresses #845. Together with #851 (leader statefulset path), this closes the two non-trivial \`FailedCreate\` call sites flagged by @Edwinhr716 in [this comment](https://github.com/kubernetes-sigs/lws/issues/845#issuecomment-3499050000).

## Special notes for your reviewer:

- The change is intentionally one-line and scoped to the worker statefulset path so it can land independently of #851 with no merge conflict on \`leaderworkerset_controller.go\`.
- No new tests added because there is no existing event-emission test harness in \`pod_controller_test.go\` and this is a format-string change; happy to add one with a fake recorder if reviewers want it.
- A follow-up that surfaces non-ready pod \`Reason\`/\`Message\` through \`updateConditions()\` (the third item in @Mostafahassen1's [comment](https://github.com/kubernetes-sigs/lws/pull/851#issuecomment-3508900000)) can land separately once this and #851 are in.

## Does this PR introduce a user-facing change?
\`\`\`release-note
Worker statefulset \`FailedCreate\` events now include the underlying error so operators can diagnose creation failures directly from \`kubectl describe leaderworkerset\` without consulting controller logs.
\`\`\`

Made with [Cursor](https://cursor.com)