### PR TITLE
Fix DisaggregatedSet sample missing workerTemplate

### DIFF
--- a/config/samples/disaggregatedset_v1_disaggregatedset.yaml
+++ b/config/samples/disaggregatedset_v1_disaggregatedset.yaml
@@ -20,12 +20,32 @@ spec:
                   image: nginx:latest
                   ports:
                     - containerPort: 80
+          workerTemplate:
+            metadata:
+              labels:
+                role: prefill
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
     - name: decode
       spec:
         replicas: 2
         leaderWorkerTemplate:
           size: 1
           leaderTemplate:
+            metadata:
+              labels:
+                role: decode
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
+          workerTemplate:
             metadata:
               labels:
                 role: decode


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`LeaderWorkerTemplate.WorkerTemplate` is a required field on the API, but the in-tree `DisaggregatedSet` sample omits it. Applying the sample on `main` fails admission:

```
$ kubectl apply -f config/samples/disaggregatedset_v1_disaggregatedset.yaml
The DisaggregatedSet "disaggregatedset-sample" is invalid:
* spec.roles[0].spec.leaderWorkerTemplate.workerTemplate: Required value
* spec.roles[1].spec.leaderWorkerTemplate.workerTemplate: Required value
```

This PR adds a `workerTemplate` to each role (duplicating the leader pod spec, which is harmless since `size: 1` means no worker pods are actually created) so the sample applies cleanly out of the box.

Verified locally with `kubectl apply --dry-run=server` against the installed CRDs.

#### Which issue(s) this PR fixes

Fixes #865

#### Special notes for your reviewer

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
