### PR TITLE
Fix: (disaggregatedset) tighten ForSingleActiveRevision waiter

### DIFF
--- a/test/e2e/disaggregatedset/e2e_test.go
+++ b/test/e2e/disaggregatedset/e2e_test.go
@@ -190,6 +190,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("waiting for initial deployment to stabilize")
 			kubectl.ForRunningPodCount(deploymentName, 4)
 
+			oldRevision := kubectl.GetRevision(deploymentName)
+			Expect(oldRevision).NotTo(BeEmpty())
+
 			By("triggering rolling update by changing image")
 			yamlV2 := fixtures.PrefillDecode(deploymentName,
 				fixtures.Role{Replicas: 2, Image: "registry.k8s.io/pause:3.10"},
@@ -198,7 +201,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(yamlV2)).To(Succeed())
 
 			By("waiting for rolling update to complete")
-			kubectl.ForSingleActiveRevision(deploymentName)
+			kubectl.ForSingleActiveRevision(deploymentName, oldRevision)
 
 			By("verifying no orphaned single-role workloads exist")
 			output, err := kubectl.LWS(deploymentName).
@@ -247,6 +250,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("waiting for initial deployment to stabilize")
 			kubectl.ForRunningPodCount(deploymentName, 8)
 
+			oldRevision := kubectl.GetRevision(deploymentName)
+			Expect(oldRevision).NotTo(BeEmpty())
+
 			By("triggering rolling update by changing image")
 			yamlV2 := fixtures.PrefillDecode(deploymentName,
 				fixtures.Role{Replicas: 4, Image: "registry.k8s.io/pause:3.10", HasRollout: true, MaxSurge: intstr.FromString("50%"), MaxUnavailable: intstr.FromString("25%")},
@@ -255,7 +261,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(yamlV2)).To(Succeed())
 
 			By("waiting for rolling update to complete")
-			kubectl.ForSingleActiveRevision(deploymentName)
+			kubectl.ForSingleActiveRevision(deploymentName, oldRevision)
 
 			By("verifying final state has correct replicas")
 			kubectl.ForRunningPodCount(deploymentName, 8)
@@ -728,6 +734,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("verifying 3 LWS resources exist (one per role)")
 			kubectl.ForLWSCount(deploymentName, 3)
 
+			oldRevision := kubectl.GetRevision(deploymentName)
+			Expect(oldRevision).NotTo(BeEmpty())
+
 			By("triggering rolling update by changing image")
 			updatedYaml := fixtures.Config{
 				Name: deploymentName,
@@ -740,7 +749,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(updatedYaml)).To(Succeed())
 
 			By("waiting for rolling update to complete")
-			kubectl.ForSingleActiveRevision(deploymentName)
+			kubectl.ForSingleActiveRevision(deploymentName, oldRevision)
 
 			By("verifying all 3 roles have correct pod count")
 			kubectl.ForRunningPodCount(deploymentName, 6)
@@ -1070,7 +1079,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(aDrainedBeforeB).To(BeFalse(), "A should NOT drain to 0 while B still has replicas")
 
 			By("verifying final state: only C at target replicas")
-			kubectl.ForSingleActiveRevision(deploymentName)
+			kubectl.ForSingleActiveRevision(deploymentName, revisionA)
 			kubectl.ForRunningPodCount(deploymentName, 12)
 		})
 	})

--- a/test/testutils/disaggregatedset/kubectl/waiters.go
+++ b/test/testutils/disaggregatedset/kubectl/waiters.go
@@ -65,33 +65,59 @@ func ForRevisionDrained(deploymentName, revision string) {
 	}, 4*time.Minute, 2*time.Second).Should(Succeed())
 }
 
-// ForSingleActiveRevision waits until only one revision has replicas > 0.
-func ForSingleActiveRevision(deploymentName string) {
+// ForSingleActiveRevision waits until oldRevision is fully drained and
+// exactly one other revision has every role at replicas > 0.
+// Passing oldRevision closes the "apply but not yet reconciled" window
+// where the old revision would otherwise satisfy a revision-agnostic check
+// before the rollout begins (kubernetes-sigs/lws#826).
+func ForSingleActiveRevision(deploymentName, oldRevision string) {
 	Eventually(func(g Gomega) {
 		output, err := LWS(deploymentName).
 			JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/revision} {.spec.replicas}{"\n"}{end}`).
 			RunQuiet()
 		g.Expect(err).NotTo(HaveOccurred())
 
-		revisionReplicas := make(map[string]int)
-		for _, line := range GetNonEmptyLines(output) {
-			fields := strings.Fields(line)
-			if len(fields) >= 2 {
-				rev := fields[0]
-				if n, err := strconv.Atoi(fields[1]); err == nil {
-					revisionReplicas[rev] += n
-				}
-			}
-		}
-
-		activeRevisions := 0
-		for _, replicas := range revisionReplicas {
-			if replicas > 0 {
-				activeRevisions++
-			}
-		}
-		g.Expect(activeRevisions).To(Equal(1), "Expected only one active revision")
+		g.Expect(evalSingleActiveRevision(output, oldRevision)).To(BeEmpty())
 	}, 4*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+// evalSingleActiveRevision is the pure-data predicate behind
+// ForSingleActiveRevision, extracted for unit testing.
+func evalSingleActiveRevision(output, oldRevision string) string {
+	revReplicas := make(map[string]int)
+	revZeroRoles := make(map[string]int)
+	for _, line := range GetNonEmptyLines(output) {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		n, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		revReplicas[fields[0]] += n
+		if n == 0 {
+			revZeroRoles[fields[0]]++
+		}
+	}
+
+	if total, ok := revReplicas[oldRevision]; ok && total > 0 {
+		return "old revision " + oldRevision + " not drained yet: total replicas=" + strconv.Itoa(total)
+	}
+
+	active := 0
+	for rev, total := range revReplicas {
+		if total > 0 {
+			if revZeroRoles[rev] != 0 {
+				return "revision " + rev + " mid-rollout: some roles still at 0 replicas"
+			}
+			active++
+		}
+	}
+	if active != 1 {
+		return "expected exactly one active revision, got " + strconv.Itoa(active)
+	}
+	return ""
 }
 
 // ForRoleReplicas waits until a role has the expected replica count.

--- a/test/testutils/disaggregatedset/kubectl/waiters_test.go
+++ b/test/testutils/disaggregatedset/kubectl/waiters_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import "testing"
+
+// TestEvalSingleActiveRevision pins the snapshot classes
+// ForSingleActiveRevision must distinguish. Case A used to escape because
+// the predicate was revision-agnostic; threading oldRevision closes it.
+// See kubernetes-sigs/lws#826.
+func TestEvalSingleActiveRevision(t *testing.T) {
+	const oldRev = "oldRev"
+
+	cases := []struct {
+		name     string
+		output   string
+		wantPass bool
+	}{
+		{
+			name:     "A_apply_but_not_reconciled",
+			output:   "oldRev 2\noldRev 2",
+			wantPass: false,
+		},
+		{
+			name:     "B_mid_rollout_new_partial",
+			output:   "oldRev 0\noldRev 0\nnewRev 1\nnewRev 0",
+			wantPass: false,
+		},
+		{
+			name:     "C_rollout_complete",
+			output:   "oldRev 0\noldRev 0\nnewRev 2\nnewRev 2",
+			wantPass: true,
+		},
+		{
+			name:     "D_two_revisions_active",
+			output:   "oldRev 2\noldRev 2\nnewRev 2\nnewRev 2",
+			wantPass: false,
+		},
+		{
+			name:     "E_old_drained_new_partial_start",
+			output:   "oldRev 0\noldRev 0\nnewRev 0\nnewRev 1",
+			wantPass: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reason := evalSingleActiveRevision(c.output, oldRev)
+			gotPass := reason == ""
+			if gotPass != c.wantPass {
+				t.Fatalf("want pass=%v, got pass=%v reason=%q", c.wantPass, gotPass, reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

`ForSingleActiveRevision` summed `spec.replicas` across all roles of a revision and treated any revision with sum > 0 as active. Two escape windows let the waiter return before the rollout was actually settled:

1. **Mid-rollout** — during coordinated drain the new revision briefly has one role scaled up (e.g. `prefill=1, decode=0`); the waiter returned, and the next assertion reported the revision as orphaned.
2. **Apply-but-not-reconciled** — immediately after `kubectl apply`, only the old revision exists with all roles `> 0`. The revision-agnostic check accepted that as a single active revision before the controller had even created the new revision, so the rollout was effectively unverified.

This PR:

- Tracks per-revision how many role LWS still have `replicas=0` and only treats a revision as active when its total is `> 0` AND no role is at 0.
- Threads the old revision through the waiter and requires it to be drained before declaring the rollout settled. All e2e callers updated to pass `oldRevision`.
- Extracts the predicate as `evalSingleActiveRevision` and adds table-driven unit tests for the snapshot classes.

The waiter copy under `disaggregatedset/test/utils/kubectl/waiters.go` is left untouched — that folder is dead code, removed as part of #789. Supersedes #828.

## Which issue(s) this PR fixes

Fixes #826

## Does this PR introduce a user-facing change?

```release-note
NONE
```
