### PR TITLE
Update e2e Kind version to Kubernetes 1.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ARTIFACTS ?= $(PROJECT_DIR)/bin
 
 INTEGRATION_TARGET ?= ./test/integration/...
 
-E2E_KIND_VERSION ?= kindest/node:v1.35.0
+E2E_KIND_VERSION ?= kindest/node:v1.36.1
 CERT_MANAGER_VERSION ?= v1.17.0
 USE_EXISTING_CLUSTER ?= false
 
@@ -160,7 +160,7 @@ test: manifests fmt vet envtest gotestsum ## Run tests.
 KIND = $(shell pwd)/bin/kind
 .PHONY: kind
 kind:
-	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install sigs.k8s.io/kind@v0.27.0
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install sigs.k8s.io/kind@v0.32.0
 
 .PHONY: kind-image-build
 kind-image-build: PLATFORMS=linux/amd64


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

Updates the default e2e Kind node image to Kubernetes 1.36 and bumps the Kind CLI used by the Makefile to a version that supports that node image.

This follows up on https://github.com/kubernetes-sigs/lws/pull/856, which updated Kubernetes dependencies and envtest to 1.36. It also aligns the local e2e default with the Kubernetes 1.36 coverage added in https://github.com/kubernetes/test-infra/pull/37222.

#### Which issue(s) this PR fixes

Part of https://github.com/kubernetes-sigs/lws/issues/751

#### Special notes for your reviewer

Validation:
- [x] `git diff --check -- Makefile`
- [x] `make -n test-e2e`
- [x] Root e2e suite on `kindest/node:v1.36.1`: 17 passed, 5 skipped
- [x] Root e2e suite on `kindest/node:v1.35.5`: 17 passed, 5 skipped

Note: local full `make test-e2e` also enters the unrelated DisaggregatedSet suite; this cleanup uses the root e2e suite as the gating signal for the Kind/Kubernetes version bump.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
