### PR TITLE
docs: add DisaggregatedSet API reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ toc-verify:
 
 .PHONY: generate-apiref
 generate-apiref: genref
-	cd $(PROJECT_DIR)/hack/genref/ && $(GENREF) -o $(PROJECT_DIR)/site/content/en/docs/reference
+	cd $(PROJECT_DIR)/hack/genref/ && $(GENREF) -o $(PROJECT_DIR)/site/content/en/docs/reference --include leaderworkerset,disaggregatedset
 
 HELM = $(PROJECT_DIR)/bin/helm
 .PHONY: helm

--- a/api/disaggregatedset/v1/disaggregatedset_types.go
+++ b/api/disaggregatedset/v1/disaggregatedset_types.go
@@ -120,6 +120,7 @@ type DisaggregatedSetStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DisaggregatedSet is the Schema for the disaggregatedsets API
 type DisaggregatedSet struct {
@@ -127,7 +128,7 @@ type DisaggregatedSet struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec defines the desired state of DisaggregatedSet
 	// +required
@@ -135,7 +136,7 @@ type DisaggregatedSet struct {
 
 	// status defines the observed state of DisaggregatedSet
 	// +optional
-	Status DisaggregatedSetStatus `json:"status,omitzero"`
+	Status DisaggregatedSetStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -143,7 +144,7 @@ type DisaggregatedSet struct {
 // DisaggregatedSetList contains a list of DisaggregatedSet
 type DisaggregatedSetList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitzero"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DisaggregatedSet `json:"items"`
 }
 

--- a/site/content/en/docs/reference/disaggregatedset.v1.md
+++ b/site/content/en/docs/reference/disaggregatedset.v1.md
@@ -10,7 +10,43 @@ description: Generated API reference documentation for disaggregatedset.x-k8s.io
 ## Resource Types 
 
 
+- [DisaggregatedSet](#disaggregatedset-x-k8s-io-v1-DisaggregatedSet)
   
+
+## `DisaggregatedSet`     {#disaggregatedset-x-k8s-io-v1-DisaggregatedSet}
+    
+
+**Appears in:**
+
+
+
+<p>DisaggregatedSet is the Schema for the disaggregatedsets API</p>
+
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
+<tbody>
+    
+<tr><td><code>apiVersion</code><br/>string</td><td><code>disaggregatedset.x-k8s.io/v1</code></td></tr>
+<tr><td><code>kind</code><br/>string</td><td><code>DisaggregatedSet</code></td></tr>
+    
+  
+<tr><td><code>spec</code> <B>[Required]</B><br/>
+<a href="#disaggregatedset-x-k8s-io-v1-DisaggregatedSetSpec"><code>DisaggregatedSetSpec</code></a>
+</td>
+<td>
+   <p>spec defines the desired state of DisaggregatedSet</p>
+</td>
+</tr>
+<tr><td><code>status</code><br/>
+<a href="#disaggregatedset-x-k8s-io-v1-DisaggregatedSetStatus"><code>DisaggregatedSetStatus</code></a>
+</td>
+<td>
+   <p>status defines the observed state of DisaggregatedSet</p>
+</td>
+</tr>
+</tbody>
+</table>
 
 ## `DisaggregatedRoleSpec`     {#disaggregatedset-x-k8s-io-v1-DisaggregatedRoleSpec}
     
@@ -46,38 +82,6 @@ RolloutStrategy.RollingUpdateConfiguration.Partition must not be set).</p>
 Note: Spec.RolloutStrategy.Type must be RollingUpdate (or empty) and
 Spec.RolloutStrategy.RollingUpdateConfiguration.Partition must not be set.
 DisaggregatedSet handles rollouts across roles.</p>
-</td>
-</tr>
-</tbody>
-</table>
-
-## `DisaggregatedSet`     {#disaggregatedset-x-k8s-io-v1-DisaggregatedSet}
-    
-
-**Appears in:**
-
-
-
-<p>DisaggregatedSet is the Schema for the disaggregatedsets API</p>
-
-
-<table class="table">
-<thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
-<tbody>
-    
-  
-<tr><td><code>spec</code> <B>[Required]</B><br/>
-<a href="#disaggregatedset-x-k8s-io-v1-DisaggregatedSetSpec"><code>DisaggregatedSetSpec</code></a>
-</td>
-<td>
-   <p>spec defines the desired state of DisaggregatedSet</p>
-</td>
-</tr>
-<tr><td><code>status,omitzero</code><br/>
-<a href="#disaggregatedset-x-k8s-io-v1-DisaggregatedSetStatus"><code>DisaggregatedSetStatus</code></a>
-</td>
-<td>
-   <p>status defines the observed state of DisaggregatedSet</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

Adds generated `v1` API reference documentation for `DisaggregatedSet` and documents the DisaggregatedSet labels and rollout annotation.

This preserves the DisaggregatedSet reference content before the legacy `disaggregatedset/` directory is removed in a follow-up cleanup.

#### Which issue(s) this PR fixes

Related to https://github.com/kubernetes-sigs/lws/issues/789.

#### Special notes for your reviewer

This PR includes a few generator-related changes so the new API reference can be generated reproducibly with the current `genref v0.28.0` tool:

- Adds `api/disaggregatedset/v1/doc.go` so `genref` can discover the `disaggregatedset.x-k8s.io` API group.
- Adds `DisaggregatedSet` to `hack/genref/config.yaml`.
- Generates `leaderworkerset` and `disaggregatedset` reference pages separately via `--include`. This keeps the embedded `LeaderWorkerSetTemplateSpec` in the DisaggregatedSet page linked to `leaderworkerset.v1.md` instead of producing a broken same-page anchor.
- Adds the `leaderworkerset/v1` external package rule used by that cross-page link.
- Adds `+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object` to `DisaggregatedSet` because `genref v0.28.0` recognizes resource types through `+genclient` or this marker, but not through `+kubebuilder:object:root=true` alone.
- Changes root object `metadata`, `status`, and list `metadata` JSON tags from `omitzero` to `omitempty`, matching the existing `LeaderWorkerSet` root object style and avoiding `genref v0.28.0` rendering `,omitzero` as part of the field name.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
