### PR TITLE
docs: document safe Helm upgrade path for CRDs

### DIFF
--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -94,10 +94,11 @@ kubectl apply --server-side --force-conflicts \
 helm upgrade lws charts/lws --namespace lws-system
 ```
 
-> **Note**: do not run `helm uninstall` followed by `helm install` to "refresh"
-> CRDs. Uninstalling deletes the CRDs, which cascades to the deletion of every
-> `LeaderWorkerSet` and `DisaggregatedSet` custom resource in the cluster. Always
-> upgrade in place and reconcile CRDs with the `kubectl apply` step above.
+> **Note**: neither `helm upgrade` nor `helm uninstall` + `helm install` will
+> update CRD schemas — Helm never modifies CRDs placed in the `crds/` directory
+> after the initial install, and does not delete them on `helm uninstall` either.
+> Always reconcile CRD schemas explicitly with the `kubectl apply` step above
+> before upgrading.
 
 ### Configuration
 

--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -8,6 +8,7 @@
     - [Installing the chart](#installing-the-chart)
         - [Install chart using Helm v3.0+](#install-chart-using-helm-v30)
         - [Verify that controller pods are running properly.](#verify-that-controller-pods-are-running-properly)
+    - [Upgrading the chart](#upgrading-the-chart)
     - [Configuration](#configuration)
 <!-- /toc -->
 
@@ -68,17 +69,35 @@ controller are always installed with the chart. To also install the
 editor/viewer/admin ClusterRoles and validating webhook, set
 `enableDisaggregatedSet` to `true`.
 
-Helm installs CRDs during `helm install`, but does not install newly added CRDs
-during `helm upgrade`. Before upgrading an existing LWS Helm release to a chart
-version that introduces DisaggregatedSet, apply the new CRD from the repository
-root:
+### Upgrading the chart
+
+The chart ships its CRDs under the special `crds/` directory. Helm installs the
+files in that directory only during the initial `helm install`; it never updates
+or deletes them on `helm upgrade` (see the
+[Helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)).
+
+This has two consequences when upgrading an existing release:
+
+- CRD schema changes (new fields, printer columns, conversion settings, etc.) do
+  **not** reach the cluster through `helm upgrade`.
+- A newly added CRD (for example `DisaggregatedSet`) is **not** installed by
+  `helm upgrade`.
+
+Apply the CRDs explicitly before upgrading so the cluster always has the schema
+the new chart version expects. `--server-side` lets the apply coexist with the
+ownership Helm records for the resource:
 
 ```bash
-kubectl apply --server-side \
+kubectl apply --server-side --force-conflicts \
+  -f charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml \
   -f charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
-helm upgrade lws charts/lws --namespace lws-system \
-  --set enableDisaggregatedSet=true
+helm upgrade lws charts/lws --namespace lws-system
 ```
+
+> **Note**: do not run `helm uninstall` followed by `helm install` to "refresh"
+> CRDs. Uninstalling deletes the CRDs, which cascades to the deletion of every
+> `LeaderWorkerSet` and `DisaggregatedSet` custom resource in the cluster. Always
+> upgrade in place and reconcile CRDs with the `kubectl apply` step above.
 
 ### Configuration
 

--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -100,6 +100,27 @@ helm upgrade lws charts/lws --namespace lws-system
 > Always reconcile CRD schemas explicitly with the `kubectl apply` step above
 > before upgrading.
 
+#### Upgrading from v0.7.0 or earlier
+
+Chart versions up to v0.7.0 rendered the `LeaderWorkerSet` CRD from
+`templates/crds/`, so the CRD is part of the Helm release manifest. Starting
+with v0.8.0 the CRD ships from the `crds/` directory and is no longer part of
+the release. Without preparation, the first `helm upgrade` across that boundary
+treats the CRD as removed from the release and deletes it — cascading to the
+deletion of every `LeaderWorkerSet` in the cluster (see
+[#880](https://github.com/kubernetes-sigs/lws/issues/880)).
+
+Before the first upgrade from v0.7.0 or earlier, run this one-time step so Helm
+keeps the CRD when it leaves the release:
+
+```bash
+kubectl annotate crd leaderworkersets.leaderworkerset.x-k8s.io \
+  helm.sh/resource-policy=keep --overwrite
+```
+
+Then follow the regular upgrade flow above (apply the CRDs, then
+`helm upgrade`). Subsequent upgrades no longer need the annotation step.
+
 ### Configuration
 
 The following table lists the configurable parameters of the LWS chart and their default values.

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -73,6 +73,33 @@ helm install lws https://github.com/kubernetes-sigs/lws/releases/download/$VERSI
   --wait --timeout 300s
 ```
 
+### Upgrade by Helm
+
+Helm only installs the chart's CRDs during the initial `helm install`. It does
+not update or delete CRDs on `helm upgrade` (see the
+[Helm documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)),
+so CRD schema changes and newly added CRDs do not reach the cluster through
+`helm upgrade` alone.
+
+Apply the CRDs explicitly before upgrading, then upgrade the release in place:
+
+```shell
+CHART_VERSION=0.8.0
+helm pull oci://registry.k8s.io/lws/charts/lws --version=$CHART_VERSION --untar
+kubectl apply --server-side --force-conflicts -f lws/crds
+helm upgrade lws oci://registry.k8s.io/lws/charts/lws \
+  --version=$CHART_VERSION \
+  --namespace lws-system \
+  --wait --timeout 300s
+```
+
+{{% alert title="Warning" color="warning" %}}
+Do not run `helm uninstall` followed by `helm install` to refresh CRDs.
+`helm uninstall` deletes the CRDs, which cascades to the deletion of every
+`LeaderWorkerSet` custom resource in the cluster. Always upgrade in place and
+reconcile the CRDs with the `kubectl apply` step above.
+{{% /alert %}}
+
 ### Uninstall
 
 To uninstall a released version of LeaderWorkerSet from your cluster, run the following command:

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -93,11 +93,11 @@ helm upgrade lws oci://registry.k8s.io/lws/charts/lws \
   --wait --timeout 300s
 ```
 
-{{% alert title="Warning" color="warning" %}}
-Do not run `helm uninstall` followed by `helm install` to refresh CRDs.
-`helm uninstall` deletes the CRDs, which cascades to the deletion of every
-`LeaderWorkerSet` custom resource in the cluster. Always upgrade in place and
-reconcile the CRDs with the `kubectl apply` step above.
+{{% alert title="Note" color="info" %}}
+`helm upgrade` does not update CRD schemas — Helm never modifies CRDs placed
+in the `crds/` directory after the initial `helm install`, and does not delete
+them on `helm uninstall` either. Always reconcile CRD schemas explicitly with
+the `kubectl apply` step above before upgrading the chart.
 {{% /alert %}}
 
 ### Uninstall

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -100,6 +100,27 @@ them on `helm uninstall` either. Always reconcile CRD schemas explicitly with
 the `kubectl apply` step above before upgrading the chart.
 {{% /alert %}}
 
+#### Upgrading from v0.7.0 or earlier
+
+Chart versions up to v0.7.0 rendered the `LeaderWorkerSet` CRD from
+`templates/crds/`, so the CRD is part of the Helm release manifest. Starting
+with v0.8.0 the CRD ships from the special `crds/` directory and is no longer
+part of the release. Without preparation, the first `helm upgrade` across that
+boundary treats the CRD as removed from the release and deletes it — cascading
+to the deletion of every `LeaderWorkerSet` in the cluster (see
+[#880](https://github.com/kubernetes-sigs/lws/issues/880)).
+
+Before the first upgrade from v0.7.0 or earlier, run this one-time step so Helm
+keeps the CRD when it leaves the release:
+
+```shell
+kubectl annotate crd leaderworkersets.leaderworkerset.x-k8s.io \
+  helm.sh/resource-policy=keep --overwrite
+```
+
+Then follow the regular upgrade flow above (apply the CRDs, then
+`helm upgrade`). Subsequent upgrades no longer need the annotation step.
+
 ### Uninstall
 
 To uninstall a released version of LeaderWorkerSet from your cluster, run the following command:


### PR DESCRIPTION
## What this PR does / why we need it

When upgrading the LWS Helm release, Helm never updates or deletes the CRDs that ship under the chart's special `crds/` directory — it only installs them on the very first `helm install` (per the [Helm CRD best practices](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)). As a result CRD schema changes and newly added CRDs (e.g. `DisaggregatedSet`) never reach existing installations through `helm upgrade` alone, and there was no documented, safe in-place upgrade path. Users who worked around this with `helm uninstall` + `helm install` lost all their `LeaderWorkerSet` custom resources to the CRD cascade deletion.

This PR documents the supported upgrade procedure in both the chart README and the site installation docs:

- Apply the CRDs explicitly with `kubectl apply --server-side --force-conflicts` before running `helm upgrade`, covering both the `leaderworkerset` and `disaggregatedset` CRDs (the README previously documented only the `disaggregatedset` CRD).
- Add a new "Upgrade by Helm" section to `site/content/en/docs/installation/_index.md` (the site previously had no Helm upgrade guidance at all).
- Warn explicitly against the `helm uninstall` + `helm install` workaround, which deletes the CRDs and cascades to the deletion of every custom resource in the cluster.

This is documentation-only; the chart structure is unchanged. CRDs intentionally remain under `crds/` (moving them back into `templates/` would re-trigger the v0.7.0 to v0.8.0 deletion cascade for users already on the `crds/`-based release). The literal "bundle CRDs into a pre-upgrade hook Job" suggestion from the issue is impractical because the two CRD files are ~1.3 MB and ~1.5 MB and cannot fit in a ConfigMap (etcd object size limit), so the lowest-risk fix is to document the supported `kubectl apply` reconcile step that maintainers already adopted for the DisaggregatedSet CRD.

## Which issue(s) this PR fixes

Refs #880

## Does this PR introduce a user-facing change?

```release-note
docs: Document the safe in-place Helm upgrade path for LWS CRDs. Because Helm installs files under the chart's `crds/` directory only on the initial install, run `kubectl apply --server-side --force-conflicts -f <crds>` to reconcile the CRDs before `helm upgrade`; do not use `helm uninstall` + `helm install`, which deletes the CRDs and all LeaderWorkerSet custom resources.
```
