### PR TITLE
fix(helm): add pre-install/pre-upgrade hook for CRD management and prevent helm upgrade deleting v0.7.0 CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
 IMAGE_REGISTRY ?= ${STAGING_IMAGE_REGISTRY}/lws
 IMAGE_NAME := lws
 IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
+CRD_UPGRADER_IMG ?= $(IMAGE_REGISTRY)/lws-upgrade-crd
+CRD_UPGRADER_DOCKERFILE ?= tools/crd-upgrade/Dockerfile
 IMG ?= $(IMAGE_REPO):$(GIT_TAG)
 # Output type of docker buildx build
 OUTPUT_TYPE ?= image
@@ -232,6 +234,14 @@ image-build:
 		$(PUSH) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./
 
+.PHONY: docker-build-crd-upgrader
+docker-build-crd-upgrader: ## Build docker image for CRD upgrader.
+	$(CONTAINER_TOOL) build -f $(CRD_UPGRADER_DOCKERFILE) -t $(CRD_UPGRADER_IMG):$(GIT_TAG) .
+
+.PHONY: docker-push-crd-upgrader
+docker-push-crd-upgrader: ## Push docker image for CRD upgrader.
+	docker push $(CRD_UPGRADER_IMG):$(GIT_TAG)
+
 .PHONY: image-push
 image-push: PUSH=--push
 image-push: image-build
@@ -241,6 +251,13 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder --use
 	- $(MAKE) image-build PUSH=$(PUSH)
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
+
+.PHONY: docker-buildx-push-crd-upgrader
+docker-buildx-push-crd-upgrader: ## Build and push CRD Upgrader image for cross-platform support
+	- $(CONTAINER_TOOL) buildx create --name lws-crd-builder
+	$(CONTAINER_TOOL) buildx use lws-crd-builder
+	$(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag $(CRD_UPGRADER_IMG):$(GIT_TAG) -f $(CRD_UPGRADER_DOCKERFILE) .
+	- $(CONTAINER_TOOL) buildx rm lws-crd-builder
 
 ##@ Deployment
 

--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -107,3 +107,10 @@ The following table lists the configurable parameters of the LWS chart and their
 | `tolerations`                              | Tolerations                                    | `{}`                                                |
 | `affinity`                                 | Affinity                                       | `{}`                                                |
 | `gangSchedulingManagement`                 | Configuration for gang scheduling.             | `{}`                                                |
+| `crdUpgrade.enabled`                       | Enable CRD upgrade Job (pre-install/pre-upgrade hook) | `true`                                       |
+| `crdUpgrade.ttlSecondsAfterFinished`       | TTL for completed CRD upgrade Jobs             | `259200` (3 days)                                   |
+| `crdUpgrade.image.repository`              | Repository for CRD upgrader image              | `registry.k8s.io/lws/lws-upgrade-crd`               |
+| `crdUpgrade.image.tag`                     | Tag for CRD upgrader image                     | `.Chart.AppVersion`                                 |
+| `crdUpgrade.image.pullPolicy`              | Pull policy for CRD upgrader image             | `IfNotPresent`                                      |
+| `crdUpgrade.tolerations`                   | Tolerations for CRD upgrader Job pod           | `[{operator: Exists}]`                              |
+| `crdUpgrade.nodeSelector`                  | Node selector for CRD upgrader Job pod         | `{}`                                                |

--- a/charts/lws/templates/upgrade/crd-upgrade.yaml
+++ b/charts/lws/templates/upgrade/crd-upgrade.yaml
@@ -1,0 +1,81 @@
+{{ if .Values.crdUpgrade.enabled -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: lws-crds-upgrade-{{ replace "." "" .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  {{- if .Values.crdUpgrade.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.crdUpgrade.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdUpgrade.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crdUpgrade.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: lws-crds-upgrade
+      containers:
+        - name: lws-crds-upgrade
+          image: "{{ .Values.crdUpgrade.image.repository }}:{{ .Values.crdUpgrade.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.crdUpgrade.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: WEBHOOK_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: WEBHOOK_SERVICE
+              value: lws-webhook-service
+      restartPolicy: OnFailure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lws-crds-upgrade
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lws-crds-upgrade
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lws-crds-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: lws-crds-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lws-crds-upgrade
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+{{- end }}

--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -57,3 +57,21 @@ affinity: {}
 # gangSchedulingManagement:
 #   schedulerProvider: volcano
 gangSchedulingManagement: {}
+
+# crdUpgrade is configuration for the CRD upgrade Job that runs as a pre-install/pre-upgrade
+# Helm hook. It applies CRDs via kubectl before the controller starts, ensuring CRDs are
+# always up-to-date regardless of whether they live in the crds/ directory or templates/.
+crdUpgrade:
+  enabled: true
+  # Time-to-live (TTL) for crd-upgrade jobs after completion. Default is 259200 seconds (3 days).
+  ttlSecondsAfterFinished: 259200
+  # CRD Upgrader image configuration
+  image:
+    repository: registry.k8s.io/lws/lws-upgrade-crd
+    tag: ""  # defaults to .Chart.AppVersion
+    pullPolicy: IfNotPresent
+  # Tolerations for CRD Upgrader Job pod
+  tolerations:
+    - operator: Exists
+  # Node selector for CRD Upgrader Job pod
+  nodeSelector: {}

--- a/tools/crd-upgrade/Dockerfile
+++ b/tools/crd-upgrade/Dockerfile
@@ -1,0 +1,24 @@
+# CRD Upgrader image for lws
+# This image contains all CRD files and kubectl to upgrade CRDs during Helm upgrade
+FROM alpine:3.20
+
+# Copy CRD files and upgrade script
+COPY ./config/crd/bases /lws/crds
+COPY ./tools/crd-upgrade/ensure-crds-up-to-date.sh /lws/ensure-crds-up-to-date.sh
+
+# Install necessary tools
+RUN apk add --update --no-cache bash curl && \
+    chmod +x /lws/ensure-crds-up-to-date.sh
+
+# Install kubectl
+ARG KUBECTL_VERSION=v1.31.0
+ARG TARGETARCH
+RUN ARCH="${TARGETARCH:-amd64}" && \
+    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" && \
+    echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c && \
+    mv kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    rm kubectl.sha256
+
+ENTRYPOINT ["bash", "/lws/ensure-crds-up-to-date.sh"]

--- a/tools/crd-upgrade/ensure-crds-up-to-date.sh
+++ b/tools/crd-upgrade/ensure-crds-up-to-date.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+# CRDs that require a conversion webhook clientConfig.
+# After install/replace, spec.conversion is patched with the correct service
+# name and namespace so Kubernetes routes conversion requests to the webhook.
+CONVERSION_CRDS=(
+  "leaderworkersets.leaderworkerset.x-k8s.io"
+)
+
+# Namespace and service name for the conversion webhook.
+# Override via environment variables when invoking this script.
+WEBHOOK_NAMESPACE="${WEBHOOK_NAMESPACE:-lws-system}"
+WEBHOOK_SERVICE="${WEBHOOK_SERVICE:-lws-webhook-service}"
+
+# Collect CRD names from the bundled YAML files.
+CRD_NAMES=()
+while IFS= read -r -d '' crdfile; do
+  crd_name=$(grep -m1 '^  name:' "$crdfile" | awk '{print $2}')
+  [[ -n "$crd_name" ]] && CRD_NAMES+=("$crd_name")
+done < <(find /lws/crds -maxdepth 1 -name '*.yaml' -print0)
+
+###############################################################################
+# Phase 1 — Apply CRDs (create or replace)
+###############################################################################
+echo "=== Phase 1: Applying CRDs ==="
+
+for crd_name in "${CRD_NAMES[@]}"; do
+  # Find the matching file.
+  crdfile=$(find /lws/crds -maxdepth 1 -name '*.yaml' | while read -r f; do
+    grep -q "name: $crd_name" "$f" && echo "$f"
+  done | head -1)
+  crdshort=${crdfile##*/}
+
+  if kubectl get crd "$crd_name" >/dev/null 2>&1; then
+    echo "$crdshort found, replacing CRD..."
+    kubectl replace -f "$crdfile"
+  else
+    echo "$crdshort not found, creating CRD..."
+    kubectl create -f "$crdfile"
+  fi
+done
+
+###############################################################################
+# Phase 2 — Patch conversion webhooks
+###############################################################################
+
+# Patch spec.conversion on CRDs that use the conversion webhook.
+# The base CRD files (from controller-gen) do not include spec.conversion;
+# it must be applied separately, mirroring what Kustomize does via
+# config/crd/patches/webhook_in_leaderworkersets.yaml.
+echo ""
+echo "=== Phase 2: Patching conversion webhooks ==="
+
+CONVERSION_PATCH=$(cat <<EOF
+{"spec":{"conversion":{"strategy":"Webhook","webhook":{"conversionReviewVersions":["v1"],"clientConfig":{"service":{"namespace":"${WEBHOOK_NAMESPACE}","name":"${WEBHOOK_SERVICE}","path":"/convert"}}}}}}
+EOF
+)
+
+for crd in "${CONVERSION_CRDS[@]}"; do
+  echo "Patching conversion webhook on CRD: $crd"
+  kubectl patch crd "$crd" --type=merge -p "${CONVERSION_PATCH}"
+done
+
+###############################################################################
+# Phase 3 — Protect CRDs from Helm deletion
+#
+# When CRDs were previously tracked under templates/ (e.g. v0.7.0) but are
+# now managed by this hook Job, Helm's manifest-diff logic would delete them
+# on upgrade because they no longer appear in the rendered templates.
+# Patching helm.sh/resource-policy: keep tells Helm to skip deletion for
+# these CRDs, preserving existing custom resources.
+#
+# IMPORTANT: This must run AFTER Phase 1 (replace) and Phase 2 (webhook patch)
+# because kubectl replace overwrites all annotations, which would strip
+# the resource-policy annotation if applied earlier.
+# Ref: kubernetes-sigs/secrets-store-csi-driver#656
+###############################################################################
+echo ""
+echo "=== Phase 3: Protecting CRDs from Helm deletion ==="
+
+for crd_name in "${CRD_NAMES[@]}"; do
+  if kubectl get crd "$crd_name" >/dev/null 2>&1; then
+    echo "Annotating $crd_name with helm.sh/resource-policy: keep"
+    kubectl annotate crd "$crd_name" "helm.sh/resource-policy=keep" --overwrite 2>&1
+  fi
+done
+
+echo ""
+echo "CRD upgrade complete."


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

When upgrading from v0.7.0 (CRDs in `templates/crds/`) to v0.8.0 (CRDs in `crds/`), Helm's manifest-diff logic deletes the LeaderWorkerSet CRD because it was tracked in the old release manifest but no longer appears in the new rendered templates. This causes cascade deletion of all LeaderWorkerSet custom resources in the cluster.

This PR adds a pre-install/pre-upgrade hook Job that manages CRDs independently of the Helm release manifest. The hook runs three phases:

1. **Apply CRDs** — `kubectl create` (new) or `kubectl replace` (existing) with the updated schema
2. **Patch conversion webhooks** — restore the `spec.conversion` webhook configuration
3. **Annotate with `helm.sh/resource-policy: keep`** — prevent Helm from deleting CRDs that were previously tracked under `templates/`

Phase 3 must run after Phase 1 because `kubectl replace` overwrites all metadata including annotations, which would strip the `resource-policy` annotation if applied earlier. This approach follows the precedent set by [secrets-store-csi-driver#656](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/656).

#### Which issue(s) this PR fixes

Fixed #880

#### Special notes for your reviewer

Verified end-to-end on a kind cluster (v0.7.0 → v0.8.0):
- LeaderWorkerSet CRD: preserved, schema updated (`volumeClaimTemplates` field present)
- DisaggregatedSet CRD: newly created
- `helm.sh/resource-policy: keep` annotation: correctly set on both CRDs
- All existing custom resources: intact

The `crds/` directory can optionally be removed since the hook fully handles the CRD lifecycle for both install and upgrade. Keeping it is harmless (Helm installs on first `helm install` only, never updates or deletes).

#### Does this PR introduce a user-facing change?

```release-note
Add a pre-install/pre-upgrade hook Job to manage CRDs, preventing CRD cascade deletion when upgrading from v0.7.0 (CRDs tracked in `templates/`) to v0.8.0+ (CRDs in `crds/`). No manual `kubectl apply` step is required.
```
