### PR TITLE
Add hasB4K to OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
 reviewers:
   - ahg-g
   - ardaguclu
+  - hasB4K
   - kerthcet
   - edwinhr716
   - yankay


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it
 
Add @hasB4K as a reviewer:
* Wrote DisaggregatedSet
* I need to review a bunch of DisaggregatedSet related PRs
* I'm now part of kubernetes-sigs: https://github.com/kubernetes/org/issues/6431

#### Which issue(s) this PR fixes

#### Special notes for your reviewer
#### Does this PR introduce a user-facing change?

```
None
```