### PR TITLE
Propagate LeaderWorkerSet metadata to StatefulSets

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -170,6 +170,10 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		return ctrl.Result{}, err
 	}
+	if err := r.syncWorkerStatefulSetsMetadata(ctx, lws); err != nil {
+		log.Error(err, "Syncing worker statefulset metadata.")
+		return ctrl.Result{}, err
+	}
 
 	if leaderSts == nil {
 		// An event is logged to track sts creation.
@@ -218,6 +222,55 @@ func (r *LeaderWorkerSetReconciler) reconcileHeadlessServices(ctx context.Contex
 		return nil
 	}
 	return nil
+}
+
+// syncWorkerStatefulSetsMetadata reconciles top-level labels and annotations on
+// existing worker StatefulSets for the given LeaderWorkerSet.
+func (r *LeaderWorkerSetReconciler) syncWorkerStatefulSetsMetadata(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet) error {
+	if *lws.Spec.LeaderWorkerTemplate.Size == 1 {
+		return nil
+	}
+
+	var statefulSetList appsv1.StatefulSetList
+	selector := client.MatchingLabels(map[string]string{
+		leaderworkerset.SetNameLabelKey: lws.Name,
+	})
+	if err := r.List(ctx, &statefulSetList, selector, client.InNamespace(lws.Namespace)); err != nil {
+		return err
+	}
+
+	for index := range statefulSetList.Items {
+		workerStatefulSet := &statefulSetList.Items[index]
+		if !isWorkerStatefulSetForLeaderWorkerSet(workerStatefulSet, lws) {
+			continue
+		}
+		desiredLabels := workerStatefulSetLabelsForMetadataSync(lws, workerStatefulSet)
+		if err := applyStatefulSetMetadata(ctx, r.Client, workerStatefulSet.Name, workerStatefulSet.Namespace, desiredLabels, lws.Annotations); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isWorkerStatefulSetForLeaderWorkerSet reports whether statefulSet is an
+// existing worker StatefulSet for lws.
+func isWorkerStatefulSetForLeaderWorkerSet(statefulSet *appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet) bool {
+	return statefulSet.Name != lws.Name &&
+		statefulSet.Namespace == lws.Namespace &&
+		statefulSet.Labels[leaderworkerset.SetNameLabelKey] == lws.Name &&
+		statefulSet.Labels[leaderworkerset.GroupIndexLabelKey] != ""
+}
+
+// workerStatefulSetLabelsForMetadataSync returns desired worker StatefulSet
+// labels using LWS labels plus controller-owned keys from the existing child.
+func workerStatefulSetLabelsForMetadataSync(lws *leaderworkerset.LeaderWorkerSet, statefulSet *appsv1.StatefulSet) map[string]string {
+	controllerLabels := map[string]string{
+		leaderworkerset.SetNameLabelKey:         lws.Name,
+		leaderworkerset.GroupIndexLabelKey:      statefulSet.Labels[leaderworkerset.GroupIndexLabelKey],
+		leaderworkerset.GroupUniqueHashLabelKey: statefulSet.Labels[leaderworkerset.GroupUniqueHashLabelKey],
+		leaderworkerset.RevisionKey:             statefulSet.Labels[leaderworkerset.RevisionKey],
+	}
+	return mergeStatefulSetMetadata(lws.Labels, controllerLabels)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -828,6 +881,13 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 		stsMaxUnavailableInt = 1
 	}
 	stsMaxUnavailable := intstr.FromInt32(stsMaxUnavailableInt)
+	stsLabels := mergeStatefulSetMetadata(lws.Labels, map[string]string{
+		leaderworkerset.SetNameLabelKey: lws.Name,
+		leaderworkerset.RevisionKey:     revisionKey,
+	})
+	stsAnnotations := mergeStatefulSetMetadata(lws.Annotations, map[string]string{
+		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
+	})
 
 	// construct statefulset apply configuration
 	statefulSetConfig := appsapplyv1.StatefulSet(lws.Name, lws.Namespace).
@@ -844,13 +904,8 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 					leaderworkerset.SetNameLabelKey:     lws.Name,
 					leaderworkerset.WorkerIndexLabelKey: "0",
 				}))).
-		WithLabels(map[string]string{
-			leaderworkerset.SetNameLabelKey: lws.Name,
-			leaderworkerset.RevisionKey:     revisionKey,
-		}).
-		WithAnnotations(map[string]string{
-			leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
-		})
+		WithLabels(stsLabels).
+		WithAnnotations(stsAnnotations)
 
 	pvcApplyConfiguration := controllerutils.GetPVCApplyConfiguration(lws)
 	if len(pvcApplyConfiguration) > 0 {

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -28,12 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -167,7 +169,10 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{
+						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
+						"leaderworkerset.sigs.k8s.io/replicas":           "1",
+					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -236,7 +241,10 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2"},
+					Annotations: map[string]string{
+						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
+						"leaderworkerset.sigs.k8s.io/replicas":           "2",
+					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](2),
@@ -440,7 +448,10 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
+						"leaderworkerset.sigs.k8s.io/replicas":            "1",
+					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -754,6 +765,235 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 				t.Errorf("unexpected StatefulSet apply configuration: %s", diff)
 			}
 		})
+	}
+}
+
+func TestLeaderStatefulSetApplyConfigPropagatesMetadata(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Labels(map[string]string{
+			"app.kubernetes.io/part-of":     "inference",
+			leaderworkerset.SetNameLabelKey: "user-value",
+		}).
+		Annotation(map[string]string{
+			"example.com/owner":                   "platform",
+			leaderworkerset.ReplicasAnnotationKey: "user-value",
+		}).
+		Replica(3).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				MaxUnavailable: intstr.FromInt32(1),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(1).
+		Obj()
+	revision, err := revisionutils.NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revisionKey := revisionutils.GetRevisionKey(revision)
+
+	statefulSetConfig, err := constructLeaderStatefulSetApplyConfiguration(lws, 0, 3, revisionKey)
+	if err != nil {
+		t.Fatalf("constructLeaderStatefulSetApplyConfiguration() error = %v", err)
+	}
+
+	wantLabels := map[string]string{
+		"app.kubernetes.io/part-of":     "inference",
+		leaderworkerset.SetNameLabelKey: "test-sample",
+		leaderworkerset.RevisionKey:     revisionKey,
+	}
+	if diff := cmp.Diff(wantLabels, statefulSetConfig.Labels); diff != "" {
+		t.Fatalf("unexpected StatefulSet labels (-want +got):\n%s", diff)
+	}
+
+	wantAnnotations := map[string]string{
+		"example.com/owner":                   "platform",
+		leaderworkerset.ReplicasAnnotationKey: "3",
+	}
+	if diff := cmp.Diff(wantAnnotations, statefulSetConfig.Annotations); diff != "" {
+		t.Fatalf("unexpected StatefulSet annotations (-want +got):\n%s", diff)
+	}
+}
+
+func TestLeaderReconcileUpdatesExistingWorkerStatefulSetMetadata(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := leaderworkerset.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	revisionKey := "rev-1"
+	lws := wrappers.BuildLeaderWorkerSet("default").
+		Replica(1).
+		Labels(map[string]string{
+			"app.kubernetes.io/part-of":             "inference",
+			leaderworkerset.SetNameLabelKey:         "user-name",
+			leaderworkerset.GroupIndexLabelKey:      "user-group",
+			leaderworkerset.GroupUniqueHashLabelKey: "user-hash",
+			leaderworkerset.RevisionKey:             "user-revision",
+		}).
+		Annotation(map[string]string{
+			"example.com/owner": "platform",
+		}).
+		Generation(2).
+		StatusReplicas(1).
+		ReadyReplicas(1).
+		Obj()
+	lws.TypeMeta = metav1.TypeMeta{
+		APIVersion: leaderworkerset.GroupVersion.String(),
+		Kind:       "LeaderWorkerSet",
+	}
+	lws.UID = types.UID("test-sample-uid")
+	lws.Status.ObservedGeneration = lws.Generation
+
+	leaderSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lws.Name,
+			Namespace: lws.Namespace,
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey: lws.Name,
+				leaderworkerset.RevisionKey:     revisionKey,
+			},
+			Annotations: map[string]string{
+				leaderworkerset.ReplicasAnnotationKey: "1",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To[int32](1),
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					Partition: ptr.To[int32](0),
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas: 1,
+		},
+	}
+	leaderPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sample-0",
+			Namespace: lws.Namespace,
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:         lws.Name,
+				leaderworkerset.WorkerIndexLabelKey:     "0",
+				leaderworkerset.GroupIndexLabelKey:      "0",
+				leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+				leaderworkerset.RevisionKey:             revisionKey,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	workerSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      leaderPod.Name,
+			Namespace: lws.Namespace,
+			Labels: map[string]string{
+				"existing-label":                        "keep",
+				leaderworkerset.SetNameLabelKey:         lws.Name,
+				leaderworkerset.GroupIndexLabelKey:      "0",
+				leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+				leaderworkerset.RevisionKey:             revisionKey,
+			},
+			Annotations: map[string]string{
+				"existing-annotation": "keep",
+				"example.com/owner":   "old",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To[int32](1),
+		},
+		Status: appsv1.StatefulSetStatus{
+			AvailableReplicas: 1,
+			CurrentRevision:   "current",
+			UpdateRevision:    "current",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(lws).
+		WithObjects(lws, leaderSts, leaderPod, workerSts).
+		Build()
+	reconciler := NewLeaderWorkerSetReconciler(fakeClient, scheme, fakeEventRecorder{})
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var got appsv1.StatefulSet
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: workerSts.Name, Namespace: workerSts.Namespace}, &got); err != nil {
+		t.Fatalf("Get() worker StatefulSet error = %v", err)
+	}
+	wantLabels := map[string]string{
+		"app.kubernetes.io/part-of":             "inference",
+		"existing-label":                        "keep",
+		leaderworkerset.SetNameLabelKey:         lws.Name,
+		leaderworkerset.GroupIndexLabelKey:      "0",
+		leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+		leaderworkerset.RevisionKey:             revisionKey,
+	}
+	if diff := cmp.Diff(wantLabels, got.Labels); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet labels (-want +got):\n%s", diff)
+	}
+
+	wantAnnotations := map[string]string{
+		"existing-annotation": "keep",
+		"example.com/owner":   "platform",
+	}
+	if diff := cmp.Diff(wantAnnotations, got.Annotations); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet annotations (-want +got):\n%s", diff)
+	}
+
+	var updatedLWS leaderworkerset.LeaderWorkerSet
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &updatedLWS); err != nil {
+		t.Fatalf("Get() LeaderWorkerSet error = %v", err)
+	}
+	updatedLWS.Labels = nil
+	updatedLWS.Annotations = nil
+	updatedLWS.Generation++
+	if err := fakeClient.Update(ctx, &updatedLWS); err != nil {
+		t.Fatalf("Update() LeaderWorkerSet error = %v", err)
+	}
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}})
+	if err != nil {
+		t.Fatalf("Reconcile() after metadata removal error = %v", err)
+	}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: workerSts.Name, Namespace: workerSts.Namespace}, &got); err != nil {
+		t.Fatalf("Get() worker StatefulSet after removal error = %v", err)
+	}
+	wantLabelsAfterRemoval := map[string]string{
+		"existing-label":                        "keep",
+		leaderworkerset.SetNameLabelKey:         lws.Name,
+		leaderworkerset.GroupIndexLabelKey:      "0",
+		leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+		leaderworkerset.RevisionKey:             revisionKey,
+	}
+	if diff := cmp.Diff(wantLabelsAfterRemoval, got.Labels); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet labels after removal (-want +got):\n%s", diff)
+	}
+
+	wantAnnotationsAfterRemoval := map[string]string{
+		"existing-annotation": "keep",
+	}
+	if diff := cmp.Diff(wantAnnotationsAfterRemoval, got.Annotations); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet annotations after removal (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/controllers/metadata.go
+++ b/pkg/controllers/metadata.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"context"
+	"maps"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// mergeStatefulSetMetadata returns a new metadata map with user entries first and
+// controller-owned entries overriding conflicting keys.
+func mergeStatefulSetMetadata(userMetadata, controllerMetadata map[string]string) map[string]string {
+	merged := make(map[string]string, len(userMetadata)+len(controllerMetadata))
+	maps.Copy(merged, userMetadata)
+	maps.Copy(merged, controllerMetadata)
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// applyStatefulSetMetadata server-side applies top-level labels and annotations
+// for a StatefulSet so removed LWS-owned metadata keys are pruned on later syncs.
+func applyStatefulSetMetadata(ctx context.Context, k8sClient client.Client, name, namespace string, desiredLabels, desiredAnnotations map[string]string) error {
+	if desiredLabels == nil {
+		desiredLabels = map[string]string{}
+	}
+	if desiredAnnotations == nil {
+		desiredAnnotations = map[string]string{}
+	}
+
+	statefulSetConfig := appsapplyv1.StatefulSet(name, namespace).
+		WithLabels(desiredLabels).
+		WithAnnotations(desiredAnnotations)
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(statefulSetConfig)
+	if err != nil {
+		return err
+	}
+	patch := &unstructured.Unstructured{
+		Object: obj,
+	}
+	return k8sClient.Patch(ctx, patch, client.Apply, &client.PatchOptions{
+		FieldManager: fieldManager,
+		Force:        ptr.To[bool](true),
+	})
+}

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -195,7 +195,12 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			}
 			return ctrl.Result{}, client.IgnoreAlreadyExists(err)
 		}
+		if err := syncWorkerStatefulSetMetadata(ctx, r.Client, pod.Name, leaderWorkerSet.Namespace, statefulSet); err != nil {
+			return ctrl.Result{}, err
+		}
 		r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created worker statefulset for leader pod %s", pod.Name))
+	} else if err := syncWorkerStatefulSetMetadata(ctx, r.Client, workerSts.Name, workerSts.Namespace, statefulSet); err != nil {
+		return ctrl.Result{}, err
 	}
 	log.V(2).Info("Worker Reconcile completed.")
 	return ctrl.Result{}, nil
@@ -410,6 +415,8 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		leaderworkerset.GroupUniqueHashLabelKey: leaderPod.Labels[leaderworkerset.GroupUniqueHashLabelKey],
 		leaderworkerset.RevisionKey:             revisionutils.GetRevisionKey(&leaderPod),
 	}
+	stsLabels := mergeStatefulSetMetadata(lws.Labels, labelMap)
+	stsAnnotations := mergeStatefulSetMetadata(lws.Annotations, nil)
 
 	podTemplateApplyConfiguration.WithLabels(labelMap)
 	podAnnotations := make(map[string]string)
@@ -440,7 +447,10 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 			WithOrdinals(appsapplyv1.StatefulSetOrdinals().WithStart(1)).
 			WithSelector(metaapplyv1.LabelSelector().
 				WithMatchLabels(selectorMap))).
-		WithLabels(labelMap)
+		WithLabels(stsLabels)
+	if len(stsAnnotations) > 0 {
+		statefulSetConfig.WithAnnotations(stsAnnotations)
+	}
 
 	pvcApplyConfiguration := controllerutils.GetPVCApplyConfiguration(&lws)
 	if len(pvcApplyConfiguration) > 0 {
@@ -455,6 +465,12 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		statefulSetConfig.Spec.WithPersistentVolumeClaimRetentionPolicy(pvcRetentionPolicy)
 	}
 	return statefulSetConfig, nil
+}
+
+// syncWorkerStatefulSetMetadata updates metadata on an existing worker StatefulSet
+// without changing its spec or removing metadata owned by other actors.
+func syncWorkerStatefulSetMetadata(ctx context.Context, k8sClient client.Client, name, namespace string, desired *appsapplyv1.StatefulSetApplyConfiguration) error {
+	return applyStatefulSetMetadata(ctx, k8sClient, name, namespace, desired.Labels, desired.Annotations)
 }
 
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -27,11 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -166,6 +168,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 					},
+					Annotations: map[string]string{
+						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
+					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -242,6 +247,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupIndexLabelKey:      "1",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
 					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
@@ -421,6 +429,159 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 				t.Errorf("unexpected StatefulSet apply operation %s", diff)
 			}
 		})
+	}
+}
+
+func TestConstructWorkerStatefulSetApplyConfigurationPropagatesMetadata(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Labels(map[string]string{
+			"app.kubernetes.io/part-of":     "inference",
+			leaderworkerset.SetNameLabelKey: "user-value",
+		}).
+		Annotation(map[string]string{
+			"example.com/owner": "platform",
+		}).
+		Replica(1).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(2).
+		Obj()
+	revision, err := revisionutils.NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revisionKey := revisionutils.GetRevisionKey(revision)
+	leaderPod := corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-sample-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				leaderworkerset.WorkerIndexLabelKey:     "0",
+				leaderworkerset.SetNameLabelKey:         "test-sample",
+				leaderworkerset.GroupIndexLabelKey:      "0",
+				leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+				leaderworkerset.RevisionKey:             revisionKey,
+			},
+		},
+	}
+
+	statefulSetConfig, err := constructWorkerStatefulSetApplyConfiguration(leaderPod, *lws, revision)
+	if err != nil {
+		t.Fatalf("constructWorkerStatefulSetApplyConfiguration() error = %v", err)
+	}
+
+	wantLabels := map[string]string{
+		"app.kubernetes.io/part-of":             "inference",
+		leaderworkerset.SetNameLabelKey:         "test-sample",
+		leaderworkerset.GroupIndexLabelKey:      "0",
+		leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+		leaderworkerset.RevisionKey:             revisionKey,
+	}
+	if diff := cmp.Diff(wantLabels, statefulSetConfig.Labels); diff != "" {
+		t.Fatalf("unexpected StatefulSet labels (-want +got):\n%s", diff)
+	}
+
+	wantAnnotations := map[string]string{
+		"example.com/owner": "platform",
+	}
+	if diff := cmp.Diff(wantAnnotations, statefulSetConfig.Annotations); diff != "" {
+		t.Fatalf("unexpected StatefulSet annotations (-want +got):\n%s", diff)
+	}
+}
+
+func TestPodReconcileUpdatesExistingWorkerStatefulSetMetadata(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := leaderworkerset.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	lws := wrappers.BuildLeaderWorkerSet("default").
+		Labels(map[string]string{
+			"app.kubernetes.io/part-of":             "inference",
+			leaderworkerset.SetNameLabelKey:         "user-name",
+			leaderworkerset.GroupIndexLabelKey:      "user-group",
+			leaderworkerset.GroupUniqueHashLabelKey: "user-key",
+			leaderworkerset.RevisionKey:             "user-revision",
+		}).
+		Annotation(map[string]string{
+			"example.com/owner": "platform",
+		}).
+		Obj()
+	revisionClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	revision, err := revisionutils.NewRevision(ctx, revisionClient, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revisionKey := revisionutils.GetRevisionKey(revision)
+	leaderPod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-sample-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				leaderworkerset.WorkerIndexLabelKey:     "0",
+				leaderworkerset.SetNameLabelKey:         "test-sample",
+				leaderworkerset.GroupIndexLabelKey:      "0",
+				leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+				leaderworkerset.RevisionKey:             revisionKey,
+			},
+		},
+	}
+	workerSts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      leaderPod.Name,
+			Namespace: leaderPod.Namespace,
+			Labels: map[string]string{
+				"existing-label":                   "keep",
+				leaderworkerset.SetNameLabelKey:    "stale-name",
+				leaderworkerset.GroupIndexLabelKey: "stale-group",
+				leaderworkerset.RevisionKey:        "stale-revision",
+			},
+			Annotations: map[string]string{
+				"existing-annotation": "keep",
+				"example.com/owner":   "old",
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(lws, revision, leaderPod, workerSts).
+		Build()
+	reconciler := PodReconciler{Client: fakeClient, Scheme: scheme, Record: fakeEventRecorder{}}
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: leaderPod.Name, Namespace: leaderPod.Namespace}})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var got appsv1.StatefulSet
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: leaderPod.Name, Namespace: leaderPod.Namespace}, &got); err != nil {
+		t.Fatalf("Get() worker StatefulSet error = %v", err)
+	}
+	wantLabels := map[string]string{
+		"app.kubernetes.io/part-of":             "inference",
+		"existing-label":                        "keep",
+		leaderworkerset.SetNameLabelKey:         "test-sample",
+		leaderworkerset.GroupIndexLabelKey:      "0",
+		leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+		leaderworkerset.RevisionKey:             revisionKey,
+	}
+	if diff := cmp.Diff(wantLabels, got.Labels); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet labels (-want +got):\n%s", diff)
+	}
+
+	wantAnnotations := map[string]string{
+		"existing-annotation": "keep",
+		"example.com/owner":   "platform",
+	}
+	if diff := cmp.Diff(wantAnnotations, got.Annotations); diff != "" {
+		t.Fatalf("unexpected worker StatefulSet annotations (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Closes #895

What changed:
- propagate top-level LeaderWorkerSet labels and annotations to leader and worker StatefulSets
- keep controller-owned StatefulSet metadata authoritative when keys conflict
- use server-side apply for worker StatefulSet metadata so updates and removals converge without changing worker specs

Tests:
- `GOPROXY=https://goproxy.cn,direct go test ./pkg/controllers -run 'TestLeaderReconcileUpdatesExistingWorkerStatefulSetMetadata|TestLeaderStatefulSetApplyConfigPropagatesMetadata|TestConstructWorkerStatefulSetApplyConfigurationPropagatesMetadata|TestPodReconcileUpdatesExistingWorkerStatefulSetMetadata' -count=1`
- `GOPROXY=https://goproxy.cn,direct go test ./pkg/controllers -count=1`
- `GOPROXY=https://goproxy.cn,direct go test ./pkg/... ./cmd/... -count=1`
- `GOPROXY=https://goproxy.cn,direct go vet ./pkg/... ./cmd/...`
- `GOPROXY=https://goproxy.cn,direct go test -race -covermode=atomic -coverprofile=profile.cov ./pkg/... ./cmd/...`

```release-note
LeaderWorkerSet labels and annotations are propagated to child StatefulSets.
```

<!-- oss-radar:idempotency=auto-20260624-101015.w0.kubernetes-sigs_lws.895 -->
