### PR TITLE
docs(site): add DisaggregatedSet documentation

### DIFF
--- a/site/content/en/docs/adoption/_index.md
+++ b/site/content/en/docs/adoption/_index.md
@@ -48,6 +48,8 @@ OptimizationJobs.
 
 [**llm-d**](https://github.com/llm-d/llm-d): llm-d is a Kubernetes-native, high-performance distributed LLM inference framework. It integrates open technologies such as vLLM for model serving and [Gateway API Inference extension (GIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) for request scheduling and load balancing, and uses LeaderWorkerSet for scalable multi-node deployments. Key features include P/D Disaggregated serving and prefix caching.
 
+> For workloads that use P/D disaggregated serving, see the [DisaggregatedSet](../concepts/disaggregatedset) API — a higher-level abstraction built into LWS that coordinates multi-role LeaderWorkerSets with N-dimensional rolling updates.
+
 [**llmaz**](https://github.com/InftyAI/llmaz): llmaz, serving as an easy to use and advanced inference platform, uses LeaderWorkerSet as the underlying workload to support both single-host and multi-host inference scenarios.
 
 [**NVIDIA Dynamo**](https://github.com/ai-dynamo/dynamo): NVIDIA Dynamo is a high-throughput low-latency inference framework designed for serving generative AI and reasoning models in multi-node distributed environments especially the disaggregated prefill & decode inference. It uses LeaderWorkerSet to support multi-node deployment on Kubernetes.

--- a/site/content/en/docs/concepts/disaggregatedset.md
+++ b/site/content/en/docs/concepts/disaggregatedset.md
@@ -1,0 +1,60 @@
+---
+title: "DisaggregatedSet"
+linkTitle: "DisaggregatedSet"
+weight: 20
+description: >
+  Learn about DisaggregatedSet, a higher-level abstraction for coordinating multi-role disaggregated inference workloads.
+---
+
+`DisaggregatedSet` is a Kubernetes Custom Resource Definition (CRD) introduced in LeaderWorkerSet (LWS) to manage and orchestrate disaggregated inference workloads. 
+
+It acts as a higher-level controller over `LeaderWorkerSet` resources, enabling users to deploy, scale, and update multi-role serving architectures (such as prefill/decode splitting for Large Language Models) as a single logical unit.
+
+For details on the initial proposal and design, see [KEP-766: DisaggregatedSet](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet).
+
+---
+
+## Why Disaggregated serving?
+
+In LLM serving, inference is split into two phases:
+1. **Prefill (Prompt phase):** Compute-bound phase that processes input tokens and generates the first token. This phase benefits from high computation capacity (e.g., larger GPU counts or memory bandwidth).
+2. **Decode (Generation phase):** Memory-bandwidth-bound phase that generates subsequent tokens one by one. This phase benefits from high memory speed but requires fewer compute resources per token.
+
+By disaggregating these phases onto separate, specialized GPU pools, serving frameworks like [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang), and [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) can optimize throughput, reduce inter-token latency, and improve hardware utilization.
+
+---
+
+## Concept and Architecture
+
+A `DisaggregatedSet` defines the configuration for multiple **roles** (at least 2, and up to 10). Under the hood, the `DisaggregatedSet` controller automatically creates and manages a separate `LeaderWorkerSet` for each role.
+
+### Naming Conventions
+
+Managed `LeaderWorkerSet` resources are named using the following format:
+```
+{disaggregatedset-name}-{revision-hash}-{role-name}
+```
+- `revision-hash` is a truncated hash of all the role templates to ensure coordinated updates and revision tracking.
+- `role-name` corresponds to the name of the role configured in the spec (e.g., `prefill`, `decode`).
+
+### Labels and Annotations
+
+The following labels are automatically applied to the managed LeaderWorkerSets and associated pods:
+- `disaggregatedset.x-k8s.io/name`: The name of the parent `DisaggregatedSet`.
+- `disaggregatedset.x-k8s.io/role`: The specific role the resource belongs to.
+- `disaggregatedset.x-k8s.io/revision`: The revision hash representing the current template configuration.
+
+An annotation `disaggregatedset.x-k8s.io/initial-replicas` is used internally by the controller on the `DisaggregatedSet` to track the starting replica counts during rollouts.
+
+---
+
+## Coordinated N-Dimensional Rolling Updates
+
+Deploying updates across independent serving roles is challenging. If a prefill pool is updated to a new version/configuration while the decode pool remains on the old version, request processing can fail. 
+
+`DisaggregatedSet` solves this by introducing a coordinated **N-dimensional rolling update algorithm**:
+
+1. **Lockstep Rollouts:** The controller coordinates updates across all roles, scaling up new revisions and scaling down old revisions in lockstep.
+2. **Surge and Availability Constraints:** The update honors per-role `maxSurge` and `maxUnavailable` configurations. 
+3. **Scale-Up Priority:** New replicas are scaled up and verified to be `Ready` before old replicas are scaled down to ensure the cluster capacity never drops below minimum requirements.
+4. **Coordinated Drain:** If a rollout is interrupted or if any role's replica count drops to `0`, the controller forces all related roles to `0` to prevent orphaned single-role workloads from wasting resources or receiving broken traffic.

--- a/site/content/en/docs/examples/disaggregatedset.md
+++ b/site/content/en/docs/examples/disaggregatedset.md
@@ -1,0 +1,187 @@
+---
+title: "DisaggregatedSet"
+linkTitle: "DisaggregatedSet"
+weight: 60
+description: >
+  A minimal example deploying a two-role disaggregated inference workload using DisaggregatedSet.
+---
+
+This example shows how to deploy a minimal two-role (prefill/decode) workload using
+`DisaggregatedSet`. It uses nginx as a placeholder container — in production you would
+replace this with your inference server image (e.g. vLLM, SGLang, NVIDIA Dynamo).
+
+For the full background on why disaggregated serving improves LLM throughput, see
+[DisaggregatedSet Concepts](../concepts/disaggregatedset).
+
+---
+
+## Prerequisites
+
+- LWS v0.9.0 or later installed (see [Installation](../installation/)).
+- `kubectl` configured against your cluster.
+
+---
+
+## Minimal Two-Role Example
+
+The `DisaggregatedSet` below creates:
+- A **prefill** pool with 2 LWS replicas, each with a 1-node leader+worker group.
+- A **decode** pool with 2 LWS replicas, each with a 1-node leader+worker group.
+
+The controller automatically creates two `LeaderWorkerSet` resources named
+`disaggregatedset-sample-{revision}-prefill` and `disaggregatedset-sample-{revision}-decode`,
+plus per-revision headless Services for each role.
+
+```yaml
+apiVersion: disaggregatedset.x-k8s.io/v1
+kind: DisaggregatedSet
+metadata:
+  name: disaggregatedset-sample
+  namespace: default
+spec:
+  roles:
+    - name: prefill
+      spec:
+        replicas: 2
+        leaderWorkerTemplate:
+          size: 1
+          leaderTemplate:
+            metadata:
+              labels:
+                role: prefill
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
+          workerTemplate:
+            metadata:
+              labels:
+                role: prefill
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
+    - name: decode
+      spec:
+        replicas: 2
+        leaderWorkerTemplate:
+          size: 1
+          leaderTemplate:
+            metadata:
+              labels:
+                role: decode
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
+          workerTemplate:
+            metadata:
+              labels:
+                role: decode
+            spec:
+              containers:
+                - name: worker
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 80
+```
+
+Apply it with:
+
+```shell
+kubectl apply -f https://github.com/kubernetes-sigs/lws/blob/main/config/samples/disaggregatedset_v1_disaggregatedset.yaml
+```
+
+---
+
+## Verify the Deployment
+
+### Check DisaggregatedSet status
+
+```shell
+kubectl get disaggregatedsets disaggregatedset-sample
+```
+
+Expected output (after all pods are ready):
+
+```
+NAME                      AGE
+disaggregatedset-sample   30s
+```
+
+For detailed status including per-role readiness:
+
+```shell
+kubectl describe disaggregatedsets disaggregatedset-sample
+```
+
+The `Status.RoleStatuses` section will show `replicas`, `readyReplicas`, and `updatedReplicas` for each role.
+
+### Inspect managed LeaderWorkerSets
+
+```shell
+kubectl get leaderworkersets \
+  -l disaggregatedset.x-k8s.io/name=disaggregatedset-sample
+```
+
+You will see one `LeaderWorkerSet` per role (and per active revision during a rolling update):
+
+```
+NAME                                        REPLICAS   READY   AGE
+disaggregatedset-sample-abc12345-prefill    2          2       30s
+disaggregatedset-sample-abc12345-decode     2          2       30s
+```
+
+### List pods by role
+
+```shell
+# Prefill pods
+kubectl get pods -l disaggregatedset.x-k8s.io/role=prefill
+
+# Decode pods
+kubectl get pods -l disaggregatedset.x-k8s.io/role=decode
+```
+
+### Inspect headless Services
+
+```shell
+kubectl get svc \
+  -l disaggregatedset.x-k8s.io/name=disaggregatedset-sample
+```
+
+Each role gets a headless service per revision:
+
+```
+NAME                                               TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
+disaggregatedset-sample-abc12345-prefill-prv       ClusterIP   None         <none>        80/TCP    30s
+disaggregatedset-sample-abc12345-decode-prv        ClusterIP   None         <none>        80/TCP    30s
+```
+
+---
+
+## Three-Role Example
+
+For workloads that require an additional role (e.g., encode, prefill, decode), apply the three-role sample:
+
+```shell
+kubectl apply -f https://github.com/kubernetes-sigs/lws/blob/main/config/samples/disaggregatedset_v1_3role.yaml
+```
+
+This sample configures `maxSurge: 1` and `maxUnavailable: 0` per role, ensuring zero-downtime
+rolling updates where new replicas are always ready before old ones are removed.
+
+---
+
+## Clean Up
+
+```shell
+kubectl delete disaggregatedsets disaggregatedset-sample
+```
+
+All owned `LeaderWorkerSet` resources and headless `Services` are garbage-collected automatically.

--- a/site/content/en/docs/installation/disaggregatedset.md
+++ b/site/content/en/docs/installation/disaggregatedset.md
@@ -1,0 +1,85 @@
+---
+title: "Installing DisaggregatedSet"
+linkTitle: "DisaggregatedSet"
+weight: 50
+description: >
+  How to verify that DisaggregatedSet is available after installing LWS.
+---
+
+`DisaggregatedSet` is **bundled with the LWS controller manager** (`lws-controller-manager`) as of v0.9.0.
+No separate installation step is required: deploying LWS via `kubectl` or Helm automatically installs
+the `DisaggregatedSet` CRD and starts the `DisaggregatedSet` controller alongside the LWS controller
+in the `lws-system` namespace.
+
+## Before You Begin
+
+Ensure you have already [installed LWS](../) and that the controller manager is ready:
+
+```shell
+kubectl wait deploy/lws-controller-manager -n lws-system \
+  --for=condition=available --timeout=5m
+```
+
+## Verify DisaggregatedSet Is Ready
+
+### Check the CRD
+
+Confirm the `DisaggregatedSet` CRD is registered in the cluster:
+
+```shell
+kubectl get crd disaggregatedsets.disaggregatedset.x-k8s.io
+```
+
+Expected output:
+
+```
+NAME                                          CREATED AT
+disaggregatedsets.disaggregatedset.x-k8s.io  2025-...
+```
+
+### Check the Controller
+
+The `DisaggregatedSet` controller runs inside the same `lws-controller-manager` pod as the LWS
+controller. Verify it is running:
+
+```shell
+kubectl get pods -n lws-system
+```
+
+Expected output:
+
+```
+NAME                                   READY   STATUS    RESTARTS   AGE
+lws-controller-manager-...             2/2     Running   0          2m
+```
+
+You can also confirm the controller registered successfully by checking the manager logs:
+
+```shell
+kubectl logs -n lws-system deploy/lws-controller-manager \
+  -c manager | grep -i disaggregatedset
+```
+
+## Install a Specific Version
+
+If you need a specific LWS release, follow the [standard installation instructions](../) and
+substitute the desired version. The `DisaggregatedSet` CRD and controller are included in all
+release manifests from v0.9.0 onwards.
+
+```shell
+VERSION=v0.9.0
+kubectl apply --server-side \
+  -f https://github.com/kubernetes-sigs/lws/releases/download/$VERSION/manifests.yaml
+```
+
+## Uninstall
+
+`DisaggregatedSet` resources are removed as part of the standard LWS uninstall procedure.
+Before uninstalling, delete any `DisaggregatedSet` objects to ensure their owned
+`LeaderWorkerSet` resources and headless `Services` are garbage-collected cleanly:
+
+```shell
+kubectl delete disaggregatedsets --all --all-namespaces
+```
+
+Then proceed with the [LWS uninstall steps](../#uninstall).

--- a/site/content/en/docs/reference/_index.md
+++ b/site/content/en/docs/reference/_index.md
@@ -5,3 +5,7 @@ weight: 5
 description: >
   This section contains the LWS reference information.
 ---
+
+- [LeaderWorkerSet API (v1)](./leaderworkerset.v1) — Full field reference for the `LeaderWorkerSet` resource.
+- [DisaggregatedSet API (v1)](./disaggregatedset.v1) — Full field reference for the `DisaggregatedSet` resource, including role spec, status conditions, labels, and headless service naming.
+- [Labels, Annotations and Environment Variables](./labels-annotations-and-environment-variables) — All well-known labels and annotations used by LWS and DisaggregatedSet.

--- a/site/content/en/docs/reference/disaggregatedset.v1.md
+++ b/site/content/en/docs/reference/disaggregatedset.v1.md
@@ -1,0 +1,110 @@
+---
+title: "DisaggregatedSet API Reference"
+linkTitle: "DisaggregatedSet API"
+weight: 20
+description: >
+  API reference for the DisaggregatedSet v1 resource (disaggregatedset.x-k8s.io/v1).
+---
+
+`DisaggregatedSet` is a cluster-scoped Custom Resource that orchestrates multiple
+`LeaderWorkerSet` resources as a single logical unit for disaggregated inference workloads.
+
+- **API Group:** `disaggregatedset.x-k8s.io`
+- **Version:** `v1`
+- **Kind:** `DisaggregatedSet`
+- **Scope:** Namespaced
+- **CRD source:** [disaggregatedset.x-k8s.io_disaggregatedsets.yaml](https://github.com/kubernetes-sigs/lws/blob/main/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml)
+
+---
+
+## DisaggregatedSet
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `apiVersion` | `string` | Yes | `disaggregatedset.x-k8s.io/v1` |
+| `kind` | `string` | Yes | `DisaggregatedSet` |
+| `metadata` | `ObjectMeta` | No | Standard Kubernetes object metadata. |
+| `spec` | `DisaggregatedSetSpec` | Yes | Desired state of the `DisaggregatedSet`. |
+| `status` | `DisaggregatedSetStatus` | No | Observed state, populated by the controller. |
+
+---
+
+## DisaggregatedSetSpec
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `roles` | `[]DisaggregatedRoleSpec` | Yes | List of roles (minimum 2, maximum 10). Role names must be unique. Either all roles have `replicas > 0` or all have `replicas == 0`; mixing is not allowed. |
+
+---
+
+## DisaggregatedRoleSpec
+
+Each entry in `spec.roles` configures one `LeaderWorkerSet` managed by the `DisaggregatedSet`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | Unique identifier for the role. Must match `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (1–63 characters). |
+| `metadata` | `ObjectMeta` | No | Labels and annotations propagated to the managed `LeaderWorkerSet` object. Useful for Kueue (`kueue.x-k8s.io/queue-name`) and topology annotations. |
+| `spec` | `LeaderWorkerSetSpec` | No | Full LWS spec for this role. The `rolloutStrategy` field is honored for per-role surge settings; `RolloutStrategy.Type` must be `RollingUpdate` (or empty). `RolloutStrategy.RollingUpdateConfiguration.Partition` must **not** be set — `DisaggregatedSet` manages rollouts across all roles. |
+
+> **Note**: `DisaggregatedRoleSpec` embeds `leaderworkerset.LeaderWorkerSetTemplateSpec` inline. See the [LeaderWorkerSet API Reference](./leaderworkerset.v1) for the full field list.
+
+---
+
+## DisaggregatedSetStatus
+
+| Field | Type | Description |
+|---|---|---|
+| `roleStatuses` | `[]RoleStatus` | Per-role observed state. Order matches `spec.roles`. |
+| `conditions` | `[]metav1.Condition` | Standard conditions reflecting overall state. |
+
+### Condition Types
+
+| Type | Meaning |
+|---|---|
+| `Available` | All roles are fully functional and `readyReplicas == replicas` for each role. |
+| `Progressing` | The `DisaggregatedSet` is being created or a rolling update is in progress. |
+| `Degraded` | The `DisaggregatedSet` failed to reach or maintain its desired state. |
+
+---
+
+## RoleStatus
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Role name (matches `spec.roles[].name`). |
+| `replicas` | `int32` | Total number of LWS replicas for this role. |
+| `readyReplicas` | `int32` | Number of replicas that are `Ready`. |
+| `updatedReplicas` | `int32` | Number of replicas updated to the latest revision. |
+
+---
+
+## Labels and Annotations
+
+### Labels (applied to managed LeaderWorkerSets and their pods)
+
+| Key | Description |
+|---|---|
+| `disaggregatedset.x-k8s.io/name` | Name of the parent `DisaggregatedSet`. |
+| `disaggregatedset.x-k8s.io/role` | Name of the role (e.g. `prefill`, `decode`). |
+| `disaggregatedset.x-k8s.io/revision` | Truncated hash of all role templates for this revision, enabling revision-aware traffic routing. |
+
+### Annotations (applied to managed LeaderWorkerSets)
+
+| Key | Description |
+|---|---|
+| `disaggregatedset.x-k8s.io/initial-replicas` | Starting replica count recorded at the beginning of a rolling update. Used internally by the rolling update planner; do not edit manually. |
+
+---
+
+## Headless Services
+
+For each role and revision, the controller automatically creates a headless `Service` named:
+
+```
+{disaggregatedset-name}-{revision-hash}-{role-name}-prv
+```
+
+These services enable revision-aware load balancers (such as [llm-d](https://github.com/llm-d/llm-d))
+to count pods per revision across all role pools and distribute traffic proportionally during rolling updates.
+Services are owned by the `DisaggregatedSet` and garbage-collected when the parent resource is deleted.


### PR DESCRIPTION
## What this PR does

Closes #806.

Adds first-party website documentation for the `DisaggregatedSet` API
(`disaggregatedset.x-k8s.io/v1`), which is bundled with the LWS controller
manager from v0.9.0 onwards. Users evaluating disaggregated inference (e.g.
prefill/decode splits with vLLM, SGLang, or NVIDIA Dynamo) previously had no
on-site guide, increasing onboarding friction.

---

### Pages added / modified

| File | Change | Covers |
|---|---|---|
| `site/content/en/docs/concepts/disaggregatedset.md` | **New** | Purpose, relationship to LWS, naming conventions, labels, N-dimensional rolling update algorithm, link to KEP-766 |
| `site/content/en/docs/installation/disaggregatedset.md` | **New** | Bundled-by-default note, CRD readiness check, controller log verification, version-specific install, clean uninstall guidance |
| `site/content/en/docs/reference/disaggregatedset.v1.md` | **New** | Full API field reference: DisaggregatedSetSpec, DisaggregatedRoleSpec, Status, conditions, labels, annotations, headless Service naming |
| `site/content/en/docs/examples/disaggregatedset.md` | **New** | Minimal 2-role (prefill/decode) nginx example with verification commands; pointer to 3-role sample |
| `site/content/en/docs/overview/_index.md` | **Modified** | DisaggregatedSet callout under Feature Overview linking to concepts and examples |
| `site/content/en/docs/adoption/_index.md` | **Modified** | Tip block after llm-d entry (P/D disaggregated serving) pointing to DisaggregatedSet API |
| `site/content/en/docs/reference/_index.md` | **Modified** | Index body listing LWS, DisaggregatedSet, and Labels references |

### Tasks from issue 806

- [x] Task 1 — Concept / overview (`concepts/disaggregatedset.md`)
- [x] Task 2 — Installation (`installation/disaggregatedset.md`)
- [x] Task 3 — Reference (`reference/disaggregatedset.v1.md`)
- [x] Task 4 — Examples (`examples/disaggregatedset.md`)
- [x] Task 5 — Navigation and cross-links (overview, adoption, reference index)