### PR TITLE
Helm: fix Prometheus ServiceMonitor for 'enablePrometheus: true'

### DIFF
--- a/charts/lws/templates/manager/service.yaml
+++ b/charts/lws/templates/manager/service.yaml
@@ -16,4 +16,5 @@ spec:
       targetPort: 8443
   selector:
     control-plane: controller-manager
+    {{- include "lws.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/lws/templates/prometheus/monitor.yaml
+++ b/charts/lws/templates/prometheus/monitor.yaml
@@ -34,5 +34,5 @@ spec:
         {{- end }}
   selector:
     matchLabels:
-      control-plane: controller-manager
+      {{- include "lws.labels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

this PR fixes Prometheus scraping which is not working at all because of a labels mismatch.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
