### PR TITLE
Fix cert-manager CA injection for Helm webhooks

### DIFF
--- a/charts/lws/templates/webhook/webhook.yaml
+++ b/charts/lws/templates/webhook/webhook.yaml
@@ -2,6 +2,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: lws-mutating-webhook-configuration
+{{ if .Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/lws-serving-cert
+{{ end }}
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -51,6 +55,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: lws-validating-webhook-configuration
+{{ if .Values.enableCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/lws-serving-cert
+{{ end }}
 webhooks:
   - admissionReviewVersions:
       - v1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The Helm chart enables cert-manager for webhook TLS, but the mutating and validating webhook configurations were missing the `cert-manager.io/inject-ca-from` annotation. Without that annotation, cert-manager does not inject the CA bundle into the webhook configurations, so API server webhook calls can fail with x509 unknown authority errors.

This PR adds the cert-manager CA injection annotation to both Helm-rendered webhook configurations when `.Values.enableCertManager` is enabled, matching the working kustomize flow and pointing at the generated `lws-serving-cert` in the release namespace.

#### Which issue(s) this PR fixes

Fixes #902

#### Special notes for your reviewer

This only affects Helm installs with cert-manager enabled. The annotation is guarded by `.Values.enableCertManager`, so installs that manage webhook certificates another way should be unchanged.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Helm chart webhook TLS configuration to inject the cert-manager CA bundle into mutating and validating webhook configurations when cert-manager is enabled.
```
