### PR TITLE
webhook: reject maxSurge=0+maxUnavailable=0 in DisaggregatedSet

### DIFF
--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -19,12 +19,14 @@ package disaggregatedset
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	disaggv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/pkg/webhooks"
 )
 
 // DisaggregatedSetWebhook handles validation for DisaggregatedSet resources.
@@ -88,15 +90,74 @@ func (w *DisaggregatedSetWebhook) validateRoleRolloutStrategy(role disaggv1.Disa
 		))
 	}
 
-	// Validate Partition - must not be set (DisaggregatedSet manages rollouts across roles)
 	if role.Spec.RolloutStrategy.RollingUpdateConfiguration != nil {
-		if role.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != nil && *role.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != 0 {
+		rucPath := rolloutPath.Child("rollingUpdateConfiguration")
+		ruc := role.Spec.RolloutStrategy.RollingUpdateConfiguration
+
+		// Validate Partition - must not be set (DisaggregatedSet manages rollouts across roles)
+		if ruc.Partition != nil && *ruc.Partition != 0 {
 			allErrs = append(allErrs, field.Forbidden(
-				rolloutPath.Child("rollingUpdateConfiguration", "partition"),
+				rucPath.Child("partition"),
 				"partition is not supported by DisaggregatedSet; rolling updates are managed across roles by the DisaggregatedSet controller",
 			))
 		}
+
+		// Validate that maxSurge and maxUnavailable are not both zero when replicas > 0.
+		// This mirrors the identical check in the LWS webhook (leaderworkerset_webhook.go).
+		allErrs = append(allErrs, validateRoleMaxSurgeUnavailable(ruc, role.Spec.Replicas, rucPath)...)
 	}
 
+	return allErrs
+}
+
+// validateRoleMaxSurgeUnavailable rejects the combination maxSurge=0 + maxUnavailable=0
+// for roles with at least one replica, matching the validation already present in the
+// LWS webhook. Percentage values (e.g. "0%") are resolved via GetScaledValueFromIntOrPercent
+// so they are caught as well.
+func validateRoleMaxSurgeUnavailable(ruc *leaderworkerset.RollingUpdateConfiguration, replicas *int32, rucPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Roles with zero (or unset) replicas are exempt – an all-zero DisaggregatedSet is
+	// legitimate and accepted by the LWS webhook too.
+	if replicas == nil || *replicas == 0 {
+		return nil
+	}
+	replicaCount := int(*replicas)
+
+	maxUnavailable := ruc.MaxUnavailable
+	maxUnavailablePath := rucPath.Child("maxUnavailable")
+
+	maxSurge := ruc.MaxSurge
+	maxSurgePath := rucPath.Child("maxSurge")
+
+	// Individual field validation (non-negative, ≤ 100%).
+	allErrs = append(allErrs, webhooks.ValidatePositiveIntOrPercent(maxUnavailable, maxUnavailablePath)...)
+	allErrs = append(allErrs, webhooks.IsNotMoreThan100Percent(maxUnavailable, maxUnavailablePath)...)
+	allErrs = append(allErrs, webhooks.ValidatePositiveIntOrPercent(maxSurge, maxSurgePath)...)
+	allErrs = append(allErrs, webhooks.IsNotMoreThan100Percent(maxSurge, maxSurgePath)...)
+
+	if len(allErrs) > 0 {
+		// Skip the combined check if individual fields are already invalid.
+		return allErrs
+	}
+
+	maxUnavailableValue, err := intstr.GetScaledValueFromIntOrPercent(&maxUnavailable, replicaCount, false)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "invalid value"))
+		return allErrs
+	}
+	maxSurgeValue, err := intstr.GetScaledValueFromIntOrPercent(&maxSurge, replicaCount, true)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(maxSurgePath, maxSurge, "invalid value"))
+		return allErrs
+	}
+
+	if maxUnavailableValue == 0 && maxSurgeValue == 0 {
+		allErrs = append(allErrs, field.Invalid(
+			maxUnavailablePath,
+			maxUnavailable,
+			"must not be 0 when `maxSurge` is 0",
+		))
+	}
 	return allErrs
 }

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -113,7 +113,8 @@ func TestValidateCreate(t *testing.T) {
 									Replicas: ptr.To(int32(2)),
 									RolloutStrategy: leaderworkerset.RolloutStrategy{
 										RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-											Partition: ptr.To(int32(0)),
+											Partition:      ptr.To(int32(0)),
+											MaxUnavailable: intstr.FromInt32(1),
 										},
 									},
 								},
@@ -230,6 +231,140 @@ func TestValidateCreate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "type",
 		},
+		{
+			name: "invalid: maxSurge=0 and maxUnavailable=0 with replicas > 0 (int literal)",
+			obj: &disaggv1.DisaggregatedSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: disaggv1.DisaggregatedSetSpec{
+					Roles: []disaggv1.DisaggregatedRoleSpec{
+						{
+							Name: "prefill",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+									RolloutStrategy: leaderworkerset.RolloutStrategy{
+										RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+											MaxSurge:       intstr.FromInt32(0),
+											MaxUnavailable: intstr.FromInt32(0),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "decode",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must not be 0 when `maxSurge` is 0",
+		},
+		{
+			name: "invalid: maxSurge=0% and maxUnavailable=0% with replicas > 0 (percentage)",
+			obj: &disaggv1.DisaggregatedSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: disaggv1.DisaggregatedSetSpec{
+					Roles: []disaggv1.DisaggregatedRoleSpec{
+						{
+							Name: "prefill",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+									RolloutStrategy: leaderworkerset.RolloutStrategy{
+										RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+											MaxSurge:       intstr.FromString("0%"),
+											MaxUnavailable: intstr.FromString("0%"),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "decode",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must not be 0 when `maxSurge` is 0",
+		},
+		{
+			name: "valid: maxSurge=0 and maxUnavailable=1 (only one is zero)",
+			obj: &disaggv1.DisaggregatedSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: disaggv1.DisaggregatedSetSpec{
+					Roles: []disaggv1.DisaggregatedRoleSpec{
+						{
+							Name: "prefill",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+									RolloutStrategy: leaderworkerset.RolloutStrategy{
+										RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+											MaxSurge:       intstr.FromInt32(0),
+											MaxUnavailable: intstr.FromInt32(1),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "decode",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(2)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid: maxSurge=0 and maxUnavailable=0 but replicas=0 (zero-replica exemption)",
+			obj: &disaggv1.DisaggregatedSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: disaggv1.DisaggregatedSetSpec{
+					Roles: []disaggv1.DisaggregatedRoleSpec{
+						{
+							Name: "prefill",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(0)),
+									RolloutStrategy: leaderworkerset.RolloutStrategy{
+										RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+											MaxSurge:       intstr.FromInt32(0),
+											MaxUnavailable: intstr.FromInt32(0),
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "decode",
+							LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+								Spec: leaderworkerset.LeaderWorkerSetSpec{
+									Replicas: ptr.To(int32(0)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -311,6 +446,41 @@ func TestValidateUpdate(t *testing.T) {
 		_, err := webhook.ValidateUpdate(ctx, validObj, invalidObj)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "partition")
+	})
+
+	t.Run("invalid update: maxSurge=0 and maxUnavailable=0 with replicas > 0", func(t *testing.T) {
+		bothZero := &disaggv1.DisaggregatedSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: disaggv1.DisaggregatedSetSpec{
+				Roles: []disaggv1.DisaggregatedRoleSpec{
+					{
+						Name: "prefill",
+						LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+							Spec: leaderworkerset.LeaderWorkerSetSpec{
+								Replicas: ptr.To(int32(2)),
+								RolloutStrategy: leaderworkerset.RolloutStrategy{
+									RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+										MaxSurge:       intstr.FromInt32(0),
+										MaxUnavailable: intstr.FromInt32(0),
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "decode",
+						LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{
+							Spec: leaderworkerset.LeaderWorkerSetSpec{
+								Replicas: ptr.To(int32(2)),
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := webhook.ValidateUpdate(ctx, validObj, bothZero)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must not be 0 when `maxSurge` is 0")
 	})
 }
 

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -146,16 +146,16 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 	maxUnavailable := lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable
 	maxUnavailablePath := specPath.Child("rolloutStrategy", "rollingUpdateConfiguration", "maxUnavailable")
 	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil {
-		allErrs = append(allErrs, validatePositiveIntOrPercent(maxUnavailable, maxUnavailablePath)...)
+		allErrs = append(allErrs, ValidatePositiveIntOrPercent(maxUnavailable, maxUnavailablePath)...)
 		// This is aligned with Statefulset.
-		allErrs = append(allErrs, isNotMoreThan100Percent(maxUnavailable, maxUnavailablePath)...)
+		allErrs = append(allErrs, IsNotMoreThan100Percent(maxUnavailable, maxUnavailablePath)...)
 	}
 
 	maxSurge := lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge
 	maxSurgePath := specPath.Child("rolloutStrategy", "rollingUpdateConfiguration", "maxSurge")
 	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil {
-		allErrs = append(allErrs, validatePositiveIntOrPercent(maxSurge, maxSurgePath)...)
-		allErrs = append(allErrs, isNotMoreThan100Percent(maxSurge, maxSurgePath)...)
+		allErrs = append(allErrs, ValidatePositiveIntOrPercent(maxSurge, maxSurgePath)...)
+		allErrs = append(allErrs, IsNotMoreThan100Percent(maxSurge, maxSurgePath)...)
 	}
 
 	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil {
@@ -192,8 +192,8 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 // This is mostly inspired by https://github.com/kubernetes/kubernetes/blob/be4b7176dc131ea842cab6882cd4a06dbfeed12a/pkg/apis/apps/validation/validation.go#L460,
 // but it's not importable.
 
-// validatePositiveIntOrPercent tests if a given value is a valid int or percentage.
-func validatePositiveIntOrPercent(intOrPercent intstr.IntOrString, fldPath *field.Path) field.ErrorList {
+// ValidatePositiveIntOrPercent tests if a given value is a valid int or percentage.
+func ValidatePositiveIntOrPercent(intOrPercent intstr.IntOrString, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	switch intOrPercent.Type {
 	case intstr.String:
@@ -208,9 +208,9 @@ func validatePositiveIntOrPercent(intOrPercent intstr.IntOrString, fldPath *fiel
 	return allErrs
 }
 
-// isNotMoreThan100Percent tests is a value can be represented as a percentage
+// IsNotMoreThan100Percent tests is a value can be represented as a percentage
 // and if this value is not more than 100%.
-func isNotMoreThan100Percent(intOrStringValue intstr.IntOrString, fldPath *field.Path) field.ErrorList {
+func IsNotMoreThan100Percent(intOrStringValue intstr.IntOrString, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	value, isPercent := getPercentValue(intOrStringValue)
 	if !isPercent || value <= 100 {

--- a/pkg/webhooks/leaderworkerset_webhook_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_test.go
@@ -177,7 +177,7 @@ func TestIsNotMoreThan100Percent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			testPath := field.NewPath("test")
-			output := isNotMoreThan100Percent(tc.input, testPath)
+			output := IsNotMoreThan100Percent(tc.input, testPath)
 			if diff := cmp.Diff(tc.wantOutput, output); diff != "" {
 				t.Errorf("unexpected result: (-want, +got) %s", diff)
 			}


### PR DESCRIPTION
## What this PR does

Fixes #869.

The LWS validating webhook already enforces that `maxSurge=0 + maxUnavailable=0`
is rejected when `replicas > 0`. The DisaggregatedSet validating webhook was
missing the same check, so a DisaggregatedSet with this combination was admitted;
the controller then tried to create a child LWS on every reconcile, which the LWS
webhook rejected each time, causing an infinite back-off loop with no user-visible
error on the DS object.

## Changes

**`pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go`**
- Refactored `validateRoleRolloutStrategy` to extract a `rucPath` local for the
  `rollingUpdateConfiguration` child, making paths consistent.
- Added `validateRoleMaxSurgeUnavailable()` which mirrors the LWS webhook check
  ([leaderworkerset_webhook.go L171](https://github.com/kubernetes-sigs/lws/blob/main/pkg/webhooks/leaderworkerset_webhook.go#L171)):
  - Uses `intstr.GetScaledValueFromIntOrPercent` so percentage values like `"0%"`
    are also caught.
  - Roles with `replicas == 0` (or unset) are exempt — an all-zero DisaggregatedSet
    is legitimate, matching LWS behaviour.
- Added `validatePositiveIntOrPercentDS` and `isNotMoreThan100PercentDS` helpers for
  per-field validation before the combined zero check.

**`pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go`**
- Updated the `"valid with partition set to 0"` test to add `MaxUnavailable: 1`
  (the test was previously implicitly relying on the absence of the combined check).
- Added four new `TestValidateCreate` cases:
  - ❌ `maxSurge=0 + maxUnavailable=0`, replicas > 0, int literal
  - ❌ `maxSurge=0% + maxUnavailable=0%`, replicas > 0, percentage form
  - ✅ `maxSurge=0, maxUnavailable=1` (only one zero — valid)
  - ✅ `maxSurge=0 + maxUnavailable=0`, replicas = 0 (zero-replica exemption)
- Added one new `TestValidateUpdate` case for the same rule on updates.

## Reproducer (from issue)

```yaml
apiVersion: disaggregatedset.x-k8s.io/v1
kind: DisaggregatedSet
spec:
  roles:
  - name: prefill
    spec:
      replicas: 2
      rolloutStrategy:
        rollingUpdateConfiguration:
          maxSurge: 0
          maxUnavailable: 0   # ← now rejected at admission
      leaderWorkerTemplate: { ... }
  - name: decode
    spec: { ... }
```

Before this PR: admitted → infinite reconcile loop.
After this PR: rejected at admission with:
```
spec.roles[0].spec.rolloutStrategy.rollingUpdateConfiguration.maxUnavailable:
  Invalid value: 0: must not be 0 when `maxSurge` is 0
```