### PR TITLE
fix: migrate deprecated commonLabels to labels for kustomize v5

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,9 +9,11 @@ namespace: lws-system
 namePrefix: lws-
 
 # Common labels to add to all resources and selectors (matches Helm behavior).
-commonLabels:
-  app.kubernetes.io/name: lws
-  app.kubernetes.io/instance: lws
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: lws
+      app.kubernetes.io/instance: lws
 
 resources:
 - ../crd


### PR DESCRIPTION
## Summary
This PR resolves the kustomize v5 deprecation warning for `config/default/kustomization.yaml` (issue #866).

- Replaces the deprecated `commonLabels` field with the kustomize v5 `labels` syntax using `includeSelectors: true`. This preserves the existing behaviour of injecting the labels into both metadata **and** selectors — `includeSelectors: true` is required so selector-injected labels don't mutate immutable `.spec.selector` fields on live clusters.
- Prior art: kueue performed the same migration in kubernetes-sigs/kueue#3091.

## Note on the cert-manager CA injection (issue #902)
The cert-manager CA injection half of the original change (adding the
`cert-manager.io/inject-ca-from` annotation to the webhook configurations)
was already merged upstream via #909, so this PR now contains **only** the
`commonLabels` → `labels` migration. The `webhook.yaml` change is dropped to
avoid duplication/conflict with #909.

## How to verify (issue #866)
Before:
```
kubectl kustomize config/default   # emits: commonLabels is deprecated
```
After:
```
kubectl kustomize config/default   # no deprecation warning
```

## Related issues
Fixes: #866
(issue #902 resolved by #909)