### PR TITLE
Fix SubGroupIndex assignment and TPU variables injection when SubGrou…

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
-  newTag: release-0.9
+  newTag: main

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,18 @@ rules:
 - apiGroups:
   - leaderworkerset.x-k8s.io
   resources:
+  - leaderworkersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
   - leaderworkersets/finalizers
   verbs:
   - update
@@ -133,22 +145,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - leaderworkerset.x-k8s.io
-  - leaderworkersetv1.x-k8s.io
-  resources:
-  - leaderworkersets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - leaderworkersetv1.x-k8s.io
-  resources:
-  - leaderworkersets/status
-  verbs:
-  - get

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -125,8 +125,9 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 	}
 	tpuWorkerId := (workerIndex) % subGroupSize
 
-	if pod.Annotations[LeaderRequestsTPUsAnnotationKey] != "true" {
+	if workerIndex != 0 && pod.Annotations[LeaderRequestsTPUsAnnotationKey] != "true" {
 		tpuWorkerId = (workerIndex - 1) % subGroupSize
+		subGroupIndex = (workerIndex - 1) / subGroupSize
 	}
 
 	tpuProcessPortInContainer, tpuProcessPort := podutils.GetEnvVarValueIfInContainer(container, TpuProcessPortName)

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -357,6 +357,50 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 		expectedError               bool
 	}{
 		{
+			name: "Leader requests TPU resources, leader pod",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-sample-0",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "0",
+						leaderworkerset.SubGroupIndexLabelKey: "0",
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupSizeAnnotationKey: "1",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "test-sample-0.default",
+			expectedTpuName:             "test-sample-0",
+			expectedTpuProcessAddresses: "test-sample-0.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
+			name: "Leader requests TPU resources, leader pod, size=2",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-sample-0",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "0",
+						leaderworkerset.SubGroupIndexLabelKey: "0",
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupSizeAnnotationKey: "2",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "test-sample-0.default,test-sample-0-1.default",
+			expectedTpuName:             "test-sample-0",
+			expectedTpuProcessAddresses: "test-sample-0.default:8476,test-sample-0-1.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
 			name: "Leader requests TPU resources",
 			pod: &corev1.Pod{
 				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
@@ -526,6 +570,96 @@ func TestAddTPUVariablesSubGroup(t *testing.T) {
 				},
 			},
 			expectedError: true,
+		},
+		{
+			name: "Worker 1 of group size 3 with subgroup size 1",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "prefill-0-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "1",
+						leaderworkerset.SubGroupIndexLabelKey: "1",
+					},
+					Annotations: map[string]string{
+						LeaderRequestsTPUsAnnotationKey:           "true",
+						leaderworkerset.SubGroupSizeAnnotationKey: "1",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "prefill-0-1.default",
+			expectedTpuName:             "prefill-0",
+			expectedTpuProcessAddresses: "prefill-0-1.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
+			name: "Worker 2 of group size 3 with subgroup size 1",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "prefill-0-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "2",
+						leaderworkerset.SubGroupIndexLabelKey: "2",
+					},
+					Annotations: map[string]string{
+						LeaderRequestsTPUsAnnotationKey:           "true",
+						leaderworkerset.SubGroupSizeAnnotationKey: "1",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "prefill-0-2.default",
+			expectedTpuName:             "prefill-0",
+			expectedTpuProcessAddresses: "prefill-0-2.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
+			name: "Leader does not request TPU resources, subGroupSize=1, worker 1",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "prefill-0-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "1",
+						leaderworkerset.SubGroupIndexLabelKey: "1",
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupSizeAnnotationKey: "1",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "prefill-0-1.default",
+			expectedTpuName:             "prefill-0",
+			expectedTpuProcessAddresses: "prefill-0-1.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
+			name: "Leader does not request TPU resources, subGroupSize=1, worker 2",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "prefill-0-2",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey:   "2",
+						leaderworkerset.SubGroupIndexLabelKey: "2",
+					},
+					Annotations: map[string]string{
+						leaderworkerset.SubGroupSizeAnnotationKey: "1",
+					},
+				},
+			},
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "prefill-0-2.default",
+			expectedTpuName:             "prefill-0",
+			expectedTpuProcessAddresses: "prefill-0-2.default:8476",
+			expectedTpuProcessPort:      "8476",
 		},
 		{
 			name: "Zero containers requesting TPUs",

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -247,7 +247,7 @@ func exclusiveAffinityApplied(pod corev1.Pod, topologyKey string) bool {
 }
 
 func getSubGroupIndex(podCount int, subGroupSize int, workerIndex int) string {
-	if (podCount-1)%subGroupSize == 0 {
+	if (podCount-1)%subGroupSize == 0 && podCount%subGroupSize != 0 {
 		// Leader is considered as extra pod, it is part of the first group
 		return fmt.Sprint((workerIndex - 1) / subGroupSize)
 	}

--- a/pkg/webhooks/pod_webhook_test.go
+++ b/pkg/webhooks/pod_webhook_test.go
@@ -292,6 +292,20 @@ func TestGetSubGroupIndex(t *testing.T) {
 			workerIndex:           2,
 			expectedSubGroupIndex: "0",
 		},
+		{
+			name:                  "SubGroupSize 1, workerIndex 1",
+			podCount:              3,
+			subGroupSize:          1,
+			workerIndex:           1,
+			expectedSubGroupIndex: "1",
+		},
+		{
+			name:                  "SubGroupSize 1, workerIndex 2",
+			podCount:              3,
+			subGroupSize:          1,
+			workerIndex:           2,
+			expectedSubGroupIndex: "2",
+		},
 	}
 
 	for _, tc := range tests {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -85,7 +85,7 @@ so CRD schema changes and newly added CRDs do not reach the cluster through
 Apply the CRDs explicitly before upgrading, then upgrade the release in place:
 
 ```shell
-CHART_VERSION=0.8.0
+CHART_VERSION=0.9.0
 helm pull oci://registry.k8s.io/lws/charts/lws --version=$CHART_VERSION --untar
 kubectl apply --server-side --force-conflicts -f lws/crds
 helm upgrade lws oci://registry.k8s.io/lws/charts/lws \

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -534,7 +534,7 @@ func CheckTPUContainerHasCorrectEnvVars(pod corev1.Pod, envVal string) error {
 					workerIndex, _ := strconv.Atoi(pod.Labels[leaderworkerset.WorkerIndexLabelKey])
 					subGroupSize, _ := strconv.Atoi(subGroupSizeStr)
 					podWorkerIndex := (workerIndex) % subGroupSize
-					if pod.Annotations[acceleratorutils.LeaderRequestsTPUsAnnotationKey] != "true" {
+					if workerIndex != 0 && pod.Annotations[acceleratorutils.LeaderRequestsTPUsAnnotationKey] != "true" {
 						podWorkerIndex = (workerIndex - 1) % subGroupSize
 					}
 					expectedIndex = podWorkerIndex*numTPUContainers + i


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

This PR fixes a bug in subgroup index assignment and TPU environment variables injection when `subGroupSize = 1` (Issue #917).

**The Bug:**
When `subGroupSize` is set to `1` (e.g., in TPU workloads where each pod represents an independent 1-slice TPU endpoint), the subgroup index calculation incorrectly evaluated the conditional `(podCount-1)%subGroupSize == 0` as true (since any integer modulo 1 is 0). This caused LWS to assume the leader was an extra pod and shift all worker subgroup indices to the left by 1:
- Pod `prefill-0` (Leader, `workerIndex=0`) got `subGroupIndex = 0`
- Pod `prefill-0-1` (`workerIndex=1`) got `subGroupIndex = 0` (colliding with the leader)
- Pod `prefill-0-2` (`workerIndex=2`) got `subGroupIndex = 1`

This incorrect labeling cascaded into `addTPUVariablesSubGroup`, leading to wrong hostnames in `TPU_WORKER_HOSTNAMES` (e.g., `prefill-0-1` pointed to the leader instead of itself).

**The Fix:**
Modified `getSubGroupIndex` in `pkg/webhooks/pod_webhook.go` to ensure that when the total pod count (including the leader) is divisible by the subgroup size (`podCount % subGroupSize == 0`), pods are partitioned into equal-sized subgroups without index shifts.

Added unit tests to `pkg/webhooks/pod_webhook_test.go` and `pkg/utils/accelerators/tpu_test.go` to cover `subGroupSize = 1` configurations.

#### Which issue(s) this PR fixes

Fixes #917

#### Special notes for your reviewer

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
