### PR TITLE
Add opt-in controller-driven rolling updates (rollout-via-delete)

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -96,6 +96,22 @@ const (
 	// Enables feature where the group will be restarted after pod failure if and only if
 	// all pods in the group are not pending
 	RecreateGroupAfterStartAnnotationKey string = "leaderworkerset.sigs.k8s.io/experimental-recreate-group-after-start"
+
+	// RolloutViaDelete opts a LeaderWorkerSet into controller-driven rolling updates:
+	// the leader statefulset uses the OnDelete update strategy and the lws controller
+	// deletes stale leader pods itself, at the concurrency allowed by the group-level
+	// maxUnavailable/maxSurge budget. Without it, updates are driven by the statefulset
+	// controller's RollingUpdate machinery, which recreates leaders one at a time
+	// unless the alpha MaxUnavailableStatefulSet feature gate is enabled.
+	// Must be "true" or "false"; defaults to "false".
+	RolloutViaDeleteAnnotationKey string = "leaderworkerset.sigs.k8s.io/rollout-via-delete"
+
+	// UpdatePartition is added to the leader statefulset to track the boundary of an
+	// in-flight rolling update: groups with index >= partition may be updated. The
+	// partition cannot live in spec.updateStrategy.rollingUpdate.partition when the
+	// statefulset uses the OnDelete update strategy (rollout-via-delete), so it is
+	// tracked here in both modes.
+	UpdatePartitionAnnotationKey string = "leaderworkerset.sigs.k8s.io/update-partition"
 )
 
 // One group consists of a single leader and M workers, and the total number of pods in a group is M+1.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,18 @@ rules:
 - apiGroups:
   - leaderworkerset.x-k8s.io
   resources:
+  - leaderworkersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
   - leaderworkersets/finalizers
   verbs:
   - update
@@ -133,22 +145,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - leaderworkerset.x-k8s.io
-  - leaderworkersetv1.x-k8s.io
-  resources:
-  - leaderworkersets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - leaderworkersetv1.x-k8s.io
-  resources:
-  - leaderworkersets/status
-  verbs:
-  - get

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -103,6 +103,7 @@ func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, 
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions/status,verbs=get;update;patch
@@ -174,16 +175,33 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if leaderSts == nil {
 		// An event is logged to track sts creation.
 		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created leader statefulset %s", lws.Name))
-	} else if !lwsUpdated && partition != *leaderSts.Spec.UpdateStrategy.RollingUpdate.Partition {
-		// An event is logged to track update progress.
-		oldPartition := *leaderSts.Spec.UpdateStrategy.RollingUpdate.Partition
-		var updateMsg string
-		if oldPartition-1 == partition {
-			updateMsg = fmt.Sprintf("Updating replica %d", partition)
-		} else {
-			updateMsg = fmt.Sprintf("Updating replicas %d to %d (inclusive)", partition, oldPartition-1)
+	} else if !lwsUpdated {
+		oldPartition, err := leaderStsUpdatePartition(leaderSts)
+		if err != nil {
+			log.Error(err, "Reading update partition from leader statefulset")
+			return ctrl.Result{}, err
 		}
-		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsUpdating, Update, updateMsg)
+		if partition != oldPartition {
+			// An event is logged to track update progress.
+			var updateMsg string
+			if oldPartition-1 == partition {
+				updateMsg = fmt.Sprintf("Updating replica %d", partition)
+			} else {
+				updateMsg = fmt.Sprintf("Updating replicas %d to %d (inclusive)", partition, oldPartition-1)
+			}
+			r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsUpdating, Update, updateMsg)
+		}
+	}
+
+	// With rollout-via-delete enabled, rolling updates are driven by deleting stale
+	// leader pods, see deleteLeaderPodsForUpdate. Gate on the fetched statefulset
+	// already carrying the target revision so that recreated pods pick up the new
+	// template rather than racing against the template update applied above.
+	if revisionKey := revisionutils.GetRevisionKey(revision); rolloutViaDelete(lws) && leaderSts != nil && revisionutils.GetRevisionKey(leaderSts) == revisionKey {
+		if err := r.deleteLeaderPodsForUpdate(ctx, lws, revisionKey, partition, replicas); err != nil {
+			log.Error(err, "Deleting stale leader pods for rolling update")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Create headless service if it does not exist.
@@ -307,6 +325,14 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 	if maxSurge > int(lwsReplicas) {
 		maxSurge = int(lwsReplicas)
 	}
+	// maxUnavailable percentages round down, so both budgets can resolve to zero even
+	// though the webhook rejects literal 0/0 (e.g. maxUnavailable=20% with 3 replicas,
+	// or after the scale subresource shrinks replicas mid-flight). Mirror the Deployment
+	// controller's ResolveFenceposts and bump maxUnavailable to 1 so the rolling update
+	// cannot stall.
+	if maxUnavailable == 0 && maxSurge == 0 {
+		maxUnavailable = 1
+	}
 	burstReplicas := lwsReplicas + int32(maxSurge)
 
 	// wantReplicas calculates the final replicas if needed.
@@ -331,7 +357,10 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 		return partition, wantReplicas(lwsReplicas), nil
 	}
 
-	partition := *sts.Spec.UpdateStrategy.RollingUpdate.Partition
+	partition, err := leaderStsUpdatePartition(sts)
+	if err != nil {
+		return 0, 0, err
+	}
 	rollingUpdateCompleted := partition == 0 && stsReplicas == lwsReplicas
 	// Case 3:
 	// In normal cases, return the values directly.
@@ -640,6 +669,85 @@ func (r *LeaderWorkerSetReconciler) getReplicaStates(ctx context.Context, lws *l
 	return states, nil
 }
 
+// rolloutViaDelete reports whether rolling updates for this LeaderWorkerSet are driven
+// by controller-side leader pod deletion (OnDelete leader statefulset) instead of the
+// statefulset controller's RollingUpdate machinery. The annotation value is validated
+// by the webhook.
+func rolloutViaDelete(lws *leaderworkerset.LeaderWorkerSet) bool {
+	return lws.Annotations[leaderworkerset.RolloutViaDeleteAnnotationKey] == "true"
+}
+
+// leaderStsUpdatePartition returns the rolling-update partition recorded on the leader
+// statefulset. The partition annotation is written in both rollout modes (OnDelete
+// forbids spec.updateStrategy.rollingUpdate, and keeping one source makes switching
+// modes on a live object seamless). For statefulsets created by pre-fork controller
+// versions the annotation does not exist yet, so fall back to the rollingUpdate
+// partition field; 0 (the at-rest value) otherwise.
+func leaderStsUpdatePartition(sts *appsv1.StatefulSet) (int32, error) {
+	if v, ok := sts.Annotations[leaderworkerset.UpdatePartitionAnnotationKey]; ok {
+		p, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("parsing %s annotation value %q of statefulset %s: %w", leaderworkerset.UpdatePartitionAnnotationKey, v, sts.Name, err)
+		}
+		return int32(p), nil
+	}
+	if sts.Spec.UpdateStrategy.RollingUpdate != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+		return *sts.Spec.UpdateStrategy.RollingUpdate.Partition, nil
+	}
+	return 0, nil
+}
+
+// deleteLeaderPodsForUpdate deletes leader pods that are inside the update window
+// [partition, replicas) but still carry a stale revision. The leader statefulset uses
+// the OnDelete update strategy with Parallel pod management, so the statefulset
+// controller recreates all deleted pods immediately with the updated template, and the
+// pod controller then rebuilds each group's worker statefulset at the new revision.
+//
+// This replaces driving the update through the statefulset controller's RollingUpdate
+// machinery, which recreates leaders strictly one at a time unless the alpha
+// MaxUnavailableStatefulSet feature gate is enabled (it is unavailable on managed
+// clusters). Deletion is level-triggered: the window is recomputed from live state on
+// every reconcile, so the group-level maxUnavailable budget encoded in the partition
+// is never exceeded.
+func (r *LeaderWorkerSetReconciler) deleteLeaderPodsForUpdate(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, revisionKey string, partition, replicas int32) error {
+	if partition >= replicas {
+		return nil
+	}
+	log := ctrl.LoggerFrom(ctx)
+
+	podSelector := client.MatchingLabels(map[string]string{
+		leaderworkerset.SetNameLabelKey:     lws.Name,
+		leaderworkerset.WorkerIndexLabelKey: "0",
+	})
+	var leaderPodList corev1.PodList
+	if err := r.List(ctx, &leaderPodList, podSelector, client.InNamespace(lws.Namespace)); err != nil {
+		return err
+	}
+
+	for i := range leaderPodList.Items {
+		pod := &leaderPodList.Items[i]
+		if pod.DeletionTimestamp != nil || revisionutils.GetRevisionKey(pod) == revisionKey {
+			continue
+		}
+		index, err := strconv.Atoi(pod.Labels[leaderworkerset.GroupIndexLabelKey])
+		if err != nil {
+			return fmt.Errorf("parsing group index of leader pod %s: %w", pod.Name, err)
+		}
+		if int32(index) < partition || int32(index) >= replicas {
+			continue
+		}
+		if err := r.Delete(ctx, pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		log.V(2).Info("Deleted leader pod for rolling update", "pod", klog.KObj(pod))
+		r.Record.Eventf(lws, nil, corev1.EventTypeNormal, GroupsUpdating, Delete, fmt.Sprintf("Deleted leader pod %s to update group %d", pod.Name, index))
+	}
+	return nil
+}
+
 func rollingUpdatePartition(states []replicaState, stsReplicas int32, rollingStep int32, currentPartition int32) int32 {
 	continuousReadyReplicas := calculateContinuousReadyReplicas(states)
 
@@ -808,26 +916,21 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 
 	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
 
-	lwsReplicas := int(*lws.Spec.Replicas)
-	lwsMaxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable, lwsReplicas, false)
-	if err != nil {
-		return nil, err
+	// With rollout-via-delete enabled, the statefulset uses the OnDelete update
+	// strategy: rolling updates are driven by the lws controller deleting stale leader
+	// pods (see deleteLeaderPodsForUpdate). Otherwise the statefulset controller drives
+	// updates through RollingUpdate with the partition field, as upstream does. The
+	// partition annotation is written in both modes.
+	updateStrategy := appsapplyv1.StatefulSetUpdateStrategy().WithType(appsv1.OnDeleteStatefulSetStrategyType)
+	if !rolloutViaDelete(lws) {
+		stsMaxUnavailable, err := legacyStsMaxUnavailable(lws)
+		if err != nil {
+			return nil, err
+		}
+		updateStrategy = appsapplyv1.StatefulSetUpdateStrategy().
+			WithType(appsv1.StatefulSetUpdateStrategyType(lws.Spec.RolloutStrategy.Type)).
+			WithRollingUpdate(appsapplyv1.RollingUpdateStatefulSetStrategy().WithMaxUnavailable(stsMaxUnavailable).WithPartition(partition))
 	}
-	lwsMaxSurge, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge, lwsReplicas, true)
-	if err != nil {
-		return nil, err
-	}
-	if lwsMaxSurge > lwsReplicas {
-		lwsMaxSurge = lwsReplicas
-	}
-	stsMaxUnavailableInt := int32(lwsMaxUnavailable + lwsMaxSurge)
-	// lwsMaxUnavailable=0 and lwsMaxSurge=0 together should be blocked by webhook,
-	// but just in case, we'll make sure that stsMaxUnavailable is at least 1.
-	// This also handles the case when lws.Spec.Replicas is 0.
-	if stsMaxUnavailableInt < 1 {
-		stsMaxUnavailableInt = 1
-	}
-	stsMaxUnavailable := intstr.FromInt32(stsMaxUnavailableInt)
 
 	// construct statefulset apply configuration
 	statefulSetConfig := appsapplyv1.StatefulSet(lws.Name, lws.Namespace).
@@ -836,9 +939,7 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 			WithReplicas(replicas).
 			WithPodManagementPolicy(appsv1.ParallelPodManagement).
 			WithTemplate(&podTemplateApplyConfiguration).
-			WithUpdateStrategy(appsapplyv1.StatefulSetUpdateStrategy().WithType(appsv1.StatefulSetUpdateStrategyType(lws.Spec.RolloutStrategy.Type)).WithRollingUpdate(
-				appsapplyv1.RollingUpdateStatefulSetStrategy().WithMaxUnavailable(stsMaxUnavailable).WithPartition(partition),
-			)).
+			WithUpdateStrategy(updateStrategy).
 			WithSelector(metaapplyv1.LabelSelector().
 				WithMatchLabels(map[string]string{
 					leaderworkerset.SetNameLabelKey:     lws.Name,
@@ -849,7 +950,8 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 			leaderworkerset.RevisionKey:     revisionKey,
 		}).
 		WithAnnotations(map[string]string{
-			leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
+			leaderworkerset.ReplicasAnnotationKey:        strconv.Itoa(int(*lws.Spec.Replicas)),
+			leaderworkerset.UpdatePartitionAnnotationKey: strconv.Itoa(int(partition)),
 		})
 
 	pvcApplyConfiguration := controllerutils.GetPVCApplyConfiguration(lws)
@@ -865,6 +967,32 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 		statefulSetConfig.Spec.WithPersistentVolumeClaimRetentionPolicy(pvcRetentionPolicy)
 	}
 	return statefulSetConfig, nil
+}
+
+// legacyStsMaxUnavailable computes the maxUnavailable applied to the leader statefulset
+// when the statefulset controller drives rolling updates (rollout-via-delete disabled).
+// It only takes effect when the alpha MaxUnavailableStatefulSet feature gate is enabled;
+// without it the statefulset controller recreates leaders one at a time.
+func legacyStsMaxUnavailable(lws *leaderworkerset.LeaderWorkerSet) (intstr.IntOrString, error) {
+	lwsReplicas := int(*lws.Spec.Replicas)
+	lwsMaxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable, lwsReplicas, false)
+	if err != nil {
+		return intstr.IntOrString{}, err
+	}
+	lwsMaxSurge, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge, lwsReplicas, true)
+	if err != nil {
+		return intstr.IntOrString{}, err
+	}
+	if lwsMaxSurge > lwsReplicas {
+		lwsMaxSurge = lwsReplicas
+	}
+	stsMaxUnavailable := int32(lwsMaxUnavailable + lwsMaxSurge)
+	// Percentages can scale both budgets to zero (also covers lws.Spec.Replicas == 0);
+	// make sure stsMaxUnavailable is at least 1.
+	if stsMaxUnavailable < 1 {
+		stsMaxUnavailable = 1
+	}
+	return intstr.FromInt32(stsMaxUnavailable), nil
 }
 
 func makeCondition(conditionType leaderworkerset.LeaderWorkerSetConditionType, lws *leaderworkerset.LeaderWorkerSet) metav1.Condition {

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -99,7 +99,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -167,7 +167,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -236,7 +236,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](2),
@@ -303,7 +303,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -370,7 +370,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -407,7 +407,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					UpdateStrategy: appsapplyv1.StatefulSetUpdateStrategy().
 						WithType(appsv1.RollingUpdateStatefulSetStrategyType).
 						// maxSurge is capped at 1 (the value of lwsReplicas),
-						// so stsMaxUnavailableInt = 0 (lwsMaxUnavailable) + 1 (capped maxSurge) = 1.
+						// so stsMaxUnavailable = 0 (lwsMaxUnavailable) + 1 (capped maxSurge) = 1.
 						WithRollingUpdate(appsapplyv1.RollingUpdateStatefulSetStrategy().WithPartition(0).WithMaxUnavailable(intstr.FromInt32(1))),
 				},
 			},
@@ -440,7 +440,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -529,7 +529,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](1),
@@ -625,7 +625,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "0"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "0", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](0),
@@ -696,7 +696,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
 					},
-					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2"},
+					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2", "leaderworkerset.sigs.k8s.io/update-partition": "0"},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
 					Replicas: ptr.To[int32](3), // using stsReplicas
@@ -733,7 +733,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					UpdateStrategy: appsapplyv1.StatefulSetUpdateStrategy().
 						WithType(appsv1.RollingUpdateStatefulSetStrategyType).
 						// maxUnavailable=1, maxSurge=50% of 2 replicas (lwsReplicas) = 1.
-						// So stsMaxUnavailableInt = 1 + 1 = 2
+						// So stsMaxUnavailable = 1 + 1 = 2
 						WithRollingUpdate(appsapplyv1.RollingUpdateStatefulSetStrategy().WithPartition(0).WithMaxUnavailable(intstr.FromInt32(2))),
 				},
 			},
@@ -1007,6 +1007,228 @@ func TestRollingUpdateParametersTemplateUpdateReclaimsSurgeWhenAllowed(t *testin
 	}
 	if replicas != 3 {
 		t.Fatalf("rollingUpdateParameters() replicas=%d, want 3", replicas)
+	}
+}
+
+// With rollout-via-delete enabled, the leader statefulset must use the OnDelete update
+// strategy (no rollingUpdate config) while still recording the partition annotation.
+func TestLeaderStatefulSetApplyConfigRolloutViaDelete(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Replica(2).
+		Size(2).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				Partition:      ptr.To[int32](0),
+				MaxUnavailable: intstr.FromInt32(1),
+				MaxSurge:       intstr.FromInt32(0),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		RolloutViaDelete(true).Obj()
+
+	stsApplyConfig, err := constructLeaderStatefulSetApplyConfiguration(lws, 1, 2, "test-hash")
+	if err != nil {
+		t.Fatalf("constructLeaderStatefulSetApplyConfiguration() unexpected error: %v", err)
+	}
+
+	wantStrategy := appsapplyv1.StatefulSetUpdateStrategy().WithType(appsv1.OnDeleteStatefulSetStrategyType)
+	if diff := cmp.Diff(wantStrategy, stsApplyConfig.Spec.UpdateStrategy); diff != "" {
+		t.Errorf("unexpected update strategy: %s", diff)
+	}
+	if got := stsApplyConfig.Annotations[leaderworkerset.UpdatePartitionAnnotationKey]; got != "1" {
+		t.Errorf("update-partition annotation=%q, want %q", got, "1")
+	}
+}
+
+// Toggling rollout-via-delete on a live LeaderWorkerSet must not change its revision
+// key: revisions hash only the leader/worker template (and network config), so the
+// annotation can be enabled on a production object without triggering a rolling update.
+func TestRolloutViaDeleteAnnotationDoesNotChangeRevision(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Replica(3).
+		Size(2).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).Obj()
+
+	before, err := revisionutils.NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	annotated := wrappers.LeaderWorkerSetWrapper{LeaderWorkerSet: *lws.DeepCopy()}
+	after, err := revisionutils.NewRevision(context.TODO(), client, annotated.RolloutViaDelete(true).Obj(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !revisionutils.EqualRevision(before, after) {
+		t.Errorf("enabling %s changed the revision: %q -> %q", leaderworkerset.RolloutViaDeleteAnnotationKey, revisionutils.GetRevisionKey(before), revisionutils.GetRevisionKey(after))
+	}
+}
+
+func makeTestLeaderPod(lwsName, namespace string, groupIndex int, revisionKey string, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lwsName + "-" + strconv.Itoa(groupIndex),
+			Namespace: namespace,
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     lwsName,
+				leaderworkerset.WorkerIndexLabelKey: "0",
+				leaderworkerset.GroupIndexLabelKey:  strconv.Itoa(groupIndex),
+				leaderworkerset.RevisionKey:         revisionKey,
+			},
+		},
+	}
+	if ready {
+		pod.Status.Phase = corev1.PodRunning
+		pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	return pod
+}
+
+// A percentage maxUnavailable that rounds down to zero (20% of 3 replicas) must not
+// stall the rolling update: the resolved budget is bumped to 1, mirroring the
+// Deployment controller's ResolveFenceposts.
+func TestRollingUpdateParametersPercentMaxUnavailableDoesNotStall(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Replica(3).
+		Size(1).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				Partition:      ptr.To[int32](0),
+				MaxUnavailable: intstr.FromString("20%"),
+				MaxSurge:       intstr.FromInt32(0),
+			},
+		}).Obj()
+
+	// All three groups are ready at the old revision; the rollout has not progressed yet.
+	client := fake.NewClientBuilder().WithObjects(
+		makeTestLeaderPod(lws.Name, lws.Namespace, 0, "rev-old", true),
+		makeTestLeaderPod(lws.Name, lws.Namespace, 1, "rev-old", true),
+		makeTestLeaderPod(lws.Name, lws.Namespace, 2, "rev-old", true),
+	).Build()
+	reconciler := &LeaderWorkerSetReconciler{Client: client, Record: fakeEventRecorder{}}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lws.Name,
+			Namespace: lws.Namespace,
+			Annotations: map[string]string{
+				leaderworkerset.ReplicasAnnotationKey:        strconv.Itoa(3),
+				leaderworkerset.UpdatePartitionAnnotationKey: strconv.Itoa(3),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To[int32](3),
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.OnDeleteStatefulSetStrategyType,
+			},
+		},
+	}
+
+	partition, replicas, err := reconciler.rollingUpdateParameters(context.Background(), lws, sts, "rev-new", false)
+	if err != nil {
+		t.Fatalf("rollingUpdateParameters() unexpected error: %v", err)
+	}
+	// Without the fencepost the rolling step would be 0 and the partition would stay at 3.
+	if partition != 2 {
+		t.Fatalf("rollingUpdateParameters() partition=%d, want 2", partition)
+	}
+	if replicas != 3 {
+		t.Fatalf("rollingUpdateParameters() replicas=%d, want 3", replicas)
+	}
+}
+
+func TestLeaderStsUpdatePartition(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		rollingUpdate *appsv1.RollingUpdateStatefulSetStrategy
+		wantPartition int32
+		wantErr       bool
+	}{
+		{
+			name:          "partition from annotation",
+			annotations:   map[string]string{leaderworkerset.UpdatePartitionAnnotationKey: "5"},
+			wantPartition: 5,
+		},
+		{
+			name:          "missing annotation falls back to rollingUpdate partition of pre-fork statefulsets",
+			rollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{Partition: ptr.To[int32](2)},
+			wantPartition: 2,
+		},
+		{
+			name:          "missing annotation and no rollingUpdate defaults to the at-rest value",
+			wantPartition: 0,
+		},
+		{
+			name:        "unparseable annotation errors",
+			annotations: map[string]string{leaderworkerset.UpdatePartitionAnnotationKey: "not-a-number"},
+			wantErr:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Annotations: tc.annotations},
+				Spec: appsv1.StatefulSetSpec{
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{RollingUpdate: tc.rollingUpdate},
+				},
+			}
+			partition, err := leaderStsUpdatePartition(sts)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("leaderStsUpdatePartition() expected error, got partition=%d", partition)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("leaderStsUpdatePartition() unexpected error: %v", err)
+			}
+			if partition != tc.wantPartition {
+				t.Fatalf("leaderStsUpdatePartition()=%d, want %d", partition, tc.wantPartition)
+			}
+		})
+	}
+}
+
+func TestDeleteLeaderPodsForUpdate(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").Replica(5).Size(1).Obj()
+
+	// Pod 3 is stale and in the window but already terminating; it must be left alone
+	// (a finalizer keeps it visible to the fake client after deletion).
+	terminatingPod := makeTestLeaderPod(lws.Name, lws.Namespace, 3, "rev-old", true)
+	terminatingPod.Finalizers = []string{"test.example.com/hold"}
+
+	client := fake.NewClientBuilder().WithObjects(
+		makeTestLeaderPod(lws.Name, lws.Namespace, 0, "rev-old", true), // below partition, kept
+		makeTestLeaderPod(lws.Name, lws.Namespace, 1, "rev-old", true), // stale and in window, deleted
+		makeTestLeaderPod(lws.Name, lws.Namespace, 2, "rev-new", true), // already updated, kept
+		terminatingPod,
+		makeTestLeaderPod(lws.Name, lws.Namespace, 4, "rev-old", true), // above replicas (scaling down), kept
+	).Build()
+	if err := client.Delete(context.Background(), terminatingPod); err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &LeaderWorkerSetReconciler{Client: client, Record: fakeEventRecorder{}}
+
+	if err := reconciler.deleteLeaderPodsForUpdate(context.Background(), lws, "rev-new", 1, 4); err != nil {
+		t.Fatalf("deleteLeaderPodsForUpdate() unexpected error: %v", err)
+	}
+
+	var podList corev1.PodList
+	if err := client.List(context.Background(), &podList); err != nil {
+		t.Fatal(err)
+	}
+	remaining := map[string]bool{}
+	for _, pod := range podList.Items {
+		remaining[pod.Name] = true
+	}
+	want := map[string]bool{"test-sample-0": true, "test-sample-2": true, "test-sample-3": true, "test-sample-4": true}
+	if diff := cmp.Diff(want, remaining); diff != "" {
+		t.Errorf("unexpected remaining leader pods: %s", diff)
 	}
 }
 

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -165,17 +165,24 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 		allErrs = append(allErrs, validateNonnegativeField(int64(*partition), partitionPath)...)
 	}
 
-	maxUnavailableValue, err := intstr.GetScaledValueFromIntOrPercent(&maxUnavailable, int(*lws.Spec.Replicas), false)
-	if err != nil {
+	if _, err := intstr.GetScaledValueFromIntOrPercent(&maxUnavailable, int(*lws.Spec.Replicas), false); err != nil {
 		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "invalid value"))
 	}
-	maxSurgeValue, err := intstr.GetScaledValueFromIntOrPercent(&maxSurge, int(*lws.Spec.Replicas), true)
-	if err != nil {
+	if _, err := intstr.GetScaledValueFromIntOrPercent(&maxSurge, int(*lws.Spec.Replicas), true); err != nil {
 		allErrs = append(allErrs, field.Invalid(maxSurgePath, maxSurge, "invalid value"))
 	}
-	if maxUnavailableValue == 0 && maxSurgeValue == 0 && *lws.Spec.Replicas != 0 {
+	// Reject only literal zero for both budgets, mirroring Deployment validation.
+	// Percentage values that scale to zero at the current replica count (e.g.
+	// maxUnavailable=20% with 3 replicas) are allowed: the controller bumps the
+	// resolved maxUnavailable to 1, like the Deployment controller's
+	// ResolveFenceposts, and replicas may change via the scale subresource anyway.
+	if getIntOrPercentValue(maxUnavailable) == 0 && getIntOrPercentValue(maxSurge) == 0 {
 		// Both MaxSurge and MaxUnavailable cannot be zero.
 		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "must not be 0 when `maxSurge` is 0"))
+	}
+
+	if v, ok := lws.Annotations[v1.RolloutViaDeleteAnnotationKey]; ok && v != "true" && v != "false" {
+		allErrs = append(allErrs, field.Invalid(metadataPath.Child("annotations", v1.RolloutViaDeleteAnnotationKey), v, "must be \"true\" or \"false\""))
 	}
 
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
@@ -228,6 +235,15 @@ func getPercentValue(intOrStringValue intstr.IntOrString) (int, bool) {
 	}
 	value, _ := strconv.Atoi(intOrStringValue.StrVal[:len(intOrStringValue.StrVal)-1])
 	return value, true
+}
+
+// getIntOrPercentValue returns the raw numeric value regardless of whether it is a
+// percentage, matching how Deployment validation checks for literal zeros.
+func getIntOrPercentValue(intOrStringValue intstr.IntOrString) int {
+	if value, isPercent := getPercentValue(intOrStringValue); isPercent {
+		return value
+	}
+	return intOrStringValue.IntValue()
 }
 
 // validateNonnegativeField validates that given value is not negative.

--- a/pkg/webhooks/leaderworkerset_webhook_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_test.go
@@ -82,6 +82,45 @@ func TestGetPercentValue(t *testing.T) {
 	}
 }
 
+func TestGetIntOrPercentValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input intstr.IntOrString
+		want  int
+	}{
+		{
+			name:  "int value",
+			input: intstr.FromInt32(3),
+			want:  3,
+		},
+		{
+			name:  "literal zero",
+			input: intstr.FromInt32(0),
+			want:  0,
+		},
+		{
+			// A nonzero percentage is nonzero even if it would scale to zero at the
+			// current replica count; the controller resolves it with a floor of 1.
+			name:  "percentage returns raw value",
+			input: intstr.FromString("20%"),
+			want:  20,
+		},
+		{
+			name:  "zero percentage",
+			input: intstr.FromString("0%"),
+			want:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getIntOrPercentValue(tc.input); got != tc.want {
+				t.Errorf("getIntOrPercentValue(%v)=%d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateNonnegativeOrZeroField(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -660,7 +660,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						// soon updated to 3 (replicas-maxUnavailable), it's fine here.
 						testing.ValidateEvent(ctx, k8sClient, controllers.GroupsUpdating, corev1.EventTypeNormal, "Updating replica 3", lws.Namespace)
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale leader pod in the update window (index 3) is deleted by the
+						// controller, so only the 3 groups below the partition remain ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 					},
 				},
 				{
@@ -675,7 +677,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ValidateEvent(ctx, k8sClient, controllers.GroupsUpdating, corev1.EventTypeNormal, "Updating replica 2", lws.Namespace)
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+						// Group 2 is now inside the update window, so its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
 					},
 				},
 				{
@@ -689,7 +692,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
+						// Group 2's leader pod is still deleted (recreated only when set ready).
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
 					},
 				},
 				{
@@ -705,8 +709,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						// 3-index status is unready but template already updated.
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
+						// 3-index status is unready but template already updated; group 2's
+						// stale leader pod remains deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
 					},
 				},
 				{
@@ -721,6 +726,152 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+					},
+				},
+			},
+		}),
+		// Toggling rollout-via-delete on a live lws is the per-pool enablement (and
+		// rollback) operation: it must switch the leader statefulset's update strategy
+		// without disturbing pods or creating a new revision.
+		ginkgo.Entry("toggling rollout-via-delete switches update strategy without disturbing pods", &testCase{
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(2).RolloutViaDelete(false)
+			},
+			updates: []*update{
+				{
+					// Set lws to available condition; statefulset-driven updates by default.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetSuperPodToReady(ctx, k8sClient, lws, 2)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
+						gomega.Eventually(func(g gomega.Gomega) {
+							var sts appsv1.StatefulSet
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
+							g.Expect(sts.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1.RollingUpdateStatefulSetStrategyType))
+							g.Expect(sts.Spec.UpdateStrategy.RollingUpdate).NotTo(gomega.BeNil())
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+				},
+				{
+					// Enable rollout-via-delete.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						gomega.Eventually(func() error {
+							var fetched leaderworkerset.LeaderWorkerSet
+							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &fetched); err != nil {
+								return err
+							}
+							fetched.Annotations[leaderworkerset.RolloutViaDeleteAnnotationKey] = "true"
+							return k8sClient.Update(ctx, &fetched)
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						gomega.Eventually(func(g gomega.Gomega) {
+							var sts appsv1.StatefulSet
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
+							g.Expect(sts.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1.OnDeleteStatefulSetStrategyType))
+							g.Expect(sts.Spec.UpdateStrategy.RollingUpdate).To(gomega.BeNil())
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
+						// Pods are untouched and no new revision is created.
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
+					},
+				},
+				{
+					// Disable it again (the rollback operation).
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						gomega.Eventually(func() error {
+							var fetched leaderworkerset.LeaderWorkerSet
+							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &fetched); err != nil {
+								return err
+							}
+							fetched.Annotations[leaderworkerset.RolloutViaDeleteAnnotationKey] = "false"
+							return k8sClient.Update(ctx, &fetched)
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						gomega.Eventually(func(g gomega.Gomega) {
+							var sts appsv1.StatefulSet
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
+							g.Expect(sts.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1.RollingUpdateStatefulSetStrategyType))
+							g.Expect(sts.Spec.UpdateStrategy.RollingUpdate).NotTo(gomega.BeNil())
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
+					},
+				},
+			},
+		}),
+		// Without the rollout-via-delete annotation, updates keep the upstream shape:
+		// the leader statefulset uses the RollingUpdate strategy driven by the partition
+		// field, and the lws controller never deletes leader pods. Groups are updated by
+		// flipping revision labels in place, so ready counts stay at full replicas.
+		ginkgo.Entry("workerTemplate changed without rollout-via-delete keeps statefulset-driven updates", &testCase{
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxUnavailable(2).RolloutViaDelete(false)
+			},
+			updates: []*update{
+				{
+					// Set lws to available condition.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetSuperPodToReady(ctx, k8sClient, lws, 4)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						gomega.Eventually(func(g gomega.Gomega) {
+							var sts appsv1.StatefulSet
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
+							g.Expect(sts.Spec.UpdateStrategy.Type).To(gomega.Equal(appsv1.RollingUpdateStatefulSetStrategyType))
+							g.Expect(sts.Spec.UpdateStrategy.RollingUpdate).NotTo(gomega.BeNil())
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+				},
+				{
+					// Update the worker template.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.UpdateWorkerTemplate(ctx, k8sClient, lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
+						// No pods are deleted: all 4 groups stay ready even though the two in
+						// the update window still run the old revision.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+					},
+				},
+				{
+					// Rolling update index-3 replica.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-3", lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+					},
+				},
+				{
+					// Rolling update the rest of the replicas.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-2", lws)
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-1", lws)
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-0", lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
 						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
 					},
 				},
@@ -755,7 +906,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The two stale leader pods in the update window (indexes 2, 3) are
+						// deleted by the controller.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 0)
 					},
 				},
 				{
@@ -769,7 +922,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+						// Group 1 enters the update window and its stale leader pod is deleted;
+						// group 2's leader pod is still deleted as well.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 1)
 					},
 				},
 				{
@@ -783,7 +938,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
+						// Groups 2, 3 are updated and ready; groups 0, 1 had their stale leader
+						// pods deleted once the partition reached 0.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
 					},
 				},
 				{
@@ -833,7 +990,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// maxUnavailable exceeds replicas, so all stale leader pods are deleted at once.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 0, 0)
 					},
 				},
 				{
@@ -942,7 +1100,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale leader pod in the update window (index 3) is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 					},
 				},
 				{
@@ -956,7 +1115,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+						// Group 2 enters the update window and its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
 					},
 				},
 				{
@@ -985,7 +1145,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 3)
+						// Group 2's stale leader pod stays deleted until it is set ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 3)
 					},
 				},
 				{
@@ -1041,7 +1202,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 5)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 0)
+						// The stale leader pod in the update window (index 5) is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 0)
 					},
 				},
 				{
@@ -1065,7 +1227,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
+						// Group 2 is inside the update window and its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 0)
 					},
 				},
 				{
@@ -1140,7 +1303,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 1)
+						// Group 3 enters the update window and its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
 					},
 				},
 				{
@@ -1154,7 +1318,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 2)
+						// Group 2's stale leader pod is deleted once the partition reaches 2.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
 					},
 				},
 				{
@@ -1168,7 +1333,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 3)
+						// Group 1's stale leader pod is deleted once the partition reaches 1.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 3)
 					},
 				},
 				{
@@ -1182,7 +1348,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 4)
+						// Group 0's stale leader pod is deleted once the partition reaches 0.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
 					},
 				},
 				{
@@ -1245,7 +1412,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale pods in the update window (index 3 and the surge pod 4,
+						// which was created at the old revision) are deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 					},
 				},
 				{
@@ -1259,7 +1428,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 1)
+						// Groups 2, 3 are deleted for update; groups 0, 1, 4 are ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
 					},
 				},
 				{
@@ -1273,7 +1443,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 2)
+						// Groups 1, 2 are deleted for update; groups 0, 3, 4 are ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
 					},
 				},
 				{
@@ -1287,7 +1458,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 3)
+						// Groups 0, 1 are deleted for update; groups 2, 3, 4 are ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 3)
 					},
 				},
 				{
@@ -1303,7 +1475,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 3)
+						// Group 0 is still deleted for update; the surge group 4 is reclaimed.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 3)
 					},
 				},
 				{
@@ -1365,8 +1538,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						// partition drops to replicas - maxUnavailable = 4 - 2 = 2
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						// none of the new pods are updated and ready yet
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// All stale pods in the update window are deleted: groups 2, 3 and the
+						// surge pods 4, 5 (created at the old revision).
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 0)
 					},
 				},
 				{
@@ -1380,7 +1554,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
+						// Groups 0, 1 are deleted for update once the partition reaches 0.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
 					},
 				},
 				{
@@ -1647,7 +1822,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale pods in the update window (group 3 and the surge pods 4, 5,
+						// which were created at the old revision) are deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 					},
 				},
 				{
@@ -1673,8 +1850,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						// The last 2 replicas are updated but not ready.
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
+						// The last 2 replicas are updated but not ready; groups 3, 4, 5 remain
+						// deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
 					},
 				},
 				{
@@ -1689,7 +1867,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 2)
+						// Groups 3, 4, 5 remain deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 2)
 					},
 				},
 				{
@@ -1713,7 +1892,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
+						// Groups 1, 2 are deleted for update; only group 0 remains ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 1, 0)
 					},
 				},
 				{
@@ -1727,7 +1907,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
+						// Groups 0, 1 are deleted for update; group 2 is updated and ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 1, 1)
 					},
 				},
 				{
@@ -1743,7 +1924,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 1)
+						// Group 0 remains deleted for update; the surge group 2 is reclaimed.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 1, 1)
 					},
 				},
 				{
@@ -1805,7 +1987,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale pods in the update window (group 3 and the surge pods 4, 5,
+						// which were created at the old revision) are deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
@@ -1821,7 +2005,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 2)
+						// Groups 1, 2, 3 are deleted for update; groups 0, 4, 5 are ready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 2)
 						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
@@ -1844,7 +2029,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						// Partition will transit from 4 to 3.
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 0)
+						// Groups 1, 2 are still deleted from the first update; groups 4, 5 are
+						// deleted again for the second revision.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 1, 0)
 						testing.ExpectRevisions(ctx, k8sClient, lws, 3)
 					},
 				},
@@ -1903,7 +2090,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale leader pod in the update window (index 3) is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
 					},
 				},
@@ -1922,7 +2110,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+						// Group 2 enters the update window and its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
 					},
 				},
 				{
@@ -1991,7 +2180,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
+						// The stale leader pod in the update window (index 3) is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
 					},
 				},
 				{
@@ -2004,7 +2194,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
+						// Group 2 enters the update window and its stale leader pod is deleted.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
 					},
 				},
 				{ // The workerPods are deleted to update them. This should not delete the leaderPod
@@ -2176,7 +2367,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						// the number of unavailable pods to 3 (while MaxUnavailable=2).
 						// This is the key test for the bugfix.
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
+						// Group 3's stale leader pod is deleted; group 1 is already unready.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 0)
 					},
 				},
 				{
@@ -2337,7 +2529,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 5)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 0)
+						// Group 5's stale leader pod is deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 0)
 					},
 				},
 				{
@@ -2350,7 +2543,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 4)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 1)
+						// Group 4's stale leader pod is deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 1)
 					},
 				},
 				{
@@ -2375,7 +2569,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 2)
+						// Group 3's stale leader pod is deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 2)
 					},
 				},
 				{
@@ -2388,7 +2583,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 3)
+						// Group 2's stale leader pod is deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 5, 3)
 					},
 				},
 				{
@@ -2433,7 +2629,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
+						// Group 2's stale leader pod is deleted for update.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 0)
 					},
 				},
 				{
@@ -2464,10 +2661,14 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						// UpdateInProgress cannot be asserted here: both remaining stale groups
+						// (0, 1) have their leader pods deleted for update, and with no
+						// statefulset controller in envtest to recreate them there are no
+						// pending-update pods left to keep the condition true.
 						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
 						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
+						// Groups 0, 1 are deleted for update once the partition reaches 0.
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
 					},
 				},
 				{

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -497,14 +497,31 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			},
 			lwsCreationShouldFail: false,
 		}),
-		ginkgo.Entry("set maxSurge to 0 and maxUnavailable to non-zero should be failed", &testValidationCase{
+		// A percentage maxUnavailable that scales to zero at the current replica count is
+		// allowed (mirroring Deployment validation on raw values); the controller bumps
+		// the resolved budget to 1 so the rolling update cannot stall.
+		ginkgo.Entry("set maxSurge to 0 and maxUnavailable to a percentage scaling to 0 should succeed", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
 				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromString("25%")
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt32(0)
 				return lws
 			},
+			lwsCreationShouldFail: false,
+		}),
+		ginkgo.Entry("rollout-via-delete annotation with invalid value should fail", &testValidationCase{
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
+				lws.Annotations[leaderworkerset.RolloutViaDeleteAnnotationKey] = "enabled"
+				return lws
+			},
 			lwsCreationShouldFail: true,
+		}),
+		ginkgo.Entry("rollout-via-delete annotation set to false should succeed", &testValidationCase{
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(ns.Name).RolloutViaDelete(false)
+			},
+			lwsCreationShouldFail: false,
 		}),
 		ginkgo.Entry("creation with negative partition should fail", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -111,10 +111,23 @@ func DeleteLeaderPods(ctx context.Context, k8sClient client.Client, lws *leaderw
 		index, _ := strconv.Atoi(leaders.Items[i].Name[len(leaders.Items[i].Name)-1:])
 		if index >= int(*leaderWorkerSet.Spec.Replicas) {
 			gomega.Expect(k8sClient.Delete(ctx, &leaders.Items[i])).To(gomega.Succeed())
-			// delete worker statefulset on behalf of kube-controller-manager
-			var sts appsv1.StatefulSet
-			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaders.Items[i].Name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
-			gomega.Expect(k8sClient.Delete(ctx, &sts)).To(gomega.Succeed())
+		}
+	}
+
+	// Delete worker statefulsets of removed groups on behalf of kube-controller-manager.
+	// Iterated separately from the pods above because the lws controller may have already
+	// deleted a stale leader pod for a rolling update while its worker statefulset (which
+	// envtest never garbage-collects) is still around.
+	var stsList appsv1.StatefulSetList
+	gomega.Expect(k8sClient.List(ctx, &stsList, client.InNamespace(lws.Namespace), &client.MatchingLabels{leaderworkerset.SetNameLabelKey: lws.Name})).To(gomega.Succeed())
+	for i := range stsList.Items {
+		if stsList.Items[i].Name == lws.Name {
+			continue
+		}
+		index, err := strconv.Atoi(stsList.Items[i].Labels[leaderworkerset.GroupIndexLabelKey])
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if index >= int(*leaderWorkerSet.Spec.Replicas) {
+			gomega.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &stsList.Items[i]))).To(gomega.Succeed())
 		}
 	}
 
@@ -126,14 +139,23 @@ func DeleteLeaderPods(ctx context.Context, k8sClient client.Client, lws *leaderw
 }
 
 func DeleteLeaderPod(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, start, end int32) {
+	// Tolerate pods (and worker statefulsets) that no longer exist: the lws controller
+	// deletes stale leader pods for rolling updates itself, so an emulated statefulset
+	// scale-down may find them already gone.
 	for index := start; index < end; index++ {
 		name := lws.Name + "-" + strconv.Itoa(int(index))
 		var pod corev1.Pod
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: lws.Namespace}, &pod)).To(gomega.Succeed())
-		gomega.Expect(k8sClient.Delete(ctx, &pod)).To(gomega.Succeed())
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: lws.Namespace}, &pod); err != nil {
+			gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+		} else {
+			gomega.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &pod))).To(gomega.Succeed())
+		}
 		var sts appsv1.StatefulSet
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: lws.Namespace}, &sts)).To(gomega.Succeed())
-		gomega.Expect(k8sClient.Delete(ctx, &sts)).To(gomega.Succeed())
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: lws.Namespace}, &sts); err != nil {
+			gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+		} else {
+			gomega.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, &sts))).To(gomega.Succeed())
+		}
 	}
 }
 
@@ -307,6 +329,29 @@ func GetStatefulSets(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, 
 
 // SetSuperPodToReady set all podGroups of the leaderWorkerSet to ready state.
 func SetSuperPodToReady(ctx context.Context, k8sClient client.Client, lws *leaderworkerset.LeaderWorkerSet, podGroupNumber int32) {
+	// Leader pods deleted by the lws controller during rolling updates are recreated by
+	// the statefulset controller in a real cluster (OnDelete strategy); emulate that
+	// first so the worker statefulsets can be recreated and marked ready below.
+	gomega.Eventually(func() error {
+		var leaderSts appsv1.StatefulSet
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: lws.Name}, &leaderSts); err != nil {
+			return err
+		}
+		for i := int32(0); i < podGroupNumber; i++ {
+			podName := lws.Name + "-" + strconv.Itoa(int(i))
+			var pod corev1.Pod
+			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: podName}, &pod); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				if err := recreateLeaderPod(ctx, k8sClient, leaderSts, lws, podName); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}, Timeout, Interval).Should(gomega.Succeed())
+
 	stsSelector := client.MatchingLabels(map[string]string{
 		leaderworkerset.SetNameLabelKey: lws.Name,
 	})
@@ -330,14 +375,21 @@ func SetSuperPodToReady(ctx context.Context, k8sClient client.Client, lws *leade
 
 func SetLeaderPodToReady(ctx context.Context, k8sClient client.Client, podName string, lws *leaderworkerset.LeaderWorkerSet) {
 	gomega.Eventually(func() error {
-		var leaderPod corev1.Pod
-		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: podName}, &leaderPod); err != nil {
-			return err
-		}
-
 		var leaderSts appsv1.StatefulSet
 		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: lws.Name}, &leaderSts); err != nil {
 			return err
+		}
+
+		var leaderPod corev1.Pod
+		if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: lws.Namespace, Name: podName}, &leaderPod); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+			// The lws controller deletes stale leader pods during rolling updates and
+			// relies on the statefulset controller (OnDelete strategy) to recreate them
+			// with the updated template. There is no statefulset controller in envtest,
+			// so emulate the recreation here.
+			return recreateLeaderPod(ctx, k8sClient, leaderSts, lws, podName)
 		}
 		leaderPod.Labels[leaderworkerset.RevisionKey] = revisionutils.GetRevisionKey(&leaderSts)
 		return k8sClient.Update(ctx, &leaderPod)
@@ -358,6 +410,24 @@ func SetLeaderPodToReady(ctx context.Context, k8sClient client.Client, podName s
 		deleteWorkerStatefulSetIfExists(ctx, k8sClient, podName, lws)
 		return k8sClient.Status().Update(ctx, &leaderPod)
 	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
+// recreateLeaderPod emulates the statefulset controller recreating a deleted leader pod
+// from the current (updated) template, as happens in a real cluster with the OnDelete
+// update strategy.
+func recreateLeaderPod(ctx context.Context, k8sClient client.Client, leaderSts appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet, podName string) error {
+	index, err := strconv.Atoi(podName[len(lws.Name)+1:])
+	if err != nil {
+		return fmt.Errorf("parsing group index from pod name %s: %w", podName, err)
+	}
+	pod, err := makeLeaderPod(leaderSts, lws, revisionutils.GetRevisionKey(&leaderSts), index)
+	if err != nil {
+		return err
+	}
+	if err := k8sClient.Create(ctx, pod); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }
 
 func SetPodToRunning(ctx context.Context, k8sClient client.Client, podName string, lws *leaderworkerset.LeaderWorkerSet) {

--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -437,7 +437,14 @@ func ExpectStatefulsetPartitionEqualTo(ctx context.Context, k8sClient client.Cli
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &sts); err != nil {
 			return -1
 		}
-		return *sts.Spec.UpdateStrategy.RollingUpdate.Partition
+		// The leader statefulset runs with the OnDelete update strategy, so the
+		// rolling-update partition is tracked in an annotation instead of
+		// spec.updateStrategy.rollingUpdate.partition.
+		p, err := strconv.Atoi(sts.Annotations[leaderworkerset.UpdatePartitionAnnotationKey])
+		if err != nil {
+			return -1
+		}
+		return int32(p)
 	}, Timeout, Interval).Should(gomega.Equal(partition))
 }
 

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -118,6 +118,14 @@ func (lwsWrapper *LeaderWorkerSetWrapper) Annotation(annotations map[string]stri
 	return lwsWrapper
 }
 
+func (lwsWrapper *LeaderWorkerSetWrapper) RolloutViaDelete(enabled bool) *LeaderWorkerSetWrapper {
+	if lwsWrapper.Annotations == nil {
+		lwsWrapper.Annotations = map[string]string{}
+	}
+	lwsWrapper.Annotations[leaderworkerset.RolloutViaDeleteAnnotationKey] = strconv.FormatBool(enabled)
+	return lwsWrapper
+}
+
 func (lwsWrapper *LeaderWorkerSetWrapper) Conditions(conditions []metav1.Condition) *LeaderWorkerSetWrapper {
 	lwsWrapper.Status.Conditions = conditions
 	return lwsWrapper
@@ -227,6 +235,9 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws := leaderworkerset.LeaderWorkerSet{}
 	lws.Name = "test-sample"
 	lws.Namespace = nsName
+	// Most tests exercise controller-driven rolling updates; statefulset-driven
+	// updates (the default) are covered by dedicated entries.
+	lws.Annotations = map[string]string{leaderworkerset.RolloutViaDeleteAnnotationKey: "true"}
 	lws.Spec = leaderworkerset.LeaderWorkerSetSpec{}
 	lws.Spec.Replicas = ptr.To[int32](2)
 	lws.Spec.LeaderWorkerTemplate = leaderworkerset.LeaderWorkerTemplate{RestartPolicy: leaderworkerset.RecreateGroupOnPodRestart}


### PR DESCRIPTION
Rolling updates are paced through the leader statefulset's rollingUpdate.maxUnavailable, an alpha field (MaxUnavailableStatefulSet) unavailable on managed clusters. Without it the statefulset controller recreates leaders strictly one at a time, gated on readiness - for multi-node inference groups where leader-ready means model-loaded, a rollout of N groups takes N cold starts in sequence.

With the leaderworkerset.sigs.k8s.io/rollout-via-delete: "true" annotation, the leader statefulset switches to OnDelete and the lws controller deletes stale leader pods itself, up to the group-level maxUnavailable budget; the statefulset controller recreates them in parallel. The existing partition math is unchanged - the partition moves into an annotation (OnDelete forbids the field) and deletion replaces the partition write as the executor.

Opt-in per object so the controller can be deployed as a no-op and enabled pool by pool; removing the annotation restores upstream statefulset-driven updates without disturbing pods or revisions.

Also resolve percentage budgets like Deployments do: reject only literal 0/0 at admission and floor the resolved maxUnavailable at 1, so maxUnavailable: 20% cannot stall a rollout at small replica counts (e.g. 3 replicas, or after a scale-down mid-rollout).