### PR TITLE
cleanup: add upgrade E2E test CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,10 @@ test-e2e: kustomize manifests fmt vet envtest ginkgo kind-image-build
 test-e2e-cert-manager: kustomize manifests fmt vet envtest ginkgo kind-image-build
 	USE_CERT_MANAGER=true CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
+.PHONY: test-e2e-upgrade
+test-e2e-upgrade: kustomize manifests fmt vet envtest ginkgo kind-image-build
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-upgrade-test.sh
+
 # Gang scheduling E2E tests with different schedulers
 VOLCANO_VERSION ?= v1.12.1
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,9 +9,11 @@ namespace: lws-system
 namePrefix: lws-
 
 # Common labels to add to all resources and selectors (matches Helm behavior).
-commonLabels:
-  app.kubernetes.io/name: lws
-  app.kubernetes.io/instance: lws
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: lws
+      app.kubernetes.io/instance: lws
 
 resources:
 - ../crd

--- a/hack/e2e-upgrade-test.sh
+++ b/hack/e2e-upgrade-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export CWD=$(pwd)
+PREV_LWS_VERSION=${PREV_LWS_VERSION:-"v0.8.0"}
+
+function cleanup {
+    if [ "${USE_EXISTING_CLUSTER:-false}" == 'false' ]
+    then
+        if [ ! -d "$ARTIFACTS" ]; then
+            mkdir -p "$ARTIFACTS"
+        fi
+        $KUBECTL logs -n lws-system deployment/lws-controller-manager > "$ARTIFACTS"/lws-controller-manager.log || true
+        $KUBECTL describe pods -n lws-system > "$ARTIFACTS"/lws-system-pods.log || true
+        
+        $KIND export logs "$ARTIFACTS" || true
+        $KIND delete cluster --name "$KIND_CLUSTER_NAME"
+    fi
+    (cd "$CWD/config/manager" && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/lws:main)
+}
+
+function startup {
+    if [ "${USE_EXISTING_CLUSTER:-false}" == 'false' ]
+    then
+        if [ ! -d "$ARTIFACTS" ]; then
+            mkdir -p "$ARTIFACTS"
+        fi
+        $KIND create cluster --name "$KIND_CLUSTER_NAME" --image "$E2E_KIND_VERSION" --wait 1m
+        $KUBECTL get nodes > "$ARTIFACTS"/kind-nodes.log || true
+        $KUBECTL describe pods -n kube-system > "$ARTIFACTS"/kube-system-pods.log || true
+    fi
+}
+
+function kind_load {
+    $KIND load docker-image "$IMAGE_TAG" --name "$KIND_CLUSTER_NAME"
+}
+
+function install_prev_lws {
+    echo "Installing previous LWS release: $PREV_LWS_VERSION"
+    $KUBECTL apply --server-side -f "https://github.com/kubernetes-sigs/lws/releases/download/${PREV_LWS_VERSION}/manifests.yaml"
+    
+    echo "Waiting for previous LWS deployment to be ready..."
+    $KUBECTL -n lws-system wait --for condition=available deployment/lws-controller-manager --timeout=5m
+}
+
+function run_upgrade_tests {
+    $GINKGO --junit-report=junit.xml --output-dir="$ARTIFACTS" -v --focus="LeaderWorkerSet controller upgrade" "$CWD/test/e2e/..."
+}
+
+trap cleanup EXIT
+startup
+kind_load
+install_prev_lws
+run_upgrade_tests

--- a/test/e2e/e2e_upgrade_test.go
+++ b/test/e2e/e2e_upgrade_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testing "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+var _ = ginkgo.Describe("LeaderWorkerSet controller upgrade", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-upgrade-ns-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, ns)
+			return err == nil
+		}, timeout, interval).Should(gomega.BeTrue())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(testing.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should not disrupt workloads during upgrade", func() {
+		ginkgo.By("creating a LeaderWorkerSet with the old controller version")
+		lws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(2).Size(2).Obj()
+		testing.MustCreateLws(ctx, k8sClient, lws)
+
+		ginkgo.By("waiting for the LeaderWorkerSet to be ready")
+		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+
+		ginkgo.By("recording existing pod UIDs and restart counts")
+		pods := &corev1.PodList{}
+		gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+		gomega.Expect(len(pods.Items)).To(gomega.Equal(4))
+
+		podUIDs := make(map[string]types.UID)
+		podRestartCounts := make(map[string]int32)
+		for _, pod := range pods.Items {
+			podUIDs[pod.Name] = pod.UID
+			var restarts int32
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				restarts += containerStatus.RestartCount
+			}
+			podRestartCounts[pod.Name] = restarts
+		}
+
+		ginkgo.By("upgrading the controller to the current build")
+		cwd, err := os.Getwd()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		imageTag := os.Getenv("IMAGE_TAG")
+		gomega.Expect(imageTag).NotTo(gomega.BeEmpty(), "IMAGE_TAG env var must be set")
+
+		configManagerDir := filepath.Join(cwd, "..", "..", "config", "manager")
+		kustomizeConfigDir := filepath.Join(cwd, "..", "..", "test", "e2e", "config")
+
+		cmdSetImage := exec.Command("kustomize", "edit", "set", "image", fmt.Sprintf("controller=%s", imageTag))
+		cmdSetImage.Dir = configManagerDir
+		_, err = testing.Run(cmdSetImage)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cmdApply := exec.Command("sh", "-c", fmt.Sprintf("kustomize build %s | kubectl apply --server-side -f -", kustomizeConfigDir))
+		_, err = testing.Run(cmdApply)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By("waiting for the upgraded controller deployment to be ready")
+		verifyControllerUpgraded := func(g gomega.Gomega) {
+			deployment := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "lws-system", Name: "lws-controller-manager"}, deployment)
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+
+			g.Expect(deployment.Status.AvailableReplicas).To(gomega.Equal(deployment.Status.Replicas))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(gomega.Equal(imageTag))
+		}
+		gomega.Eventually(verifyControllerUpgraded, 5*time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+		ginkgo.By("verifying existing workload pods are not recreated or restarted")
+		time.Sleep(10 * time.Second)
+
+		currentPods := &corev1.PodList{}
+		gomega.Expect(k8sClient.List(ctx, currentPods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+		gomega.Expect(len(currentPods.Items)).To(gomega.Equal(4))
+
+		for _, pod := range currentPods.Items {
+			recordedUID, exists := podUIDs[pod.Name]
+			gomega.Expect(exists).To(gomega.BeTrue(), fmt.Sprintf("Pod %s was recreated under a new name or was not recorded originally", pod.Name))
+			gomega.Expect(pod.UID).To(gomega.Equal(recordedUID), fmt.Sprintf("Pod %s UID changed from %s to %s", pod.Name, recordedUID, pod.UID))
+
+			var currentRestarts int32
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				currentRestarts += containerStatus.RestartCount
+			}
+			recordedRestarts := podRestartCounts[pod.Name]
+			gomega.Expect(currentRestarts).To(gomega.Equal(recordedRestarts), fmt.Sprintf("Pod %s container restarted: before %d, after %d", pod.Name, recordedRestarts, currentRestarts))
+		}
+
+		ginkgo.By("verifying the upgraded controller remains healthy by creating a new LeaderWorkerSet")
+		newLws := wrappers.BuildLeaderWorkerSet(ns.Name).Replica(1).Size(2).Obj()
+		newLws.Name = "leaderworkerset-sample-2"
+		testing.MustCreateLws(ctx, k8sClient, newLws)
+
+		testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, newLws, "New LeaderWorkerSet replica is ready")
+	})
+})


### PR DESCRIPTION
This PR adds an automated upgrade E2E test for the LWS controller to prevent upgrade regressions.

### Changes
- **E2E Upgrade Test Case**: Implemented under `test/e2e/e2e_upgrade_test.go`. The test deploys a `LeaderWorkerSet` workload using the previous release (defaulting to `v0.8.0`), records Pod UIDs and restart counts, upgrades the controller to the current build, and verifies that no workload pods were disrupted or restarted. Finally, it validates controller health by creating a new `LeaderWorkerSet`.
- **Orchestration Script**: Implemented under `hack/e2e-upgrade-test.sh` to initialize the Kind cluster, preload the current build image, bootstrap the previous version, and run the Ginkgo focus group.
- **Makefile target**: Added `test-e2e-upgrade` to invoke the orchestration script.

Closes #926