### PR TITLE
Add manifests upgrade E2E coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ INTEGRATION_TARGET ?= ./test/integration/...
 E2E_KIND_VERSION ?= kindest/node:v1.36.1
 CERT_MANAGER_VERSION ?= v1.17.0
 USE_EXISTING_CLUSTER ?= false
+LWS_UPGRADE_FROM_VERSION ?= v0.9.0
+UPGRADE_KIND_CLUSTER_NAME ?= lws-upgrade
 
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster
@@ -175,6 +177,13 @@ test-integration: manifests fmt vet envtest ginkgo ## Run integration tests.
 .PHONY: test-e2e
 test-e2e: kustomize manifests fmt vet envtest ginkgo kind-image-build
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
+
+.PHONY: test-e2e-upgrade
+test-e2e-upgrade: test-e2e-upgrade-manifests
+
+.PHONY: test-e2e-upgrade-manifests
+test-e2e-upgrade-manifests: kustomize manifests fmt vet ginkgo kind-image-build
+	LWS_UPGRADE_FROM_VERSION=$(LWS_UPGRADE_FROM_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(UPGRADE_KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=false IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 .PHONY: test-e2e-cert-manager
 test-e2e-cert-manager: kustomize manifests fmt vet envtest ginkgo kind-image-build

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -19,7 +19,26 @@ set -o nounset
 set -o pipefail
 
 SCHEDULER_PROVIDER=${SCHEDULER_PROVIDER:-""}
+LWS_UPGRADE_FROM_VERSION=${LWS_UPGRADE_FROM_VERSION:-""}
 export CWD=$(pwd)
+
+KUBECONFIG_PATH=""
+OLD_MANIFEST=""
+
+if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+    OLD_CONTROLLER_IMAGE="registry.k8s.io/lws/lws:${LWS_UPGRADE_FROM_VERSION}"
+    OLD_MANIFEST_URL="https://github.com/kubernetes-sigs/lws/releases/download/${LWS_UPGRADE_FROM_VERSION}/manifests.yaml"
+    PAUSE_IMAGE="registry.k8s.io/pause:3.10"
+    TEST_NAMESPACE="lws-upgrade-test"
+    SNAPSHOT_PATH="${ARTIFACTS}/upgrade-snapshot.json"
+fi
+
+function save_controller_logs {
+    local output="$1"
+    $KUBECTL logs -n lws-system deployment/lws-controller-manager \
+        --all-pods=true --prefix=true > "$output" 2>&1 || true
+}
+
 function cleanup {
     if [ $USE_EXISTING_CLUSTER == 'false' ]
     then
@@ -34,17 +53,47 @@ function cleanup {
             $KUBECTL logs -n volcano-system deployment/volcano-controllers > "$ARTIFACTS"/volcano-controller-manager.log || true
             $KUBECTL describe pods -n volcano-system > "$ARTIFACTS"/volcano-system-pods.log || true
         fi
-        $KIND export logs "$ARTIFACTS" || true
+
+        if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+            $KUBECTL get events -A --sort-by=.lastTimestamp > "$ARTIFACTS"/events.log 2>&1 || true
+            $KUBECTL get leaderworkersets,disaggregatedsets,pods,statefulsets,services \
+                -n "$TEST_NAMESPACE" -o yaml > "$ARTIFACTS"/upgrade-workloads.yaml 2>&1 || true
+        fi
+
+        $KIND export logs "$ARTIFACTS" --name "$KIND_CLUSTER_NAME" || true
         $KIND delete cluster --name $KIND_CLUSTER_NAME
     fi
-    (cd $CWD/config/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/lws:main)
+
+    if [ -n "$KUBECONFIG_PATH" ]; then
+        rm -f "$KUBECONFIG_PATH"
+    fi
+    if [ -n "$OLD_MANIFEST" ]; then
+        rm -f "$OLD_MANIFEST"
+    fi
+    if [ -z "$LWS_UPGRADE_FROM_VERSION" ]; then
+        (cd $CWD/config/manager && $KUSTOMIZE edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/lws:main)
+    fi
 }
+
+function pull_upgrade_images {
+    if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+        docker pull --platform=linux/amd64 "$OLD_CONTROLLER_IMAGE"
+        docker pull --platform=linux/amd64 "$PAUSE_IMAGE"
+    fi
+}
+
 function startup {
     if [ $USE_EXISTING_CLUSTER == 'false' ]
     then
         if [ ! -d "$ARTIFACTS" ]; then
             mkdir -p "$ARTIFACTS"
         fi
+
+        if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+            KUBECONFIG_PATH="$(mktemp)"
+            export KUBECONFIG="$KUBECONFIG_PATH"
+        fi
+
         $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION --wait 1m
         $KUBECTL get nodes > $ARTIFACTS/kind-nodes.log || true
         $KUBECTL describe pods -n kube-system > $ARTIFACTS/kube-system-pods.log || true
@@ -66,10 +115,90 @@ function deploy_gang_scheduler() {
         echo "Volcano deployed successfully"
     fi
 }
+
+# Avoid kind's --all-platforms import path for multi-arch release images.
+function kind_load_image {
+    local image="$1"
+    local archive
+    archive="$(mktemp)"
+    trap 'rm -f "$archive"' RETURN
+    docker save "$image" -o "$archive"
+
+    while IFS= read -r node; do
+        docker exec -i "$node" ctr --namespace=k8s.io images import \
+            --digests --snapshotter=overlayfs - < "$archive"
+    done < <($KIND get nodes --name "$KIND_CLUSTER_NAME")
+
+    rm -f "$archive"
+}
+
 function kind_load {
     $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
+
+    if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+        kind_load_image "$OLD_CONTROLLER_IMAGE"
+        kind_load_image "$PAUSE_IMAGE"
+    fi
 }
+
+function install_old_release {
+    OLD_MANIFEST="$(mktemp)"
+    curl --fail --location --silent --show-error \
+        --connect-timeout 10 --max-time 120 \
+        --retry 5 --retry-delay 2 \
+        --output "$OLD_MANIFEST" "$OLD_MANIFEST_URL"
+
+    $KUBECTL apply --server-side -f "$OLD_MANIFEST"
+    $KUBECTL rollout status deployment/lws-controller-manager \
+        -n lws-system --timeout=5m
+}
+
+function run_upgrade_phase {
+    local phase="$1"
+    LWS_UPGRADE_PHASE="$phase" \
+    LWS_UPGRADE_SNAPSHOT_PATH="$SNAPSHOT_PATH" \
+    IMAGE_TAG="$IMAGE_TAG" \
+        $GINKGO \
+        --junit-report="junit-upgrade-${phase}.xml" \
+        --output-dir="$ARTIFACTS" \
+        -v "$CWD/test/e2e/upgrade"
+}
+
+function upgrade_to_current {
+    (
+        # Set the canonical image name before parent kustomizations transform it.
+        local manager_kustomization="$CWD/config/manager/kustomization.yaml"
+        local manager_kustomization_backup
+        manager_kustomization_backup="$(mktemp)"
+        cp "$manager_kustomization" "$manager_kustomization_backup"
+        trap 'cp "$manager_kustomization_backup" "$manager_kustomization"; rm -f "$manager_kustomization_backup"' EXIT
+
+        (
+            cd "$CWD/config/manager"
+            $KUSTOMIZE edit set image controller="$IMAGE_TAG"
+        )
+        $KUSTOMIZE build "$CWD/test/e2e/config" \
+            | $KUBECTL apply --server-side --force-conflicts -f -
+    )
+
+    $KUBECTL rollout status deployment/lws-controller-manager \
+        -n lws-system --timeout=5m
+}
+
+function upgrade_test_flow {
+    echo "Upgrade test: $LWS_UPGRADE_FROM_VERSION -> current"
+    install_old_release
+    run_upgrade_phase before
+    save_controller_logs "$ARTIFACTS/old-controller.log"
+    upgrade_to_current
+}
+
 function lws_deploy {
+    if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+        upgrade_test_flow
+        return
+    fi
+
     pushd "$CWD/config/manager"
     $KUSTOMIZE edit set image controller=$IMAGE_TAG
     # Base configuration
@@ -124,17 +253,23 @@ EOF
 }
 
 function run_tests() {
+    if [ -n "$LWS_UPGRADE_FROM_VERSION" ]; then
+        run_upgrade_phase after
+        return
+    fi
+
     if [ -n "$SCHEDULER_PROVIDER" ]; then
         # Run gang scheduling tests
-        $GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v --focus="leaderWorkerSet e2e gang scheduling tests" $CWD/test/e2e/...
+        $GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v --skip-package=upgrade --focus="leaderWorkerSet e2e gang scheduling tests" $CWD/test/e2e/...
     else
         # Run normal tests, skip gang scheduling tests
-        $GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v --skip="leaderWorkerSet e2e gang scheduling tests" $CWD/test/e2e/...
+        $GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v --skip-package=upgrade --skip="leaderWorkerSet e2e gang scheduling tests" $CWD/test/e2e/...
     fi
 }
 
 trap cleanup EXIT
 startup
+pull_upgrade_images
 kind_load
 deploy_cert_manager
 deploy_gang_scheduler

--- a/test/e2e/upgrade/suite_test.go
+++ b/test/e2e/upgrade/suite_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+var (
+	ctx             context.Context
+	cancel          context.CancelFunc
+	k8sClient       client.Client
+	upgradePhase    string
+	snapshotPath    string
+	currentImageTag string
+)
+
+func TestUpgrade(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Upgrade E2E Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+
+	upgradePhase = os.Getenv("LWS_UPGRADE_PHASE")
+	if upgradePhase != "before" && upgradePhase != "after" {
+		ginkgo.Fail("LWS_UPGRADE_PHASE must be either before or after")
+	}
+
+	snapshotPath = os.Getenv("LWS_UPGRADE_SNAPSHOT_PATH")
+	gomega.Expect(snapshotPath).NotTo(gomega.BeEmpty())
+
+	currentImageTag = os.Getenv("IMAGE_TAG")
+	gomega.Expect(currentImageTag).NotTo(gomega.BeEmpty())
+
+	testScheme := runtime.NewScheme()
+	gomega.Expect(corev1.AddToScheme(testScheme)).To(gomega.Succeed())
+	gomega.Expect(appsv1.AddToScheme(testScheme)).To(gomega.Succeed())
+	gomega.Expect(leaderworkersetv1.AddToScheme(testScheme)).To(gomega.Succeed())
+	gomega.Expect(disaggregatedsetv1.AddToScheme(testScheme)).To(gomega.Succeed())
+
+	var err error
+	k8sClient, err = client.New(config.GetConfigOrDie(), client.Options{Scheme: testScheme})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	waitForWebhooks()
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	cancel()
+})

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	testutils "sigs.k8s.io/lws/test/testutils"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+const (
+	testNamespace   = "lws-upgrade-test"
+	existingLWSName = "existing-lws"
+	existingDSName  = "existing-ds"
+	newLWSName      = "new-lws"
+	newDSName       = "new-ds"
+	pauseImage      = "registry.k8s.io/pause:3.10"
+)
+
+type objectSnapshot struct {
+	UID        types.UID `json:"uid"`
+	Generation int64     `json:"generation"`
+}
+
+type generatedLWSSnapshot struct {
+	Name     string    `json:"name"`
+	UID      types.UID `json:"uid"`
+	Role     string    `json:"role"`
+	Revision string    `json:"revision"`
+}
+
+type podSnapshot struct {
+	Name                  string           `json:"name"`
+	UID                   types.UID        `json:"uid"`
+	ContainerRestarts     map[string]int32 `json:"containerRestarts"`
+	InitContainerRestarts map[string]int32 `json:"initContainerRestarts"`
+}
+
+type upgradeSnapshot struct {
+	LeaderWorkerSet  objectSnapshot         `json:"leaderWorkerSet"`
+	DisaggregatedSet objectSnapshot         `json:"disaggregatedSet"`
+	GeneratedLWS     []generatedLWSSnapshot `json:"generatedLWS"`
+	WorkloadPods     []podSnapshot          `json:"workloadPods"`
+}
+
+var _ = ginkgo.Describe("Controller upgrade", ginkgo.Ordered, func() {
+	ginkgo.It("preserves existing workloads and reconciles new workloads", func() {
+		switch upgradePhase {
+		case "before":
+			createExistingWorkloads()
+			writeSnapshot(captureSnapshot())
+		case "after":
+			expected := readSnapshot()
+			expectCurrentControllerReady()
+			gomega.Consistently(func(g gomega.Gomega) {
+				current, err := captureSnapshot()
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(current).To(gomega.Equal(expected))
+			}, 30*time.Second, time.Second).Should(gomega.Succeed())
+			createNewWorkloads()
+		}
+	})
+})
+
+func waitForWebhooks() {
+	ginkgo.By("waiting for the LeaderWorkerSet webhook")
+	gomega.Eventually(func() error {
+		probe := newLeaderWorkerSet("default", "upgrade-lws-webhook-probe", 1, 1)
+		return k8sClient.Create(ctx, probe, client.DryRunAll)
+	}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
+
+	ginkgo.By("waiting for the DisaggregatedSet webhook")
+	gomega.Eventually(func() error {
+		probe := newDisaggregatedSet("default", "upgrade-ds-webhook-probe")
+		return k8sClient.Create(ctx, probe, client.DryRunAll)
+	}, 2*time.Minute, 2*time.Second).Should(gomega.Succeed())
+}
+
+func createExistingWorkloads() {
+	ginkgo.By("creating the upgrade test namespace")
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	gomega.Expect(k8sClient.Create(ctx, namespace)).To(gomega.Succeed())
+
+	ginkgo.By("creating a LeaderWorkerSet with the old controller")
+	lws := newLeaderWorkerSet(testNamespace, existingLWSName, 2, 2)
+	testutils.MustCreateLws(ctx, k8sClient, lws)
+	testutils.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
+	testutils.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+	testutils.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "")
+	testutils.ExpectValidPods(ctx, k8sClient, lws, &corev1.PodList{})
+	testutils.ExpectValidServices(ctx, k8sClient, lws, 1)
+
+	ginkgo.By("creating a DisaggregatedSet with the old controller")
+	ds := newDisaggregatedSet(testNamespace, existingDSName)
+	gomega.Expect(k8sClient.Create(ctx, ds)).To(gomega.Succeed())
+	waitForDisaggregatedSet(existingDSName)
+}
+
+func createNewWorkloads() {
+	ginkgo.By("creating a new LeaderWorkerSet with the upgraded controller")
+	lws := newLeaderWorkerSet(testNamespace, newLWSName, 1, 2)
+	testutils.MustCreateLws(ctx, k8sClient, lws)
+	testutils.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "")
+	testutils.ExpectValidPods(ctx, k8sClient, lws, &corev1.PodList{})
+
+	ginkgo.By("creating a new DisaggregatedSet with the upgraded controller")
+	ds := newDisaggregatedSet(testNamespace, newDSName)
+	gomega.Expect(k8sClient.Create(ctx, ds)).To(gomega.Succeed())
+	waitForDisaggregatedSet(newDSName)
+}
+
+func newLeaderWorkerSet(namespace, name string, replicas, size int) *leaderworkersetv1.LeaderWorkerSet {
+	return wrappers.BuildLeaderWorkerSet(namespace).
+		Name(name).
+		Replica(replicas).
+		Size(size).
+		RestartPolicy(leaderworkersetv1.RecreateGroupOnPodRestart).
+		LeaderTemplateSpec(pausePodSpec()).
+		WorkerTemplateSpec(pausePodSpec()).
+		Obj()
+}
+
+func newDisaggregatedSet(namespace, name string) *disaggregatedsetv1.DisaggregatedSet {
+	ds := wrappers.BuildDisaggregatedSet(name, namespace).
+		UID("").
+		WithRole("prefill", 1, pauseImage).
+		WithRole("decode", 1, pauseImage).
+		Obj()
+	for i := range ds.Spec.Roles {
+		ds.Spec.Roles[i].Spec.StartupPolicy = leaderworkersetv1.LeaderCreatedStartupPolicy
+		ds.Spec.Roles[i].Spec.RolloutStrategy.Type = leaderworkersetv1.RollingUpdateStrategyType
+	}
+	return ds
+}
+
+func pausePodSpec() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:            "main",
+			Image:           pauseImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "scratch",
+				MountPath: "/scratch",
+			}},
+		}},
+		Volumes: []corev1.Volume{{
+			Name: "scratch",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}},
+	}
+}
+
+func waitForDisaggregatedSet(name string) {
+	gomega.Eventually(func() error {
+		generated := &leaderworkersetv1.LeaderWorkerSetList{}
+		if err := k8sClient.List(ctx, generated,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: name},
+		); err != nil {
+			return err
+		}
+		if len(generated.Items) != 2 {
+			return fmt.Errorf("expected 2 generated LeaderWorkerSets, got %d", len(generated.Items))
+		}
+
+		roles := make(map[string]bool, 2)
+		for _, lws := range generated.Items {
+			role := lws.Labels[disaggregatedsetv1.RoleLabelKey]
+			if role == "" || lws.Labels[disaggregatedsetv1.RevisionLabelKey] == "" {
+				return fmt.Errorf("generated LeaderWorkerSet %q is missing role or revision labels", lws.Name)
+			}
+			if lws.Status.ReadyReplicas != 1 {
+				return fmt.Errorf("generated LeaderWorkerSet %q has %d ready replicas", lws.Name, lws.Status.ReadyReplicas)
+			}
+			roles[role] = true
+		}
+		if !roles["prefill"] || !roles["decode"] {
+			return fmt.Errorf("expected prefill and decode roles, got %v", roles)
+		}
+
+		pods := &corev1.PodList{}
+		if err := k8sClient.List(ctx, pods,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: name},
+		); err != nil {
+			return err
+		}
+		if len(pods.Items) != 2 {
+			return fmt.Errorf("expected 2 DisaggregatedSet pods, got %d", len(pods.Items))
+		}
+		for _, pod := range pods.Items {
+			if !isPodReady(&pod) {
+				return fmt.Errorf("pod %q is not ready", pod.Name)
+			}
+		}
+
+		services := &corev1.ServiceList{}
+		if err := k8sClient.List(ctx, services,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: name},
+		); err != nil {
+			return err
+		}
+		if len(services.Items) != 2 {
+			return fmt.Errorf("expected 2 DisaggregatedSet services, got %d", len(services.Items))
+		}
+		return nil
+	}, 3*time.Minute, time.Second).Should(gomega.Succeed())
+}
+
+func captureSnapshot() (upgradeSnapshot, error) {
+	lws := &leaderworkersetv1.LeaderWorkerSet{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: existingLWSName}, lws); err != nil {
+		return upgradeSnapshot{}, err
+	}
+
+	ds := &disaggregatedsetv1.DisaggregatedSet{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: existingDSName}, ds); err != nil {
+		return upgradeSnapshot{}, err
+	}
+
+	generated := &leaderworkersetv1.LeaderWorkerSetList{}
+	if err := k8sClient.List(ctx, generated,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: existingDSName},
+	); err != nil {
+		return upgradeSnapshot{}, err
+	}
+	if len(generated.Items) != 2 {
+		return upgradeSnapshot{}, fmt.Errorf("expected 2 generated LeaderWorkerSets, got %d", len(generated.Items))
+	}
+
+	generatedSnapshots := make([]generatedLWSSnapshot, 0, len(generated.Items))
+	for _, generatedLWS := range generated.Items {
+		role := generatedLWS.Labels[disaggregatedsetv1.RoleLabelKey]
+		revision := generatedLWS.Labels[disaggregatedsetv1.RevisionLabelKey]
+		if role == "" || revision == "" {
+			return upgradeSnapshot{}, fmt.Errorf("generated LeaderWorkerSet %q is missing role or revision labels", generatedLWS.Name)
+		}
+		generatedSnapshots = append(generatedSnapshots, generatedLWSSnapshot{
+			Name:     generatedLWS.Name,
+			UID:      generatedLWS.UID,
+			Role:     role,
+			Revision: revision,
+		})
+	}
+	sort.Slice(generatedSnapshots, func(i, j int) bool {
+		return generatedSnapshots[i].Name < generatedSnapshots[j].Name
+	})
+
+	pods, err := workloadPodSnapshots()
+	if err != nil {
+		return upgradeSnapshot{}, err
+	}
+
+	return upgradeSnapshot{
+		LeaderWorkerSet:  objectSnapshot{UID: lws.UID, Generation: lws.Generation},
+		DisaggregatedSet: objectSnapshot{UID: ds.UID, Generation: ds.Generation},
+		GeneratedLWS:     generatedSnapshots,
+		WorkloadPods:     pods,
+	}, nil
+}
+
+func workloadPodSnapshots() ([]podSnapshot, error) {
+	standalonePods := &corev1.PodList{}
+	if err := k8sClient.List(ctx, standalonePods,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{leaderworkersetv1.SetNameLabelKey: existingLWSName},
+	); err != nil {
+		return nil, err
+	}
+	if len(standalonePods.Items) != 4 {
+		return nil, fmt.Errorf("expected 4 standalone LeaderWorkerSet pods, got %d", len(standalonePods.Items))
+	}
+
+	dsPods := &corev1.PodList{}
+	if err := k8sClient.List(ctx, dsPods,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: existingDSName},
+	); err != nil {
+		return nil, err
+	}
+	if len(dsPods.Items) != 2 {
+		return nil, fmt.Errorf("expected 2 DisaggregatedSet pods, got %d", len(dsPods.Items))
+	}
+
+	allPods := append(standalonePods.Items, dsPods.Items...)
+	snapshots := make([]podSnapshot, 0, len(allPods))
+	for i := range allPods {
+		pod := &allPods[i]
+		snapshots = append(snapshots, podSnapshot{
+			Name:                  pod.Name,
+			UID:                   pod.UID,
+			ContainerRestarts:     restartCounts(pod.Status.ContainerStatuses),
+			InitContainerRestarts: restartCounts(pod.Status.InitContainerStatuses),
+		})
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Name < snapshots[j].Name
+	})
+	return snapshots, nil
+}
+
+func restartCounts(statuses []corev1.ContainerStatus) map[string]int32 {
+	counts := make(map[string]int32, len(statuses))
+	for _, status := range statuses {
+		counts[status.Name] = status.RestartCount
+	}
+	return counts
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func writeSnapshot(snapshot upgradeSnapshot, err error) {
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(os.WriteFile(snapshotPath, data, 0o600)).To(gomega.Succeed())
+}
+
+func readSnapshot() upgradeSnapshot {
+	data, err := os.ReadFile(snapshotPath)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	var snapshot upgradeSnapshot
+	gomega.Expect(json.Unmarshal(data, &snapshot)).To(gomega.Succeed())
+	return snapshot
+}
+
+func expectCurrentControllerReady() {
+	gomega.Eventually(func() error {
+		deployment := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: "lws-system",
+			Name:      "lws-controller-manager",
+		}, deployment); err != nil {
+			return err
+		}
+		if deployment.Status.ObservedGeneration != deployment.Generation {
+			return fmt.Errorf("controller deployment has not observed generation %d", deployment.Generation)
+		}
+		if deployment.Spec.Replicas == nil ||
+			deployment.Status.UpdatedReplicas != *deployment.Spec.Replicas ||
+			deployment.Status.ReadyReplicas != *deployment.Spec.Replicas ||
+			deployment.Status.AvailableReplicas != *deployment.Spec.Replicas {
+			return fmt.Errorf("controller deployment is not fully available")
+		}
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "manager" {
+				if container.Image != currentImageTag {
+					return fmt.Errorf("expected controller image %q, got %q", currentImageTag, container.Image)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("manager container not found")
+	}, 5*time.Minute, 2*time.Second).Should(gomega.Succeed())
+}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it

Adds a manifests/Kustomize upgrade E2E test from v0.9.0 to the current build.

The test:

- Creates standalone LeaderWorkerSet and DisaggregatedSet workloads before the upgrade.
- Snapshots LWS/DS identity, generated LWS role/revision, Pod UIDs, and container/init-container restart counts.
- Verifies the snapshot remains stable for 30 seconds after the upgrade.
- Waits for both webhooks and the current controller to become ready.
- Creates new LWS and DS workloads after the upgrade.

This aligns with the [DisaggregatedSet KEP](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet) and [DisaggregatedSet slices KEP](https://github.com/kubernetes-sigs/lws/tree/main/keps/846-disaggregatedset-slices).

#### Which issue(s) this PR fixes

Fixes https://github.com/kubernetes-sigs/lws/issues/926

#### Special notes for your reviewer

This overlaps with https://github.com/kubernetes-sigs/lws/pull/927, which currently covers standalone LWS upgrades. This implementation keeps shared manifests unchanged and adds DS coverage, stronger continuity assertions, a temporary kubeconfig, image preloading, server-side apply conflict handling, and explicit webhook readiness checks.

Validated with:

`make test-e2e-upgrade`

This PR covers the manifests/Kustomize upgrade path. Helm upgrade E2E coverage and the Prow lane can be added in follow-up PRs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
