### PR TITLE
fix: propagate SubGroupPolicyTypeAnnotationKey to worker pod annotations

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -419,6 +419,9 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		podAnnotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
 	}
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
+		if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type != nil {
+			podAnnotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey] = string(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type)
+		}
 		podAnnotations[leaderworkerset.SubGroupSizeAnnotationKey] = strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize))
 		if lws.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey] != "" {
 			podAnnotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -231,7 +231,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 				WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
 				Annotation(map[string]string{
 					leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
-				}).Size(2).SubGroupSize(2).Obj(),
+				}).Size(2).SubGroupSize(2).SubGroupType(leaderworkerset.SubGroupPolicyTypeLeaderExcluded).Obj(),
 			wantStatefulSetConfig: &appsapplyv1.StatefulSetApplyConfiguration{
 				TypeMetaApplyConfiguration: metaapplyv1.TypeMetaApplyConfiguration{
 					Kind:       ptr.To[string]("StatefulSet"),
@@ -272,6 +272,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/leader-name":         "test-sample",
 								leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topologyKey",
 								leaderworkerset.SubGroupSizeAnnotationKey:         "2",
+								leaderworkerset.SubGroupPolicyTypeAnnotationKey:   "LeaderExcluded",
 							},
 						},
 						Spec: &coreapplyv1.PodSpecApplyConfiguration{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When `subGroupPolicy` is set on a LeaderWorkerSet, `leaderworkerset_controller.go` adds `SubGroupPolicyTypeAnnotationKey` (`leaderworkerset.sigs.k8s.io/subgroup-policy-type`) to the leader pod template annotations.

However, `pod_controller.go` omitted `SubGroupPolicyTypeAnnotationKey` when building the worker StatefulSet pod template annotations. As a result, worker pods lacked this annotation, causing webhooks and TPU utilities (`pod_webhook.go` and `tpu.go`) reading `pod.Annotations[SubGroupPolicyTypeAnnotationKey]` to evaluate an empty string on worker pods instead of detecting policies like `LeaderExcluded`.

This PR propagates `SubGroupPolicyTypeAnnotationKey` to worker pod template annotations when `lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type` is specified, and adds unit test coverage in `pod_controller_test.go`.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```