### PR TITLE
fix: preserve missing-node reconcile errors

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -313,18 +313,13 @@ func (r *PodReconciler) setNodeSelectorForWorkerPods(ctx context.Context, pod *c
 }
 
 func (r *PodReconciler) topologyValueFromPod(ctx context.Context, pod *corev1.Pod, topologyKey string) (string, error) {
-	log := ctrl.LoggerFrom(ctx)
-
 	nodeName := pod.Spec.NodeName
 	ns := pod.Namespace
 
 	// Get node the leader pod is running on.
 	var node corev1.Node
 	if err := r.Get(ctx, types.NamespacedName{Name: nodeName, Namespace: ns}, &node); err != nil {
-		// We'll ignore not-found errors, since there is nothing we can do here.
-		// A node may not exist temporarily due to a maintenance event or other scenarios.
-		log.Error(err, fmt.Sprintf("getting node %s", nodeName))
-		return "", client.IgnoreNotFound(err)
+		return "", fmt.Errorf("getting node %q: %w", nodeName, err)
 	}
 
 	// Get topology (e.g. node pool name) from node labels.

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -430,6 +430,29 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 	}
 }
 
+func TestSetNodeSelectorForWorkerPodsReturnsNotFoundWhenLeaderNodeIsMissing(t *testing.T) {
+	reconciler := PodReconciler{Client: fake.NewClientBuilder().Build()}
+	leaderPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "missing-node"},
+	}
+	workerStatefulSet := &appsapplyv1.StatefulSetApplyConfiguration{
+		Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
+			Template: &coreapplyv1.PodTemplateSpecApplyConfiguration{
+				Spec: &coreapplyv1.PodSpecApplyConfiguration{},
+			},
+		},
+	}
+
+	err := reconciler.setNodeSelectorForWorkerPods(context.Background(), leaderPod, workerStatefulSet, "topology.kubernetes.io/zone")
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("setNodeSelectorForWorkerPods() error = %v, want NotFound", err)
+	}
+	if workerStatefulSet.Spec.Template.Spec.NodeSelector != nil {
+		t.Fatalf("setNodeSelectorForWorkerPods() set a node selector after a missing leader node: %v", workerStatefulSet.Spec.Template.Spec.NodeSelector)
+	}
+}
+
 func TestWorkerStatefulSetApplyConfigPropagatesObjectMeta(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
 	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -431,6 +431,29 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 	}
 }
 
+func TestSetNodeSelectorForWorkerPodsReturnsNotFoundWhenLeaderNodeIsMissing(t *testing.T) {
+	reconciler := PodReconciler{Client: fake.NewClientBuilder().Build()}
+	leaderPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "missing-node"},
+	}
+	workerStatefulSet := &appsapplyv1.StatefulSetApplyConfiguration{
+		Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
+			Template: &coreapplyv1.PodTemplateSpecApplyConfiguration{
+				Spec: &coreapplyv1.PodSpecApplyConfiguration{},
+			},
+		},
+	}
+
+	err := reconciler.setNodeSelectorForWorkerPods(context.Background(), leaderPod, workerStatefulSet, "topology.kubernetes.io/zone")
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("setNodeSelectorForWorkerPods() error = %v, want NotFound", err)
+	}
+	if workerStatefulSet.Spec.Template.Spec.NodeSelector != nil {
+		t.Fatalf("setNodeSelectorForWorkerPods() set a node selector after a missing leader node: %v", workerStatefulSet.Spec.Template.Spec.NodeSelector)
+	}
+}
+
 func TestWorkerStatefulSetApplyConfigPropagatesObjectMeta(t *testing.T) {
 	client := fake.NewClientBuilder().Build()
 	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").


### PR DESCRIPTION
## Summary

- Preserve the API error when the node hosting an exclusive-placement leader is unavailable.
- Prevent creation of a worker StatefulSet with an empty topology node selector.

## Root cause

`topologyValueFromPod` converted a missing Node error to `nil`, so reconciliation applied an empty topology value before creating the worker StatefulSet. Existing worker StatefulSets are not updated by this path.

## Validation

- `go test ./pkg/controllers -run '^TestSetNodeSelectorForWorkerPodsReturnsNotFoundWhenLeaderNodeIsMissing$' -count=1`
- `go test ./pkg/controllers -count=1`
- `go test ./api/... ./pkg/... ./cmd/... -count=1`
- `go vet ./...`
