### PR TITLE
[feat] DS external scaling slices support

### DIFF
--- a/api/disaggregatedset/v1/disaggregatedsetrolescaler_types.go
+++ b/api/disaggregatedset/v1/disaggregatedsetrolescaler_types.go
@@ -29,11 +29,13 @@ const DisaggregatedSetRoleScalerReady string = "Ready"
 // autoscaler via the /scale subresource. The (DS, role) association is derived
 // from the scaler's controller ownerReference and its role label.
 type DisaggregatedSetRoleScalerSpec struct {
-	// Replicas is the desired replica count for the role. The controller seeds
-	// this at scaler creation — 1 for a fresh role (0 would deadlock vanilla
-	// HPA in ScalingDisabled), or the LWS's current replica count for a
-	// Static→External flip so the role does not silently drain to zero.
-	// External autoscalers overwrite it on their first tick.
+	// Replicas is the desired total replica count for the role, summed across
+	// all slices. The controller seeds this at scaler creation — the slice
+	// count for a fresh role, one group per slice (0 would deadlock vanilla
+	// HPA in ScalingDisabled), or the current replica count summed across the
+	// role's LWS objects for a Static→External flip so the role is not
+	// resized by the flip. External autoscalers overwrite it on their first
+	// tick.
 	//
 	// Non-pointer with a default because kube-apiserver's CRD /scale handler
 	// extracts .spec.replicas at read time and errors ("the spec replicas

--- a/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsetrolescalers.yaml
+++ b/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsetrolescalers.yaml
@@ -62,11 +62,13 @@ spec:
                 replicas:
                   default: 0
                   description: |-
-                    Replicas is the desired replica count for the role. The controller seeds
-                    this at scaler creation — 1 for a fresh role (0 would deadlock vanilla
-                    HPA in ScalingDisabled), or the LWS's current replica count for a
-                    Static→External flip so the role does not silently drain to zero.
-                    External autoscalers overwrite it on their first tick.
+                    Replicas is the desired total replica count for the role, summed across
+                    all slices. The controller seeds this at scaler creation — the slice
+                    count for a fresh role, one group per slice (0 would deadlock vanilla
+                    HPA in ScalingDisabled), or the current replica count summed across the
+                    role's LWS objects for a Static→External flip so the role is not
+                    resized by the flip. External autoscalers overwrite it on their first
+                    tick.
 
                     Non-pointer with a default because kube-apiserver's CRD /scale handler
                     extracts .spec.replicas at read time and errors ("the spec replicas

--- a/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsetrolescalers.yaml
+++ b/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsetrolescalers.yaml
@@ -60,11 +60,13 @@ spec:
               replicas:
                 default: 0
                 description: |-
-                  Replicas is the desired replica count for the role. The controller seeds
-                  this at scaler creation — 1 for a fresh role (0 would deadlock vanilla
-                  HPA in ScalingDisabled), or the LWS's current replica count for a
-                  Static→External flip so the role does not silently drain to zero.
-                  External autoscalers overwrite it on their first tick.
+                  Replicas is the desired total replica count for the role, summed across
+                  all slices. The controller seeds this at scaler creation — the slice
+                  count for a fresh role, one group per slice (0 would deadlock vanilla
+                  HPA in ScalingDisabled), or the current replica count summed across the
+                  role's LWS objects for a Static→External flip so the role is not
+                  resized by the flip. External autoscalers overwrite it on their first
+                  tick.
 
                   Non-pointer with a default because kube-apiserver's CRD /scale handler
                   extracts .spec.replicas at read time and errors ("the spec replicas

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -136,18 +136,6 @@ rules:
 - apiGroups:
   - leaderworkerset.x-k8s.io
   resources:
-  - leaderworkersets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - leaderworkerset.x-k8s.io
-  resources:
   - leaderworkersets/finalizers
   verbs:
   - update

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -102,6 +102,13 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile scalers: %w", err)
 	}
 
+	// Resolve every role's replica target per slice up front. External roles
+	// treat the scaler value as the total across slices, split here by
+	// distribute(); Static roles use the inline per-slice count. The per-slice
+	// loop below (and the executor) consume only resolved targets, so a slice
+	// can never mistake the aggregate for its own share.
+	targets := resolveTargets(disaggregatedSet, sliceCount, scalers)
+
 	// Step 3: Reconcile LWS objects.
 	executor := r.createRollingUpdateExecutor()
 	roleNames := disaggregatedsetutils.GetRoleNames(disaggregatedSet)
@@ -127,7 +134,7 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	var result ctrl.Result
 	var errs []error
 	for slice := range sliceCount {
-		sliceResult, err := r.reconcileSlice(ctx, executor, disaggregatedSet, slice, revision, roleNames, scalers)
+		sliceResult, err := r.reconcileSlice(ctx, executor, disaggregatedSet, slice, revision, roleNames, targets[slice])
 		if err != nil {
 			errs = append(errs, fmt.Errorf("slice %d: %w", slice, err))
 			continue
@@ -146,13 +153,14 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // seedForRole returns a callback that yields the initial spec.replicas value
 // for a newly-created scaler. For a Static→External flip the seed is the
-// role's current aggregate LWS replica count so the running fleet is not
-// drained to 0. For a fresh role (no LWS yet) the seed is 1 rather than 0 so
-// vanilla HPA can bootstrap via minReplicas — HPA parks in ScalingDisabled
-// when it reads current=0 from /scale, regardless of minReplicas, unless the
-// HPAScaleToZero feature gate is enabled. Autoscalers that support scale-from-
-// zero (KEDA, HPA with the gate flipped) can still take the role down to 0
-// after attach.
+// role's current aggregate LWS replica count across all slices and revisions,
+// so the running fleet is not resized by the flip. For a fresh role (no LWS
+// yet) the seed is the slice count (one group per slice) rather than 0 so
+// every slice serves from the start and vanilla HPA can bootstrap via
+// minReplicas — HPA parks in ScalingDisabled when it reads current=0 from
+// /scale, regardless of minReplicas, unless the HPAScaleToZero feature gate is
+// enabled. Autoscalers that support scale-from-zero (KEDA, HPA with the gate
+// flipped) can still take the role down to 0 after attach.
 func (r *DisaggregatedSetReconciler) seedForRole(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet) (func(string) int32, error) {
 	all, err := r.LWSManager.List(ctx, ds.Namespace, ds.Name, -1, "")
 	if err != nil {
@@ -171,7 +179,7 @@ func (r *DisaggregatedSetReconciler) seedForRole(ctx context.Context, ds *disagg
 	}
 	return func(role string) int32 {
 		if !seen[role] {
-			return 1
+			return disaggregatedsetutils.GetSlices(ds)
 		}
 		return sums[role]
 	}, nil
@@ -214,7 +222,7 @@ func (r *DisaggregatedSetReconciler) reconcileSlice(
 	slice int,
 	revision string,
 	roleNames []string,
-	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+	targets SliceTargets,
 ) (ctrl.Result, error) {
 	if err := r.cleanupDrainedLWS(ctx, disaggregatedSet, slice, revision); err != nil {
 		return ctrl.Result{}, err
@@ -234,9 +242,9 @@ func (r *DisaggregatedSetReconciler) reconcileSlice(
 	// LWS objects directly for the target revision (steady-state path).
 	var result ctrl.Result
 	if len(oldRevisions) > 0 && totalOldReplicas > 0 {
-		result, err = executor.ReconcileRollingUpdateNew(ctx, disaggregatedSet, slice, revision, scalers)
+		result, err = executor.ReconcileRollingUpdateNew(ctx, disaggregatedSet, slice, revision, targets)
 	} else {
-		result, err = r.reconcileSimple(ctx, disaggregatedSet, slice, revision, scalers)
+		result, err = r.reconcileSimple(ctx, disaggregatedSet, slice, revision, targets)
 	}
 	if err != nil {
 		return result, err
@@ -299,11 +307,11 @@ func (r *DisaggregatedSetReconciler) createRollingUpdateExecutor() *RollingUpdat
 }
 
 //nolint:unparam // Result is always empty but signature matches controller-runtime pattern
-func (r *DisaggregatedSetReconciler) reconcileSimple(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, slice int, revision string, scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler) (ctrl.Result, error) {
+func (r *DisaggregatedSetReconciler) reconcileSimple(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, slice int, revision string, targets SliceTargets) (ctrl.Result, error) {
 	roleConfigs := disaggregatedsetutils.GetRoleConfigs(disaggregatedSet)
 
 	for role, config := range roleConfigs {
-		if err := r.reconcileRoleSimple(ctx, disaggregatedSet, slice, role, config, revision, scalers); err != nil {
+		if err := r.reconcileRoleSimple(ctx, disaggregatedSet, slice, role, config, revision, targets); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile %s role: %w", role, err)
 		}
 	}
@@ -311,7 +319,7 @@ func (r *DisaggregatedSetReconciler) reconcileSimple(ctx context.Context, disagg
 	return ctrl.Result{}, nil
 }
 
-func (r *DisaggregatedSetReconciler) reconcileRoleSimple(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, slice int, role string, config *disaggregatedsetv1.DisaggregatedRoleSpec, revision string, scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler) error {
+func (r *DisaggregatedSetReconciler) reconcileRoleSimple(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, slice int, role string, config *disaggregatedsetv1.DisaggregatedRoleSpec, revision string, targets SliceTargets) error {
 	log := logf.FromContext(ctx)
 
 	// GetForRole adopts a legacy slice-0 LWS in place, so we do not create a
@@ -321,12 +329,13 @@ func (r *DisaggregatedSetReconciler) reconcileRoleSimple(ctx context.Context, di
 		return fmt.Errorf("failed to get LWS for role %s revision %s: %w", role, revision, err)
 	}
 
-	// External roles pull replicas from the scaler; Static roles use spec.replicas.
+	// Targets are pre-resolved per slice: this slice's distributed share for
+	// External roles, the inline per-slice count for Static roles.
 	currentReplicas := int32(0)
 	if existing != nil && existing.Spec.Replicas != nil {
 		currentReplicas = *existing.Spec.Replicas
 	}
-	desiredReplicas := int32(getTargetReplicas(disaggregatedSet, role, scalers, int(currentReplicas)))
+	desiredReplicas := int32(targets.Resolve(role, int(currentReplicas)))
 
 	if existing == nil {
 		lwsName := disaggregatedsetutils.GenerateName(disaggregatedSet.Name, slice, revision, role)

--- a/pkg/controllers/disaggregatedset/distribution.go
+++ b/pkg/controllers/disaggregatedset/distribution.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disaggregatedset
+
+import (
+	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+)
+
+// RoleTarget is the resolved desired replica count for one role in one slice.
+// Hold means no target could be determined (an External role whose scaler is
+// unavailable, e.g. a name conflict prevented adoption) and the current count
+// must be kept.
+type RoleTarget struct {
+	Replicas int
+	Hold     bool
+}
+
+// SliceTargets maps role name to its resolved target for a single slice. It is
+// computed once per reconcile, before the per-slice loop, so every slice works
+// from a consistent snapshot and the executor never consults scalers directly.
+type SliceTargets map[string]RoleTarget
+
+// Resolve returns the role's target, or current when the role has no resolved
+// target (unknown role or Hold).
+func (t SliceTargets) Resolve(role string, current int) int {
+	rt, ok := t[role]
+	if !ok || rt.Hold {
+		return current
+	}
+	return rt.Replicas
+}
+
+// resolveTargets computes the per-slice replica target for every role in the
+// spec. Static roles use the inline per-slice spec.replicas. External roles
+// treat scaler.spec.replicas as the total across all slices and split it with
+// distribute; a missing scaler resolves to Hold.
+func resolveTargets(
+	ds *disaggregatedsetv1.DisaggregatedSet,
+	sliceCount int,
+	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+) []SliceTargets {
+	targets := make([]SliceTargets, sliceCount)
+	for i := range targets {
+		targets[i] = make(SliceTargets, len(ds.Spec.Roles))
+	}
+
+	for _, role := range ds.Spec.Roles {
+		if role.Scaling != nil && role.Scaling.Mode == disaggregatedsetv1.RoleScalingExternal {
+			scaler := scalers[role.Name]
+			if scaler == nil {
+				for i := range targets {
+					targets[i][role.Name] = RoleTarget{Hold: true}
+				}
+				continue
+			}
+			total := int(scaler.Spec.Replicas)
+			for i := range targets {
+				targets[i][role.Name] = RoleTarget{Replicas: distribute(total, sliceCount, i)}
+			}
+			continue
+		}
+
+		perSlice := 1
+		if role.Spec.Replicas != nil {
+			perSlice = int(*role.Spec.Replicas)
+		}
+		for i := range targets {
+			targets[i][role.Name] = RoleTarget{Replicas: perSlice}
+		}
+	}
+	return targets
+}
+
+// distribute splits an aggregate replica total across slices: every slice gets
+// floor(total/slices) and the remainder goes to the lowest-indexed slices, one
+// each. The result is a pure function of (total, slices, index), so
+// concurrently reconciling slices always compute a consistent split, targets
+// differ by at most one across slices, and raising the total never lowers any
+// slice's share (or vice versa). Keeping the remainder on low indices means
+// slice scale-down, which removes the highest slices first, disturbs the
+// smallest shares.
+func distribute(total, slices, index int) int {
+	if slices <= 0 || total <= 0 {
+		return 0
+	}
+	base := total / slices
+	if index < total%slices {
+		return base + 1
+	}
+	return base
+}

--- a/pkg/controllers/disaggregatedset/distribution_test.go
+++ b/pkg/controllers/disaggregatedset/distribution_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disaggregatedset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+func TestDistribute(t *testing.T) {
+	tests := []struct {
+		name   string
+		total  int
+		slices int
+		want   []int
+	}{
+		{name: "even split", total: 4, slices: 2, want: []int{2, 2}},
+		{name: "remainder to lowest slices", total: 5, slices: 2, want: []int{3, 2}},
+		{name: "remainder of two", total: 8, slices: 3, want: []int{3, 3, 2}},
+		{name: "total below slice count", total: 1, slices: 3, want: []int{1, 0, 0}},
+		{name: "zero total", total: 0, slices: 2, want: []int{0, 0}},
+		{name: "single slice passthrough", total: 7, slices: 1, want: []int{7}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make([]int, tc.slices)
+			sum := 0
+			for i := range tc.slices {
+				got[i] = distribute(tc.total, tc.slices, i)
+				sum += got[i]
+			}
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, max(tc.total, 0), sum, "shares must sum to the total")
+		})
+	}
+}
+
+// Raising the total must never lower any slice's share, and lowering it must
+// never raise one, so autoscaler steps translate to monotone per-slice moves.
+func TestDistributeMonotone(t *testing.T) {
+	const slices = 4
+	for total := 0; total < 20; total++ {
+		for i := range slices {
+			assert.GreaterOrEqual(t, distribute(total+1, slices, i), distribute(total, slices, i),
+				"total %d -> %d lowered slice %d", total, total+1, i)
+		}
+	}
+}
+
+func TestResolveTargets(t *testing.T) {
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Spec: disaggregatedsetv1.DisaggregatedSetSpec{
+			Roles: []disaggregatedsetv1.DisaggregatedRoleSpec{
+				{
+					Name:    "prefill",
+					Scaling: &disaggregatedsetv1.RoleScaling{Mode: disaggregatedsetv1.RoleScalingExternal},
+				},
+				{
+					Name: "decode",
+					LeaderWorkerSetTemplateSpec: leaderworkersetv1.LeaderWorkerSetTemplateSpec{
+						Spec: leaderworkersetv1.LeaderWorkerSetSpec{Replicas: ptr.To(int32(2))},
+					},
+				},
+			},
+		},
+	}
+	scalers := map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler{
+		"prefill": {Spec: disaggregatedsetv1.DisaggregatedSetRoleScalerSpec{Replicas: 5}},
+	}
+
+	targets := resolveTargets(ds, 2, scalers)
+
+	// External: aggregate 5 split 3/2. Static: per-slice count in every slice.
+	assert.Equal(t, RoleTarget{Replicas: 3}, targets[0]["prefill"])
+	assert.Equal(t, RoleTarget{Replicas: 2}, targets[1]["prefill"])
+	assert.Equal(t, RoleTarget{Replicas: 2}, targets[0]["decode"])
+	assert.Equal(t, RoleTarget{Replicas: 2}, targets[1]["decode"])
+
+	// A missing scaler resolves to Hold, and Resolve keeps the current count.
+	targets = resolveTargets(ds, 2, nil)
+	assert.True(t, targets[0]["prefill"].Hold)
+	assert.Equal(t, 4, targets[0].Resolve("prefill", 4))
+	assert.Equal(t, 2, targets[1].Resolve("decode", 9))
+}

--- a/pkg/controllers/disaggregatedset/executor.go
+++ b/pkg/controllers/disaggregatedset/executor.go
@@ -58,7 +58,7 @@ func (executor *RollingUpdateExecutor) ReconcileRollingUpdateNew(
 	disaggregatedSet *disaggregatedsetv1.DisaggregatedSet,
 	slice int,
 	revision string,
-	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+	targets SliceTargets,
 ) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	roleNames := disaggregatedsetutils.GetRoleNames(disaggregatedSet)
@@ -81,7 +81,7 @@ func (executor *RollingUpdateExecutor) ReconcileRollingUpdateNew(
 		return executor.initRollingUpdate(ctx, disaggregatedSet, slice, revision, roleNames, roleConfigs, oldRevisions)
 	}
 
-	return executor.ReconcileRollingUpdate(ctx, disaggregatedSet, slice, oldRevisions, *newRevision, scalers)
+	return executor.ReconcileRollingUpdate(ctx, disaggregatedSet, slice, oldRevisions, *newRevision, targets)
 }
 
 func (executor *RollingUpdateExecutor) initRollingUpdate(
@@ -137,7 +137,7 @@ func (executor *RollingUpdateExecutor) ReconcileRollingUpdate(
 	slice int,
 	oldRevisions disaggregatedsetutils.RevisionRolesList,
 	newRevision disaggregatedsetutils.RevisionRoles,
-	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+	targets SliceTargets,
 ) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	specRoleNames := disaggregatedsetutils.GetRoleNames(disaggregatedSet)
@@ -153,8 +153,8 @@ func (executor *RollingUpdateExecutor) ReconcileRollingUpdate(
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
-	initialOld, currentOld, currentNew, targetNew := buildPlannerState(disaggregatedSet, allRoleNames, specRoleSet, oldRevisions, newRevision, scalers)
-	config := extractRollingUpdateConfig(disaggregatedSet, allRoleNames, scalers)
+	initialOld, currentOld, currentNew, targetNew := buildPlannerState(disaggregatedSet, allRoleNames, specRoleSet, oldRevisions, newRevision, targets)
+	config := extractRollingUpdateConfig(disaggregatedSet, allRoleNames, targets)
 
 	nextStep := ComputeNextStep(initialOld, currentOld, currentNew, targetNew, config)
 	if nextStep == nil {
@@ -208,7 +208,7 @@ func buildPlannerState(
 	specRoleSet map[string]bool,
 	oldRevisions disaggregatedsetutils.RevisionRolesList,
 	newRevision disaggregatedsetutils.RevisionRoles,
-	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+	targets SliceTargets,
 ) (initialOld, currentOld, currentNew, targetNew RoleReplicaState) {
 	n := len(allRoleNames)
 	initialOld, currentOld, currentNew, targetNew = make(RoleReplicaState, n), make(RoleReplicaState, n), make(RoleReplicaState, n), make(RoleReplicaState, n)
@@ -221,39 +221,18 @@ func buildPlannerState(
 			if lws := newRevision.Roles[roleName]; lws != nil {
 				currentNew[i] = int(getLWSReplicas(lws))
 			}
-			targetNew[i] = getTargetReplicas(ds, roleName, scalers, currentNew[i])
-			// No-shrink guard: an External role mid-rollout must not shrink the
-			// new-revision fleet if HPA writes a smaller value while the old
-			// revision is still draining. Releases once the rollout completes.
+			targetNew[i] = targets.Resolve(roleName, currentNew[i])
+			// No-shrink guard, per (slice, role): an External role mid-rollout in
+			// this slice must not shrink the new-revision fleet if the autoscaler
+			// lowers this slice's distributed share while the old revision is
+			// still draining. Both counts are this slice's own, so a rollout here
+			// never clamps a sibling slice. Releases once the rollout completes.
 			if isExternal(ds, roleName) && len(oldRevisions) > 0 && targetNew[i] < currentNew[i] {
 				targetNew[i] = currentNew[i]
 			}
 		}
 	}
 	return
-}
-
-// getTargetReplicas resolves the desired replica count. External roles read
-// spec.replicas from the scaler (always materialised since the CRD defaults it
-// to 0 and the controller seeds it at creation to avoid draining a running
-// Static→External flip).
-func getTargetReplicas(ds *disaggregatedsetv1.DisaggregatedSet, roleName string, scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler, currentNew int) int {
-	for _, p := range ds.Spec.Roles {
-		if p.Name != roleName {
-			continue
-		}
-		if p.Scaling != nil && p.Scaling.Mode == disaggregatedsetv1.RoleScalingExternal {
-			if s := scalers[roleName]; s != nil {
-				return int(s.Spec.Replicas)
-			}
-			return currentNew
-		}
-		if p.Spec.Replicas == nil {
-			return 1
-		}
-		return int(*p.Spec.Replicas)
-	}
-	return 1
 }
 
 func isExternal(ds *disaggregatedsetv1.DisaggregatedSet, roleName string) bool {
@@ -268,7 +247,7 @@ func isExternal(ds *disaggregatedsetv1.DisaggregatedSet, roleName string) bool {
 func extractRollingUpdateConfig(
 	ds *disaggregatedsetv1.DisaggregatedSet,
 	allRoleNames []string,
-	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
+	targets SliceTargets,
 ) []RollingUpdateConfig {
 	config := DefaultRollingUpdateConfig(len(allRoleNames))
 
@@ -280,10 +259,11 @@ func extractRollingUpdateConfig(
 	for _, role := range ds.Spec.Roles {
 		if rc := role.Spec.RolloutStrategy.RollingUpdateConfiguration; rc != nil {
 			i := roleIndex[role.Name]
-			// For External roles this returns the scaler value (or currentNew=0
-			// if none is available); percentages against 0 collapse to 0, which
-			// matches how a paused rollout should behave.
-			replicas := getTargetReplicas(ds, role.Name, scalers, 0)
+			// Percentage budgets are computed against this slice's resolved
+			// target (0 when the target is held, so a paused rollout's budgets
+			// collapse to 0), consistent with their per-slice meaning for
+			// Static roles.
+			replicas := targets.Resolve(role.Name, 0)
 			// Use GetScaledValueFromIntOrPercent to handle both integers and percentages.
 			// For maxSurge, round up (true); for maxUnavailable, round down (false).
 			surge, _ := intstr.GetScaledValueFromIntOrPercent(&rc.MaxSurge, replicas, true)

--- a/pkg/controllers/disaggregatedset/executor_test.go
+++ b/pkg/controllers/disaggregatedset/executor_test.go
@@ -682,7 +682,7 @@ func TestExtractRollingUpdateConfig(t *testing.T) {
 			}
 
 			roleNames := []string{testRolePrefill, testRoleDecode}
-			config := extractRollingUpdateConfig(ds, roleNames, nil)
+			config := extractRollingUpdateConfig(ds, roleNames, resolveTargets(ds, 1, nil)[0])
 
 			assert.Equal(t, tc.expectedPrefillSurge, config[0].MaxSurge)
 			assert.Equal(t, tc.expectedPrefillUnavail, config[0].MaxUnavailable)
@@ -791,7 +791,7 @@ func TestExtractRollingUpdateConfigWithPercentages(t *testing.T) {
 			}
 
 			roleNames := []string{testRolePrefill, testRoleDecode}
-			config := extractRollingUpdateConfig(ds, roleNames, nil)
+			config := extractRollingUpdateConfig(ds, roleNames, resolveTargets(ds, 1, nil)[0])
 
 			assert.Equal(t, tc.expectedPrefillSurge, config[0].MaxSurge)
 			assert.Equal(t, tc.expectedPrefillUnavail, config[0].MaxUnavailable)
@@ -1230,7 +1230,7 @@ func TestReconcileRollingUpdateABCScenario(t *testing.T) {
 				testRolePrefill: makeLWS(withReplicas(int(tc.cPrefill)), withReadyReplicas(int(tc.cPrefill))),
 				testRoleDecode:  makeLWS(withReplicas(int(tc.cDecode)), withReadyReplicas(int(tc.cDecode)))}}
 
-			_, err := executor.ReconcileRollingUpdate(context.TODO(), deployment, 0, oldRevisions, newRevision, nil)
+			_, err := executor.ReconcileRollingUpdate(context.TODO(), deployment, 0, oldRevisions, newRevision, resolveTargets(deployment, 1, nil)[0])
 			require.NoError(t, err)
 
 			if tc.aPrefill > 0 || tc.aDecode > 0 {

--- a/pkg/controllers/disaggregatedset/scaler_manager_test.go
+++ b/pkg/controllers/disaggregatedset/scaler_manager_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	disaggregatedsetutils "sigs.k8s.io/lws/pkg/utils/disaggregatedset"
 	"sigs.k8s.io/lws/test/wrappers"
 )
 
@@ -119,7 +121,7 @@ func TestScalerManagerReconcileRefusesForeignScaler(t *testing.T) {
 	}
 }
 
-func TestGetTargetReplicasResolutionMatrix(t *testing.T) {
+func TestTargetReplicasResolutionMatrix(t *testing.T) {
 	cases := []struct {
 		name         string
 		role         disaggregatedsetv1.DisaggregatedRoleSpec
@@ -143,7 +145,8 @@ func TestGetTargetReplicasResolutionMatrix(t *testing.T) {
 					Spec: disaggregatedsetv1.DisaggregatedSetRoleScalerSpec{Replicas: tc.scalerVal},
 				}
 			}
-			assert.Equal(t, tc.wantReplicas, getTargetReplicas(ds, "r", scalers, tc.currentNew))
+			targets := resolveTargets(ds, 1, scalers)
+			assert.Equal(t, tc.wantReplicas, targets[0].Resolve("r", tc.currentNew))
 		})
 	}
 }
@@ -181,4 +184,42 @@ func TestScalerManagerWriteStatus(t *testing.T) {
 // for one call in tests.
 func apierrorsIsNotFound(err error) bool {
 	return err != nil && client.IgnoreNotFound(err) == nil
+}
+
+func TestSeedForRole(t *testing.T) {
+	ds := newDSWithRoles("myds", externalRole("prefill"), staticRole("decode"))
+	ds.Spec.Slices = ptr.To(int32(3))
+
+	makeLWSWithLabels := func(name string, slice int, role string, replicas int32) *leaderworkersetv1.LeaderWorkerSet {
+		return &leaderworkersetv1.LeaderWorkerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    disaggregatedsetutils.GenerateLabels("myds", slice, "rev1", role),
+			},
+			Spec: leaderworkersetv1.LeaderWorkerSetSpec{Replicas: ptr.To(replicas)},
+		}
+	}
+
+	t.Run("fresh role seeds to the slice count", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(wrappers.DisaggregatedSetTestScheme()).Build()
+		r := &DisaggregatedSetReconciler{Client: cl, LWSManager: NewLeaderWorkerSetManager(cl)}
+		seedFor, err := r.seedForRole(context.TODO(), ds)
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, seedFor("prefill"))
+	})
+
+	t.Run("flip seeds to the observed total across slices", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(wrappers.DisaggregatedSetTestScheme()).
+			WithObjects(
+				makeLWSWithLabels("myds-0-rev1-prefill", 0, "prefill", 2),
+				makeLWSWithLabels("myds-1-rev1-prefill", 1, "prefill", 3),
+			).Build()
+		r := &DisaggregatedSetReconciler{Client: cl, LWSManager: NewLeaderWorkerSetManager(cl)}
+		seedFor, err := r.seedForRole(context.TODO(), ds)
+		require.NoError(t, err)
+		assert.EqualValues(t, 5, seedFor("prefill"))
+		// decode has no LWS yet, so it seeds fresh.
+		assert.EqualValues(t, 3, seedFor("decode"))
+	})
 }

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -68,7 +68,6 @@ func (w *DisaggregatedSetWebhook) validate(obj *disaggv1.DisaggregatedSet) (admi
 	var warnings admission.Warnings
 	rolesPath := field.NewPath("spec", "roles")
 
-	hasExternal := false
 	for i, role := range obj.Spec.Roles {
 		rolePath := rolesPath.Index(i)
 		allErrs = append(allErrs, w.validateRoleRolloutStrategy(role, rolePath)...)
@@ -76,7 +75,6 @@ func (w *DisaggregatedSetWebhook) validate(obj *disaggv1.DisaggregatedSet) (admi
 		if role.Scaling == nil || role.Scaling.Mode != disaggv1.RoleScalingExternal {
 			continue
 		}
-		hasExternal = true
 
 		// Scaler name is "<ds>-<role>" and must fit within the Kubernetes 253-character limit.
 		if scalerName := obj.Name + "-" + role.Name; len(scalerName) > 253 {
@@ -91,14 +89,6 @@ func (w *DisaggregatedSetWebhook) validate(obj *disaggv1.DisaggregatedSet) (admi
 				"role %q sets scaling.mode: External and spec.replicas: %d — spec.replicas is ignored; drive replicas via DisaggregatedSetRoleScaler %q instead",
 				role.Name, *role.Spec.Replicas, obj.Name+"-"+role.Name))
 		}
-	}
-
-	// Alpha: External scaling and slices > 1 are incompatible. The scaler
-	// design for multi-slice is deferred to a follow-up KEP.
-	if hasExternal && obj.Spec.Slices != nil && *obj.Spec.Slices > 1 {
-		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("spec", "slices"),
-			"spec.slices > 1 is not supported while any role has scaling.mode: External (alpha restriction)"))
 	}
 
 	return warnings, allErrs

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -685,7 +685,7 @@ func TestValidateExternalScalingRules(t *testing.T) {
 		require.Contains(t, warnings[0], "spec.replicas is ignored")
 	})
 
-	t.Run("rejects External + spec.slices > 1", func(t *testing.T) {
+	t.Run("allows External + spec.slices > 1", func(t *testing.T) {
 		obj := &disaggv1.DisaggregatedSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "ds", Namespace: "default"},
 			Spec: disaggv1.DisaggregatedSetSpec{
@@ -693,9 +693,9 @@ func TestValidateExternalScalingRules(t *testing.T) {
 				Roles:  []disaggv1.DisaggregatedRoleSpec{{Name: "prefill", Scaling: external}},
 			},
 		}
-		_, err := webhook.ValidateCreate(ctx, obj)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "spec.slices > 1")
+		warnings, err := webhook.ValidateCreate(ctx, obj)
+		require.NoError(t, err)
+		require.Empty(t, warnings)
 	})
 
 	t.Run("rejects when scaler name would exceed 253 chars", func(t *testing.T) {

--- a/site/content/en/docs/reference/disaggregatedset.v1.md
+++ b/site/content/en/docs/reference/disaggregatedset.v1.md
@@ -155,11 +155,13 @@ from the scaler's controller ownerReference and its role label.</p>
 <code>int32</code>
 </td>
 <td>
-   <p>Replicas is the desired replica count for the role. The controller seeds
-this at scaler creation — 1 for a fresh role (0 would deadlock vanilla
-HPA in ScalingDisabled), or the LWS's current replica count for a
-Static→External flip so the role does not silently drain to zero.
-External autoscalers overwrite it on their first tick.</p>
+   <p>Replicas is the desired total replica count for the role, summed across
+all slices. The controller seeds this at scaler creation — the slice
+count for a fresh role, one group per slice (0 would deadlock vanilla
+HPA in ScalingDisabled), or the current replica count summed across the
+role's LWS objects for a Static→External flip so the role is not
+resized by the flip. External autoscalers overwrite it on their first
+tick.</p>
 <p>Non-pointer with a default because kube-apiserver's CRD /scale handler
 extracts .spec.replicas at read time and errors (&quot;the spec replicas
 field does not exist&quot;) when the JSONPath resolves to nothing. HPA reads

--- a/test/e2e/disaggregatedset/hpa_test.go
+++ b/test/e2e/disaggregatedset/hpa_test.go
@@ -139,4 +139,66 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", Ordered, func() {
 			g.Expect(strings.TrimSpace(out)).To(BeEmpty())
 		}).Should(Succeed())
 	})
+
+	// KEP-948: the scaler value is an aggregate across slices, split by
+	// distribute() with the remainder on the lowest slice indices. Slice-count
+	// changes rebalance the same total rather than multiplying it.
+	It("distributes an aggregate /scale write across slices and rebalances on slice-count changes", func() {
+		By("creating a 2-slice DisaggregatedSet with an External prefill role")
+		cfg := fixtures.PrefillDecode(dsName,
+			fixtures.Role{External: true},
+			fixtures.Role{Replicas: 1},
+		)
+		cfg.Slices = 2
+		Expect(applyYAML(cfg.YAML())).To(Succeed())
+
+		By("waiting for the scaler, seeded to the slice count (one group per slice)")
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName,
+				"-o", "jsonpath={.spec.replicas}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("2"))
+		}).Should(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 0)).To(Equal(1))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 1)).To(Equal(1))
+		}).Should(Succeed())
+
+		By("writing an aggregate of 5 via /scale and expecting a 3/2 split, remainder on slice 0")
+		_, err := utils.Run(exec.Command("kubectl", "scale",
+			"disaggregatedsetrolescaler/"+scalerName, "--replicas=5"))
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 0)).To(Equal(3))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 1)).To(Equal(2))
+		}).Should(Succeed())
+
+		By("verifying scaler status converges to the aggregate")
+		Eventually(func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName,
+				"-o", "jsonpath={.status.replicas}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal("5"))
+		}).Should(Succeed())
+
+		By("raising slices to 3 and expecting the same total rebalanced to 2/2/1")
+		_, err = utils.Run(exec.Command("kubectl", "patch", "disaggregatedset", dsName,
+			"--type=merge", "-p", `{"spec":{"slices":3}}`))
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 0)).To(Equal(2))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 1)).To(Equal(2))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 2)).To(Equal(1))
+		}).Should(Succeed())
+
+		By("dropping slices back to 2 and expecting the remaining slices to absorb the total")
+		_, err = utils.Run(exec.Command("kubectl", "patch", "disaggregatedset", dsName,
+			"--type=merge", "-p", `{"spec":{"slices":2}}`))
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func(g Gomega) {
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 0)).To(Equal(3))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 1)).To(Equal(2))
+			g.Expect(kubectl.GetRoleReplicasBySlice(dsName, "prefill", 2)).To(Equal(0))
+		}).Should(Succeed())
+	})
 })

--- a/test/integration/webhooks/disaggregatedset_test.go
+++ b/test/integration/webhooks/disaggregatedset_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	disaggregatedset "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -146,5 +147,59 @@ var _ = ginkgo.Describe("disaggregatedset placement policy validation", func() {
 		err := k8sClient.Update(ctx, &fetched)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(leaderworkerset.ExclusiveKeyAnnotationKey))
+	})
+})
+
+var _ = ginkgo.Describe("disaggregatedset external scaling with slices", func() {
+
+	var ns *corev1.Namespace
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-ns-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	buildDisaggregatedSet := func() *wrappers.DisaggregatedSetWrapper {
+		disagg := wrappers.BuildDisaggregatedSet("scaling-test", ns.Name).
+			WithRole("prefill", 1, "nginx:1.14.2").
+			WithRole("decode", 1, "nginx:1.14.2")
+		// The DisaggregatedSet CRD enum-validates these fields but has no
+		// defaulting webhook to fill them in, so set them explicitly.
+		for i := range disagg.Spec.Roles {
+			disagg.Spec.Roles[i].Spec.RolloutStrategy.Type = leaderworkerset.RollingUpdateStrategyType
+			disagg.Spec.Roles[i].Spec.StartupPolicy = leaderworkerset.LeaderCreatedStartupPolicy
+		}
+		return disagg
+	}
+
+	ginkgo.It("allows creating a multi-slice DisaggregatedSet with an External role", func() {
+		ctx := context.Background()
+		disagg := buildDisaggregatedSet().Slices(2).WithExternalScaling("prefill").Obj()
+		gomega.Expect(k8sClient.Create(ctx, disagg)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("allows raising slices on a DisaggregatedSet with an External role", func() {
+		ctx := context.Background()
+		disagg := buildDisaggregatedSet().WithExternalScaling("prefill").Obj()
+		gomega.Expect(k8sClient.Create(ctx, disagg)).To(gomega.Succeed())
+
+		var fetched disaggregatedset.DisaggregatedSet
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: disagg.Name, Namespace: disagg.Namespace}, &fetched)).To(gomega.Succeed())
+		fetched.Spec.Slices = ptr.To(int32(3))
+		gomega.Expect(k8sClient.Update(ctx, &fetched)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("allows flipping a role to External on a multi-slice DisaggregatedSet", func() {
+		ctx := context.Background()
+		disagg := buildDisaggregatedSet().Slices(2).Obj()
+		gomega.Expect(k8sClient.Create(ctx, disagg)).To(gomega.Succeed())
+
+		var fetched disaggregatedset.DisaggregatedSet
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: disagg.Name, Namespace: disagg.Namespace}, &fetched)).To(gomega.Succeed())
+		fetched.Spec.Roles[0].Scaling = &disaggregatedset.RoleScaling{Mode: disaggregatedset.RoleScalingExternal}
+		gomega.Expect(k8sClient.Update(ctx, &fetched)).To(gomega.Succeed())
 	})
 })

--- a/test/testutils/disaggregatedset/fixtures/fixtures.go
+++ b/test/testutils/disaggregatedset/fixtures/fixtures.go
@@ -45,6 +45,8 @@ type Config struct {
 	Name      string
 	Namespace string
 	Roles     []Role
+	// Slices, when > 0, emits spec.slices.
+	Slices int
 	// PlacementType, when non-empty, adds a spec.placementPolicy block
 	// (None | ExclusiveSlice | ExclusiveTopology). PlacementTopology is the
 	// topologyKey and is required for a non-None type.
@@ -67,6 +69,10 @@ metadata:
   namespace: %s
 spec:
 `, c.Name, ns))
+
+	if c.Slices > 0 {
+		sb.WriteString(fmt.Sprintf("  slices: %d\n", c.Slices))
+	}
 
 	if c.PlacementType != "" {
 		sb.WriteString("  placementPolicy:\n")

--- a/test/testutils/disaggregatedset/kubectl/queries.go
+++ b/test/testutils/disaggregatedset/kubectl/queries.go
@@ -25,6 +25,7 @@ const (
 	labelName     = "disaggregatedset.x-k8s.io/name"
 	labelRole     = "disaggregatedset.x-k8s.io/role"
 	labelRevision = "disaggregatedset.x-k8s.io/revision"
+	labelSlice    = "disaggregatedset.x-k8s.io/slice"
 	defaultNS     = "default"
 )
 
@@ -146,6 +147,18 @@ func CountService(deploymentName string) int {
 // GetTotalReplicas returns total replicas across all LWS for a revision.
 func GetTotalReplicas(deploymentName, revision string) int {
 	output, err := LWSByRevision(deploymentName, revision).
+		JSONPath("{range .items[*]}{.spec.replicas} {end}").RunQuiet()
+	if err != nil {
+		return 0
+	}
+	return sumInts(output)
+}
+
+// GetRoleReplicasBySlice returns total spec.replicas across a role's LWS
+// objects in a single slice (summed across revisions).
+func GetRoleReplicasBySlice(deploymentName, role string, slice int) int {
+	output, err := LWSByRole(deploymentName, role).
+		Label(labelSlice, strconv.Itoa(slice)).
 		JSONPath("{range .items[*]}{.spec.replicas} {end}").RunQuiet()
 	if err != nil {
 		return 0

--- a/test/wrappers/disaggregatedset_wrappers.go
+++ b/test/wrappers/disaggregatedset_wrappers.go
@@ -99,6 +99,16 @@ func (w *DisaggregatedSetWrapper) WithRollout(role string, surge, unavail intstr
 	return w
 }
 
+// WithExternalScaling sets scaling.mode: External on the named role.
+func (w *DisaggregatedSetWrapper) WithExternalScaling(role string) *DisaggregatedSetWrapper {
+	for i := range w.Spec.Roles {
+		if w.Spec.Roles[i].Name == role {
+			w.Spec.Roles[i].Scaling = &disaggregatedsetv1.RoleScaling{Mode: disaggregatedsetv1.RoleScalingExternal}
+		}
+	}
+	return w
+}
+
 func (w *DisaggregatedSetWrapper) WithPlacementPolicy(policyType disaggregatedsetv1.PlacementType, topology string) *DisaggregatedSetWrapper {
 	w.Spec.PlacementPolicy = &disaggregatedsetv1.PlacementPolicy{
 		Type:     policyType,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Implements KEP-948: allows `scaling.mode: External` together with `spec.slices` > 1. The DisaggregatedSetRoleScaler value is treated as the role's total across all slices and split deterministically by the controller before the per-slice reconcile loop, the mid-rollout no-shrink guard applies per slice, and fresh scalers seed to the slice count. Removes the KEP-849 alpha webhook restriction. No API fields change.

#### Which issue(s) this PR fixes

Fixes #948
Related to #949

#### Testing

Tested e2e on a cluster with HPA: aggregate distribution across slices, slice count changes under an active scaler, and per-slice guard behavior under a mid-rollout scale down.

#### Does this PR introduce a user-facing change?

```release-note
DisaggregatedSet roles with scaling.mode: External can be combined with spec.slices > 1. The DisaggregatedSetRoleScaler replicas value is the desired total across all slices, distributed by the controller.
```