### PR TITLE
fix: ignore unrelated StatefulSets in LeaderWorkerSet watch mapper

### DIFF
--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -227,15 +227,21 @@ func (r *LeaderWorkerSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Watches(&appsv1.StatefulSet{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					{NamespacedName: types.NamespacedName{
-						Name:      a.GetLabels()[leaderworkerset.SetNameLabelKey],
-						Namespace: a.GetNamespace(),
-					}},
-				}
-			})).
+			handler.EnqueueRequestsFromMapFunc(enqueueLWSRequests)).
 		Complete(r)
+}
+
+func enqueueLWSRequests(ctx context.Context, a client.Object) []reconcile.Request {
+	name := a.GetLabels()[leaderworkerset.SetNameLabelKey]
+	if name == "" {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: a.GetNamespace(),
+		}},
+	}
 }
 
 func SetupIndexes(indexer client.FieldIndexer) error {

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -38,6 +39,7 @@ import (
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
 	"sigs.k8s.io/lws/test/wrappers"
 )
@@ -1198,6 +1200,67 @@ func TestGetUpdatedRevision(t *testing.T) {
 			gotUpdate := updatedRevision != nil
 			if gotUpdate != tc.expectUpdate {
 				t.Errorf("expected update=%t, got update=%t", tc.expectUpdate, gotUpdate)
+			}
+		})
+	}
+}
+
+func TestEnqueueLWSRequests(t *testing.T) {
+	tests := []struct {
+		name        string
+		statefulSet *appsv1.StatefulSet
+		want        []reconcile.Request
+	}{
+		{
+			name: "unrelated statefulset without lws label",
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-sts",
+					Namespace: "default",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "statefulset with empty lws label",
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-label-sts",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.SetNameLabelKey: "",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "lws-managed statefulset with valid lws label",
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lws-sts",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.SetNameLabelKey: "my-lws",
+					},
+				},
+			},
+			want: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      "my-lws",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := enqueueLWSRequests(context.Background(), tc.statefulSet)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected reconcile requests (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #955

What happened:
LeaderWorkerSetReconciler setup mapped all StatefulSets unconditionally to a reconcile request, returning a request with Name: "" when the leaderworkerset.sigs.k8s.io/name label was absent.

Fix:
Restored missing label check in a named mapper function enqueueLWSRequests to return nil for StatefulSets without the LWS label, and added unit test TestEnqueueLWSRequests.