### PR TITLE
docs(site): complete DisaggregatedSet website navigation and accuracy

### DIFF
--- a/site/content/en/docs/adoption/_index.md
+++ b/site/content/en/docs/adoption/_index.md
@@ -48,6 +48,13 @@ OptimizationJobs.
 
 [**llm-d**](https://github.com/llm-d/llm-d): llm-d is a Kubernetes-native, high-performance distributed LLM inference framework. It integrates open technologies such as vLLM for model serving and [Gateway API Inference extension (GIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) for request scheduling and load balancing, and uses LeaderWorkerSet for scalable multi-node deployments. Key features include P/D Disaggregated serving and prefix caching.
 
+{{% alert title="Tip" color="info" %}}
+For first-party multi-role (prefill/decode) orchestration on Kubernetes, see the
+[DisaggregatedSet concepts](/docs/concepts/disaggregatedset/),
+[installation notes](/docs/installation/#disaggregatedset), and
+[examples](/docs/examples/disaggregatedset/).
+{{% /alert %}}
+
 [**llmaz**](https://github.com/InftyAI/llmaz): llmaz, serving as an easy to use and advanced inference platform, uses LeaderWorkerSet as the underlying workload to support both single-host and multi-host inference scenarios.
 
 [**NVIDIA Dynamo**](https://github.com/ai-dynamo/dynamo): NVIDIA Dynamo is a high-throughput low-latency inference framework designed for serving generative AI and reasoning models in multi-node distributed environments especially the disaggregated prefill & decode inference. It uses LeaderWorkerSet to support multi-node deployment on Kubernetes.

--- a/site/content/en/docs/concepts/disaggregatedset/_index.md
+++ b/site/content/en/docs/concepts/disaggregatedset/_index.md
@@ -21,6 +21,8 @@ DisaggregatedSet was introduced in
 [KEP-766](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet) to address
 these multi-role, multi-resource serving patterns with a single, declarative Kubernetes resource.
 
+![DisaggregatedSet concept](/images/ds-concept.svg)
+
 ## Relationship to LeaderWorkerSet
 
 DisaggregatedSet does **not** replace LeaderWorkerSet — it **orchestrates multiple LeaderWorkerSets**.
@@ -34,17 +36,25 @@ in the same namespace. This means:
 | Use case | Uniform inference or training | Disaggregated prefill/decode/encode serving |
 | CRD version | `leaderworkerset.x-k8s.io/v1` | `disaggregatedset.x-k8s.io/v1` |
 | Controller namespace | `lws-system` | `lws-system` |
-| Dependency | None | None (bundled in LWS) |
+| Dependency | None | None (bundled in LWS from v0.9.0) |
+
+Child LeaderWorkerSets use a **slice index** and a **revision hash** in their names:
 
 ```
-DisaggregatedSet
-├── roles[0]: prefill  →  creates LeaderWorkerSet "disaggdeployment-xxx-prefill"
-├── roles[1]: decode   →  creates LeaderWorkerSet "disaggdeployment-xxx-decode"
-└── roles[2]: encode   →  creates LeaderWorkerSet "disaggdeployment-xxx-encode"
+DisaggregatedSet "my-inference"
+├── roles[0]: prefill  →  LeaderWorkerSet "my-inference-0-<rev>-prefill"
+├── roles[1]: decode   →  LeaderWorkerSet "my-inference-0-<rev>-decode"
+└── roles[2]: encode   →  LeaderWorkerSet "my-inference-0-<rev>-encode"
 ```
 
-Each child LWS inherits all standard LWS capabilities: rolling updates, subgroup policies,
-exclusive placement, volume claim templates, and health monitoring.
+Naming format: `<DisaggregatedSet-name>-<slice>-<revision-hash>-<role-name>`.
+The revision hash is dynamic — always select child resources with labels
+(`disaggregatedset.x-k8s.io/name`, `disaggregatedset.x-k8s.io/role`,
+`disaggregatedset.x-k8s.io/slice`) rather than hardcoding names.
+
+Each child LWS inherits standard LWS capabilities such as subgroup policies,
+exclusive placement, volume claim templates, and health monitoring. Rollout
+strategy for the set is owned by the DisaggregatedSet controller (see below).
 
 ## Roles in DisaggregatedSet
 
@@ -53,13 +63,18 @@ A `DisaggregatedSet` spec contains a `roles` list. Each role defines:
 | Field | Description |
 |---|---|
 | `name` | Unique name for this role (e.g., `prefill`, `decode`) |
-| `replicas` | Number of LWS replicas (pod groups) for this role |
+| `replicas` | Number of LWS replicas (pod groups) for this role (per slice) |
 | `rolloutStrategy` | Rolling update config for this role (DisaggregatedSet coordinates rollouts across roles; `partition`-based rollout is not supported) |
 | `leaderWorkerTemplate` | Pod template defining leader + worker containers |
+| `scaling` | Optional external scaling mode (for example HPA via `DisaggregatedSetRoleScaler`) |
 
 DisaggregatedSet coordinates lifecycle and rollouts across roles. Each role's replica count,
 rollout strategy, and pod template can be configured independently, while the controller manages
 them as a single cohesive unit.
+
+Optional top-level fields such as `slices` (replicate the full role topology) and
+`placementPolicy` (topology co-location / spread) are covered in the
+[examples and operations guide](/docs/examples/disaggregatedset/).
 
 ## When to Use DisaggregatedSet vs Plain LWS
 
@@ -87,4 +102,6 @@ Use **DisaggregatedSet** when:
 - [KEP-766: DisaggregatedSet design document](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet)
 - [Installation guide](/docs/installation/#disaggregatedset)
 - [API Reference](/docs/reference/disaggregatedset.v1/)
-- [Examples](/docs/examples/)
+- [Labels and annotations](/docs/reference/labels-annotations-and-environment-variables/)
+- [Examples and operations](/docs/examples/disaggregatedset/)
+- In-repo samples: [`config/samples/disaggregatedset_v1_disaggregatedset.yaml`](https://github.com/kubernetes-sigs/lws/blob/main/config/samples/disaggregatedset_v1_disaggregatedset.yaml), [`config/samples/disaggregatedset_v1_3role.yaml`](https://github.com/kubernetes-sigs/lws/blob/main/config/samples/disaggregatedset_v1_3role.yaml)

--- a/site/content/en/docs/examples/_index.md
+++ b/site/content/en/docs/examples/_index.md
@@ -5,3 +5,8 @@ weight: 6
 description: >
   This section contains examples of using LWS with or without specific inference runtime.
 ---
+
+Use the pages in this section for runtime-specific LeaderWorkerSet deployments
+(vLLM, SGLang, TensorRT-LLM, and others). For multi-role disaggregated inference
+(prefill/decode and related patterns), start with the
+[DisaggregatedSet examples](disaggregatedset/).

--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -47,6 +47,13 @@ Key features of DisaggregatedSet include:
 - **Automatic Service Orchestration:** Automatically creates and manages headless services for each role to facilitate discovery and revision-aware routing.
 - **Advanced Failure Handling:** Coordinated drain and restart policies across all roles in the disaggregated set.
 
+Learn more:
+- [Concepts: DisaggregatedSet](../concepts/disaggregatedset/) — how it relates to LeaderWorkerSet and when to use it
+- [Installation](../installation/#disaggregatedset) — DisaggregatedSet ships with the LWS operator (v0.9.0+)
+- [Examples](../examples/disaggregatedset/) — minimal multi-role demos and day-2 operations
+- [API reference](../reference/disaggregatedset.v1/) — `disaggregatedset.x-k8s.io/v1` field reference
+- [KEP-766](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet) — design document
+
 ## Community, Discussion, Contribution, and Support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).

--- a/site/content/en/docs/reference/_index.md
+++ b/site/content/en/docs/reference/_index.md
@@ -5,3 +5,10 @@ weight: 5
 description: >
   This section contains the LWS reference information.
 ---
+
+API and configuration reference for LeaderWorkerSet and DisaggregatedSet:
+
+- [LeaderWorkerSet v1](leaderworkerset.v1/)
+- [DisaggregatedSet v1](disaggregatedset.v1/)
+- [Labels, annotations, and environment variables](labels-annotations-and-environment-variables/)
+

--- a/site/content/en/docs/reference/labels-annotations-and-environment-variables.md
+++ b/site/content/en/docs/reference/labels-annotations-and-environment-variables.md
@@ -18,6 +18,7 @@ description:  A reference for all labels, annotations, and environment variables
 | `leaderworkerset.sigs.k8s.io/subgroup-key`           | Pods that are part of the same subgroup will have the same unique hash value.     | 92904e74...801                 | Pod (only if SubGroup is set)  |
 | `disaggregatedset.x-k8s.io/name`                     | The name of the DisaggregatedSet object to which these resources belong.          | disaggregatedset-sample        | LeaderWorkerSet, Service, Pod  |
 | `disaggregatedset.x-k8s.io/role`                     | The DisaggregatedSet role for the resource.                                       | prefill                        | LeaderWorkerSet, Service, Pod  |
+| `disaggregatedset.x-k8s.io/slice`                    | Slice index for the resource within the DisaggregatedSet.                         | 0                              | LeaderWorkerSet, Service, Pod  |
 | `disaggregatedset.x-k8s.io/revision`                 | Revision hash used to track a DisaggregatedSet rollout.                           | a1b2c3d4                       | LeaderWorkerSet, Service, Pod  |
 
 # Annotations


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

Issue #806 asked for first-party **DisaggregatedSet** documentation on the project website (`site/content/en/docs/`), covering how it relates to LeaderWorkerSet, how to install the operator, and where to find examples and API details.

Core pages already landed via #811 / #911 / #951, but #806 stayed open and several discoverability/accuracy gaps remained:

| Area | Change |
|---|---|
| Overview | "Learn more" links to concepts, installation, examples, API reference, and KEP-766 |
| Concepts | Slice-aware child LWS naming (`<ds>-<slice>-<rev>-<role>`), concept diagram, role fields, links to samples and operations docs |
| Labels reference | Document `disaggregatedset.x-k8s.io/slice` |
| Examples / Reference indexes | Point users at DisaggregatedSet pages from section landings |
| Adoption | Tip after llm-d (P/D disaggregated serving) linking to DisaggregatedSet docs |

Docs-only; design reference remains [KEP-766](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet).

#### Which issue(s) this PR fixes

Fixes #806

#### Special notes for your reviewer

- DCO sign-off included (`Signed-off-by`).
- Intentionally does not re-add pages that already exist from #811; this closes the remaining website navigation/accuracy work for the issue.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI disclosure

This change was developed with AI assistance (Grok). I reviewed the full diff for accuracy against current DisaggregatedSet behavior (slice-aware naming, labels, install bundling in v0.9.0+).