### PR TITLE
Rebuild worker StatefulSet entirely from the leader's revision

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -413,16 +413,19 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 
 	podTemplateApplyConfiguration.WithLabels(labelMap)
 	podAnnotations := make(map[string]string)
-	podAnnotations[leaderworkerset.SizeAnnotationKey] = strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size))
+	// Spec-derived values must come from the revision-applied spec (currentLws), not the
+	// live one: when an old-revision group is rebuilt mid rolling update, mixing the old
+	// pod template with live size/subGroupPolicy/networkConfig breaks the group.
+	podAnnotations[leaderworkerset.SizeAnnotationKey] = strconv.Itoa(int(*currentLws.Spec.LeaderWorkerTemplate.Size))
 	podAnnotations[leaderworkerset.LeaderPodNameAnnotationKey] = leaderPod.Name
 	if lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "" {
 		podAnnotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
 	}
-	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
-		if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type != nil {
-			podAnnotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey] = string(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type)
+	if currentLws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
+		if currentLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type != nil {
+			podAnnotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey] = string(*currentLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type)
 		}
-		podAnnotations[leaderworkerset.SubGroupSizeAnnotationKey] = strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize))
+		podAnnotations[leaderworkerset.SubGroupSizeAnnotationKey] = strconv.Itoa(int(*currentLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize))
 		if lws.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey] != "" {
 			podAnnotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]
 		}
@@ -430,7 +433,7 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	acceleratorutils.AddTPUAnnotations(leaderPod, podAnnotations)
 	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
 	serviceName := leaderPod.Name
-	if lws.Spec.NetworkConfig == nil || *lws.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainShared {
+	if currentLws.Spec.NetworkConfig == nil || *currentLws.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainShared {
 		serviceName = lws.Name
 	}
 	// construct statefulset apply configuration
@@ -438,7 +441,7 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	statefulSetConfig := appsapplyv1.StatefulSet(leaderPod.Name, leaderPod.Namespace).
 		WithSpec(appsapplyv1.StatefulSetSpec().
 			WithServiceName(serviceName).
-			WithReplicas(*lws.Spec.LeaderWorkerTemplate.Size - 1).
+			WithReplicas(*currentLws.Spec.LeaderWorkerTemplate.Size - 1).
 			WithPodManagementPolicy(appsv1.ParallelPodManagement).
 			WithTemplate(&podTemplateApplyConfiguration).
 			WithOrdinals(appsapplyv1.StatefulSetOrdinals().WithStart(1)).
@@ -447,15 +450,15 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		WithLabels(statefulSetLabels).
 		WithAnnotations(lws.Annotations)
 
-	pvcApplyConfiguration := controllerutils.GetPVCApplyConfiguration(&lws)
+	pvcApplyConfiguration := controllerutils.GetPVCApplyConfiguration(currentLws)
 	if len(pvcApplyConfiguration) > 0 {
 		statefulSetConfig.Spec.WithVolumeClaimTemplates(pvcApplyConfiguration...)
 	}
 
-	if lws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy != nil {
+	if currentLws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy != nil {
 		pvcRetentionPolicy := &appsapplyv1.StatefulSetPersistentVolumeClaimRetentionPolicyApplyConfiguration{
-			WhenDeleted: &lws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy.WhenDeleted,
-			WhenScaled:  &lws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy.WhenScaled,
+			WhenDeleted: &currentLws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy.WhenDeleted,
+			WhenScaled:  &currentLws.Spec.LeaderWorkerTemplate.PersistentVolumeClaimRetentionPolicy.WhenScaled,
 		}
 		statefulSetConfig.Spec.WithPersistentVolumeClaimRetentionPolicy(pvcRetentionPolicy)
 	}

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -54,11 +54,9 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 		pod                   *corev1.Pod
 		lws                   *leaderworkerset.LeaderWorkerSet
 		wantStatefulSetConfig *appsapplyv1.StatefulSetApplyConfiguration
-		revision              *appsv1.ControllerRevision
 	}{
 		{
-			name:     "1 replica, size 1, exclusive placement disabled",
-			revision: updateRevision,
+			name: "1 replica, size 1, exclusive placement disabled",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample",
@@ -131,8 +129,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:     "1 replica, size 2, exclusive placement enabled",
-			revision: updateRevision,
+			name: "1 replica, size 2, exclusive placement enabled",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample",
@@ -211,8 +208,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:     "1 replica, size 2, subgroupsize 2, exclusive placement enabled",
-			revision: updateRevision,
+			name: "1 replica, size 2, subgroupsize 2, exclusive placement enabled",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample",
@@ -293,8 +289,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name:     "1 replica, size 1, with volumeClaimTemplates and PersistentVolumeClaimRetentionPolicy configured",
-			revision: updateRevision,
+			name: "1 replica, size 1, with volumeClaimTemplates and PersistentVolumeClaimRetentionPolicy configured",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-sample",
@@ -420,7 +415,18 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			statefulSetConfig, err := constructWorkerStatefulSetApplyConfiguration(*tc.pod, *tc.lws, tc.revision)
+			// Build the revision from this test case's lws, mirroring production where the
+			// revision snapshots the same spec: revision-covered fields (size, subGroupPolicy,
+			// networkConfig, volume claims) are read from the revision by the function under test.
+			revision, err := revisionutils.NewRevision(context.TODO(), client, tc.lws, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			revisionKey := revisionutils.GetRevisionKey(revision)
+			tc.pod.Labels[leaderworkerset.RevisionKey] = revisionKey
+			tc.wantStatefulSetConfig.Labels[leaderworkerset.RevisionKey] = revisionKey
+			tc.wantStatefulSetConfig.Spec.Template.Labels[leaderworkerset.RevisionKey] = revisionKey
+			statefulSetConfig, err := constructWorkerStatefulSetApplyConfiguration(*tc.pod, *tc.lws, revision)
 			if err != nil {
 				t.Errorf("failed with error %s", err.Error())
 			}

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -1961,6 +1961,88 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 				},
 			},
 		}),
+		ginkgo.Entry("Not updated worker gets recreated with old size if restarted during update that changes size", &testCase{
+			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).Size(4)
+			},
+			updates: []*update{
+				{
+					// Set lws to available condition.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetSuperPodToReady(ctx, k8sClient, lws, 4)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
+						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testing.ExpectRevisions(ctx, k8sClient, lws, 1)
+					},
+				},
+				{
+					// Trigger a rolling update that changes both the worker template and the size (4 -> 2).
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						gomega.Eventually(func() error {
+							var leaderworkerset leaderworkerset.LeaderWorkerSet
+							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
+								return err
+							}
+							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Name = "new-worker-name"
+							leaderworkerset.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](2)
+							return k8sClient.Update(ctx, &leaderworkerset)
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
+						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
+						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
+					},
+				},
+				{
+					// Rolling update 1 replica so the partition keeps the 0-index group on the old revision.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-3", lws)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
+						testing.ExpectUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-3")
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						testing.ExpectRevisions(ctx, k8sClient, lws, 2)
+					},
+				},
+				{
+					// Delete the not-yet-updated 0-index leader pod and re-create it from the old
+					// revision, like the statefulset controller would while the pod is still below
+					// the partition.
+					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+						testing.DeleteLeaderPod(ctx, k8sClient, lws, 0, 1)
+						var leaderSts appsv1.StatefulSet
+						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderSts)).To(gomega.Succeed())
+						testing.CreateLeaderPodsFromRevisionNumber(ctx, leaderSts, k8sClient, lws, 0, 1, 1)
+					},
+					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
+						// The worker statefulset must be recreated entirely from the old revision:
+						// not only the old pod template, but also the old size, i.e. 4-1=3 worker
+						// replicas and a size annotation of 4. Mixing the old template with the
+						// live size breaks the still-not-updated group.
+						testing.ExpectNotUpdatedWorkerStatefulSet(ctx, k8sClient, lws, lws.Name+"-0")
+						gomega.Eventually(func() error {
+							var sts appsv1.StatefulSet
+							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name + "-0", Namespace: lws.Namespace}, &sts); err != nil {
+								return err
+							}
+							gotSize := sts.Spec.Template.Annotations[leaderworkerset.SizeAnnotationKey]
+							if *sts.Spec.Replicas != 3 || gotSize != "4" {
+								return fmt.Errorf("worker statefulset %s should be rebuilt entirely from the old revision: want replicas=3 (old size 4 - 1) and size annotation=4, got replicas=%d and size annotation=%s", sts.Name, *sts.Spec.Replicas, gotSize)
+							}
+							return nil
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+					},
+				},
+			},
+		}),
 		ginkgo.Entry("leader with RecreateGroupOnPodRestart only gets restarted once during rolling update", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
 				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a not-yet-updated group's leader pod is recreated mid rolling update (node maintenance, spot reclaim, or a group restart under the default `RecreateGroupOnPodRestart`), `PodReconciler` rebuilds the worker StatefulSet from the leader's ControllerRevision. Today only the **pod template** is taken from the revision (#280's fix); everything else — the size annotation, `replicas`, `subGroupPolicy`, `networkConfig`/serviceName, volume claim templates and the PVC retention policy — is read from the **live** spec.

A rolling update that changes any of those fields therefore corrupts the rebuilt old-revision group. Example (pinned by the new integration test): update changes size 4→2 while group 0 is still below the partition; its leader restarts; the rebuilt worker StatefulSet gets `replicas=1` and size annotation `2`, while its old-revision pods expect a 4-pod group — `LWS_GROUP_SIZE` and TPU hostname lists disagree and distributed init breaks. A `subdomainPolicy` change mid-rollout similarly points the rebuilt workers at a service the old-revision leader doesn't have.

The fix reads all revision-covered fields from the revision-applied spec (`currentLws`) in `constructWorkerStatefulSetApplyConfiguration`. Metadata (name, labels, annotations) is intentionally still read live, since it is not part of the revision snapshot.

#### Which issue(s) this PR fixes:

None filed — this is the residual of the scenario behind #280, whose fix covered only the pod template. Happy to open an issue if preferred.

#### Special notes for your reviewer:

- The new integration test follows the adjacent #280 entry's exact pattern; without the controller change it fails with: `worker statefulset test-sample-0 should be rebuilt entirely from the old revision: want replicas=3 (old size 4 - 1) and size annotation=4, got replicas=1 and size annotation=2`.
- The unit test now builds each case's revision from that case's own lws (mirroring production, where the revision snapshots the same spec); previously a shared revision from an unrelated basic lws was used, which only worked because the code read the live spec.
- Two related reads happen at Reconcile level **before** the revision is fetched (the `Size == 1` short-circuit and the per-replica headless service creation) and are unchanged here; happy to address them in a follow-up if you'd like.
- Full integration suite (53 specs) and all unit tests pass.
- AI tooling (Claude Code) was used to assist with this contribution; the mechanism, repro and fix were verified manually.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a not-yet-updated group's worker StatefulSet, when rebuilt after a leader pod restart during a rolling update, mixed the old revision's pod template with the live size, subGroupPolicy, networkConfig and volume claim configuration, breaking the group (e.g. wrong worker count after a size change).
```
