### PR TITLE
Run make manifest

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -136,18 +136,6 @@ rules:
 - apiGroups:
   - leaderworkerset.x-k8s.io
   resources:
-  - leaderworkersets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - leaderworkerset.x-k8s.io
-  resources:
   - leaderworkersets/finalizers
   verbs:
   - update


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it
It looks like running `make manifest` generates a diff which basically removes the duplicated rbac rule. This PR fixes it.

#### Does this PR introduce a user-facing change?
```release-note
None
```
