### PR TITLE
Support custom namespace for DisaggregatedSet e2e tests

### DIFF
--- a/test/e2e/disaggregatedset/e2e_suite_test.go
+++ b/test/e2e/disaggregatedset/e2e_suite_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ import (
 	utils "sigs.k8s.io/lws/test/testutils/disaggregatedset"
 )
 
+var lwsNamespace string
+
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting disaggregatedset e2e test suite\n")
@@ -35,10 +38,15 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	lwsNamespace = "lws-system"
+	if ns := os.Getenv("LWS_NAMESPACE"); ns != "" {
+		lwsNamespace = ns
+	}
+
 	By("verifying LWS controller is ready")
 	Eventually(func() error {
 		cmd := exec.Command("kubectl", "get", "deployment", "lws-controller-manager",
-			"-n", "lws-system", "-o", "jsonpath={.status.availableReplicas}")
+			"-n", lwsNamespace, "-o", "jsonpath={.status.availableReplicas}")
 		output, err := utils.Run(cmd)
 		if err != nil {
 			return fmt.Errorf("LWS controller not found: %w", err)

--- a/test/e2e/disaggregatedset/e2e_test.go
+++ b/test/e2e/disaggregatedset/e2e_test.go
@@ -32,9 +32,6 @@ import (
 	"sigs.k8s.io/lws/test/testutils/disaggregatedset/kubectl"
 )
 
-// Operator namespace where the controller is deployed
-const namespace = "lws-system"
-
 var controllerPodName string
 
 // applyYAML applies a YAML string using kubectl
@@ -50,7 +47,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 		if specReport.Failed() {
 			By("Fetching controller manager pod logs")
 			if controllerPodName != "" {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", lwsNamespace)
 				controllerLogs, err := utils.Run(cmd)
 				if err == nil {
 					_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", controllerLogs)
@@ -73,7 +70,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 		It("should have the controller-manager running", func() {
 			By("checking if controller-manager is already deployed")
 			cmd := exec.Command("kubectl", "get", "deployment",
-				"lws-controller-manager", "-n", namespace, "-o", "name")
+				"lws-controller-manager", "-n", lwsNamespace, "-o", "name")
 			output, err := utils.Run(cmd)
 			if err == nil && strings.Contains(output, "deployment") {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Controller-manager already deployed, skipping deployment\n")
@@ -86,7 +83,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 						"{{ if not .metadata.deletionTimestamp }}"+
 						"{{ .metadata.name }}"+
 						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
+					"-n", lwsNamespace,
 				)
 
 				podOutput, err := utils.Run(cmd)
@@ -97,7 +94,7 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 				g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
 
 				cmd = exec.Command("kubectl", "get", "pods", controllerPodName,
-					"-o", "jsonpath={.status.phase}", "-n", namespace)
+					"-o", "jsonpath={.status.phase}", "-n", lwsNamespace)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(output).To(Equal("Running"))

--- a/test/testutils/disaggregatedset/utils.go
+++ b/test/testutils/disaggregatedset/utils.go
@@ -116,10 +116,15 @@ func InstallLWS() error {
 		return fmt.Errorf("failed to install LWS: %w", err)
 	}
 
+	lwsNamespace := "lws-system"
+	if ns := os.LookupEnv("LWS_NAMESPACE"); ns != "" {
+		lwsNamespace = ns
+	}
+
 	// Wait for LWS controller deployment to be ready
 	cmd = exec.Command("kubectl", "wait", "deployment/lws-controller-manager",
 		"--for", "condition=Available",
-		"--namespace", "lws-system",
+		"--namespace", lwsNamespace,
 		"--timeout", "5m",
 	)
 	if _, err := Run(cmd); err != nil {
@@ -147,9 +152,14 @@ func IsLWSInstalled() bool {
 
 // WaitForLWSReady waits for LWS webhook to be available by creating a test LWS.
 func WaitForLWSReady() error {
+	lwsNamespace := "lws-system"
+	if ns := os.LookupEnv("LWS_NAMESPACE"); ns != "" {
+		lwsNamespace = ns
+	}
+
 	// Check if LWS controller is ready
 	cmd := exec.Command("kubectl", "get", "deployment", "lws-controller-manager",
-		"-n", "lws-system", "-o", "jsonpath={.status.availableReplicas}")
+		"-n", lwsNamespace, "-o", "jsonpath={.status.availableReplicas}")
 	output, err := Run(cmd)
 	if err != nil {
 		return fmt.Errorf("LWS controller not found: %w", err)

--- a/test/testutils/disaggregatedset/utils.go
+++ b/test/testutils/disaggregatedset/utils.go
@@ -117,7 +117,7 @@ func InstallLWS() error {
 	}
 
 	lwsNamespace := "lws-system"
-	if ns := os.LookupEnv("LWS_NAMESPACE"); ns != "" {
+	if ns := os.Getenv("LWS_NAMESPACE"); ns != "" {
 		lwsNamespace = ns
 	}
 
@@ -153,7 +153,7 @@ func IsLWSInstalled() bool {
 // WaitForLWSReady waits for LWS webhook to be available by creating a test LWS.
 func WaitForLWSReady() error {
 	lwsNamespace := "lws-system"
-	if ns := os.LookupEnv("LWS_NAMESPACE"); ns != "" {
+	if ns := os.Getenv("LWS_NAMESPACE"); ns != "" {
 		lwsNamespace = ns
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it
This PR removes hardcoded namespace references from the DisaggregatedSet e2e tests and makes them respect the `LWS_NAMESPACE` environment variable, following the same pattern used in the main e2e test suite.

  **Changes:**
  - **test/e2e/disaggregatedset/e2e_suite_test.go**: Added `lwsNamespace` variable that defaults to `"lws-system"` but can be overridden via the `LWS_NAMESPACE` environment variable
  - **test/e2e/disaggregatedset/e2e_test.go**: Replaced hardcoded `namespace` constant with the  `lwsNamespace` 
  - **test/testutils/disaggregatedset/utils.go**: Updated `InstallLWS()` and `WaitForLWSReady()` functions to respect the `LWS_NAMESPACE` environment variable

  **Why this is needed:**
  - Enables running tests against LWS controllers deployed in custom namespaces (not just `lws-system`)
  - Improves consistency with the main e2e test suite which already supports this pattern
  - Makes the test suite more flexible for different deployment scenarios

#### Which issue(s) this PR fixes
NONE

#### Special notes for your reviewer
 This aligns the DisaggregatedSet e2e tests with the pattern already established in the main e2e suite 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
