### PR TITLE
Fix HPA e2e tests with non-default kubeconfig namespace

### DIFF
--- a/test/e2e/disaggregatedset/hpa_test.go
+++ b/test/e2e/disaggregatedset/hpa_test.go
@@ -60,12 +60,12 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", Ordered, func() {
 
 		By("waiting for the controller to auto-create the scaler")
 		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-o", "name"))
+			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
 			g.Expect(err).NotTo(HaveOccurred())
 		}).Should(Succeed())
 
 		By("verifying the scaler carries the parent DS as controller ownerRef")
-		out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName,
+		out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
 			"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.TrimSpace(out)).To(Equal(dsName))
@@ -98,13 +98,13 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", Ordered, func() {
 
 		By("waiting for the scaler to exist")
 		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-o", "name"))
+			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
 			g.Expect(err).NotTo(HaveOccurred())
 		}).Should(Succeed())
 
 		By("writing spec.replicas=3 via the /scale subresource (same call HPA/KEDA use)")
 		_, err := utils.Run(exec.Command("kubectl", "scale",
-			"disaggregatedsetrolescaler/"+scalerName, "--replicas=3"))
+			"disaggregatedsetrolescaler/"+scalerName, "-n", "default", "--replicas=3"))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the LWS for prefill scales to 3")
@@ -123,17 +123,17 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", Ordered, func() {
 
 		By("waiting for the scaler to exist")
 		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-o", "name"))
+			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
 			g.Expect(err).NotTo(HaveOccurred())
 		}).Should(Succeed())
 
 		By("deleting the DisaggregatedSet")
-		_, err := kubectl.Delete("disaggregatedset", dsName).Run()
+		_, err := kubectl.Delete("disaggregatedset", dsName).Namespace("default").Run()
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the scaler is garbage-collected")
 		Eventually(func(g Gomega) {
-			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName,
+			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
 				"--ignore-not-found", "-o", "name"))
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(strings.TrimSpace(out)).To(BeEmpty())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it

This PR fixes HPA e2e tests that fail on clusters where the kubeconfig's default context namespace is not "default" 

**Problem**: The hpa_test.go kubectl commands (kubectl get dsrs, kubectl scale, kubectl delete) don't specify -n default, so they fall back to the kubeconfig's current context namespace causing tests to fail with namespace  not found error.

```
DisaggregatedSet HPA External Scaling auto-creates a scaler and GET /scale succeeds on it before any write
/tmp/tmp.icFoicRfur/test/e2e/disaggregatedset/hpa_test.go:53
  STEP: creating a DisaggregatedSet with an External prefill role @ 08/11/26 12:12:30.902
  running: "kubectl apply -f -"
  STEP: waiting for the controller to auto-create the scaler @ 08/11/26 12:12:32.596
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  running: "kubectl get dsrs test-hpa-prefill -o name"
  [FAILED] Timed out after 120.003s.
  The function passed to Eventually failed at /tmp/tmp.icFoicRfur/test/e2e/disaggregatedset/hpa_test.go:64 with:
  Unexpected error:
      <*fmt.wrapError | 0x307743010a20>: 
      "kubectl get dsrs test-hpa-prefill -o name" failed with error "Error from server (NotFound): disaggregatedsetrolescalers.disaggregatedset.x-k8s.io \"test-hpa-prefill\" not found\n": exit status 1
      {
          msg: "\"kubectl get dsrs test-hpa-prefill -o name\" failed with error \"Error from server (NotFound): disaggregatedsetrolescalers.disaggregatedset.x-k8s.io \\\"test-hpa-prefill\\\" not found\\n\": exit status 1",
          err: <*exec.ExitError | 0x307743010a00>{
              ProcessState: {
                  pid: 1472057,
                  status: 256,
                  rusage: {
                      Utime: {Sec: 0, Usec: 65293},
                      Stime: {Sec: 0, Usec: 24183},
                      Maxrss: 95588,
                      Ixrss: 0,
                      Idrss: 0,
                      Isrss: 0,
                      Minflt: 8099,
                      Majflt: 0,
                      Nswap: 0,
                      Inblock: 0,
                      Oublock: 0,
                      Msgsnd: 0,
                      Msgrcv: 0,
                      Nsignals: 0,
                      Nvcsw: 660,
                      Nivcsw: 5,
                  },
              },
              Stderr: nil,
          },
      }
  occurred
  In [It] at: /tmp/tmp.icFoicRfur/test/e2e/disaggregatedset/hpa_test.go:65 
```

**Solution**: Add explicit -n "default" to all bare kubectl commands and .Namespace("default") to the delete builder in hpa_test.go, consistent with how queries.go already hardcodes defaultNS = "default" for all
  workload queries.

#### Which issue(s) this PR fixes
Fixes #
 Fixes HPA test failures  where the kubeconfig default namespace is not "default"

#### Special notes for your reviewer
 
-  hpa_test.go is changed to check the workloads on default namespace, not contextual default namespace


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
