### PR TITLE
Fix: defer cleanup of drained LWS objects to preserve drain ordering

### DIFF
--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -216,10 +216,6 @@ func (r *DisaggregatedSetReconciler) reconcileSlice(
 	roleNames []string,
 	scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler,
 ) (ctrl.Result, error) {
-	if err := r.cleanupDrainedLWS(ctx, disaggregatedSet, slice, revision); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	oldRevisions, _, err := executor.LWSManager.GetRevisionRolesList(ctx, disaggregatedSet.Namespace, disaggregatedSet.Name, slice, revision)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -251,6 +247,12 @@ func (r *DisaggregatedSetReconciler) reconcileSlice(
 
 	if err := r.ServiceManager.ReconcileServices(ctx, disaggregatedSet, slice, revisionRoles, revision); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile services: %w", err)
+	}
+
+	// Clean up fully-drained old revisions after rolling update and service reconciliation.
+	// This must happen after drain ordering logic to preserve revision history during the rollout.
+	if err := r.cleanupDrainedLWS(ctx, disaggregatedSet, slice, revision); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return result, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it

**Problem**: During mid-rollout scenarios with multiple revisions (e.g., A→B→C), the drain ordering becomes incorrect. When revision B (intermediate) is completely drained to 0 replicas and revision C is applied as the new target, the controller fails to drain B before A, violating the newest-first drain ordering guarantee.

**Root Cause**: `cleanupDrainedLWS()` was called at the START of `reconcileSlice()`, deleting fully-drained revisions (those at 0 replicas) BEFORE we even fetched the list of old revisions for drain ordering. This caused intermediate revisions to disappear from the tracking list before the sorting logic could process them.

**Solution**: Defer the cleanup of drained LWS objects to AFTER the rolling update and service reconciliation logic completes. This ensures that revision history remains intact during the drain ordering phase, allowing the controller to correctly sort revisions by creation timestamp and drain in newest-first order.


#### Which issue(s) this PR fixes
Fixes the drain ordering bug in DisaggregatedSet multi-version rollouts
Fixes #
The fix is validated by the e2e test: `should drain B (broken intermediate) before A (stable original)`

**Scenario**:
- Revision A (stable) with 6 replicas per role
- Revision B (bad intermediate) starts rolling out
- Revision C (fix) applied mid-rollout while B is at ~50% completion
- Expected: B drains to 0 before A starts draining
- Result:  PASS

#### Special notes for your reviewer

This is a critical fix for production rollouts. Without this fix, drain ordering is unpredictable in multi-version scenarios, potentially causing suboptimal resource utilization during complex updates.

The change is minimal and surgical - only moving `cleanupDrainedLWS()` from the beginning ion phase. No algorithm changes or behavioral modifications to the core drain logic.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
