### PR TITLE
Drop unneeded client cert from metrics ServiceMonitor tlsConfig

### DIFF
--- a/charts/lws/templates/prometheus/monitor.yaml
+++ b/charts/lws/templates/prometheus/monitor.yaml
@@ -22,13 +22,6 @@ spec:
           secret:
             name: lws-metrics-server-cert
             key: ca.crt
-        cert:
-          secret:
-            name: lws-metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: lws-metrics-server-cert
-          key: tls.key
         {{- else }}
           insecureSkipVerify: true
         {{- end }}

--- a/config/components/prometheus/monitor_tls_patch.yaml
+++ b/config/components/prometheus/monitor_tls_patch.yaml
@@ -10,10 +10,3 @@
       secret:
         name: metrics-server-cert
         key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key

--- a/site/content/en/docs/manage/prometheus.md
+++ b/site/content/en/docs/manage/prometheus.md
@@ -63,13 +63,6 @@ metrics:
         secret:
           name: lws-metrics-server-cert
           key: ca.crt
-      cert:
-        secret:
-          name: lws-metrics-server-cert
-          key: tls.crt
-      keySecret:
-        name: lws-metrics-server-cert
-        key: tls.key
 ```
 
 The secrets must reference the cert manager generated secrets.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The metrics server doesn't do client cert auth — auth is TokenReview/SAR via `filters.WithAuthenticationAndAuthorization`, which the existing `bearerTokenFile` already covers. `BuildTLSOptions` in `pkg/config/tls.go` only sets `MinVersion`/`CipherSuites`; there's no `ClientAuth`/`ClientCAs` anywhere in the repo, so the server never requests a client cert.

Despite that, the rendered ServiceMonitor sets `cert`/`keySecret` in `tlsConfig`, in both the Helm chart and the kustomize `PROMETHEUS-WITH-CERTS` patch. This also breaks scraping through the OpenTelemetry Operator target allocator when TA mTLS isn't enabled: the TA only forwards real secret values over mTLS, and since `TLSConfig.Key` is a `config.Secret` in prometheus/common while `CA`/`Cert` are plain strings, the collector gets a literal `<secret>` for the key and the scrape job fails.

This drops `cert`/`keySecret` from both `charts/lws/templates/prometheus/monitor.yaml` and `config/components/prometheus/monitor_tls_patch.yaml`, and updates the matching example in the Helm Prometheus docs. `ca` and `serverName` stay — the server does present that cert, and TokenReview/SAR + bearer token still needs CA verification.

Verified with `helm template lws charts/lws --set enablePrometheus=true --set enableCertManager=true` and a standalone `kustomize build` with the TLS patch applied: both now render `tlsConfig` with only `serverName`/`insecureSkipVerify`/`ca`. `enableCertManager=false` is unaffected (`insecureSkipVerify: true`).

#### Which issue(s) this PR fixes

Fixes #974

#### Special notes for your reviewer

NONE

#### Does this PR introduce a user-facing change?

```release-note
Removed the unneeded client certificate (`cert`/`keySecret`) from the metrics ServiceMonitor's `tlsConfig` — the metrics server does not perform client cert auth, and the extra fields could break scraping through the OpenTelemetry target allocator.
```

<!-- oss-radar:idempotency=auto-20260811-191301.w2.kubernetes-sigs_lws.974 -->
