### PR TITLE
Add serviceMonitor.extraLabels to values and extend serviceMonitor template to use them

### DIFF
--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -130,6 +130,7 @@ The following table lists the configurable parameters of the LWS chart and their
 | `nameOverride`                             | nameOverride                                   | ``                                                  |
 | `fullnameOverride`                         | fullnameOverride                               | ``                                                  |
 | `enablePrometheus`                         | enable Prometheus                              | `false`                                             |
+| `serviceMonitor.extraLabels`               | Inject labels for prometheus selector rules    | `{}`                                             |
 | `enableCertManager`                        | enable CertManager                             | `false`                                             |
 | `enableDisaggregatedSet`                   | install DisaggregatedSet editor/viewer/admin ClusterRoles and validating webhook (the CRD, bundled controller, and its required RBAC rules are always installed) | `false` |
 | `imagePullSecrets`                         | Image pull secrets                             | `[]`                                                |

--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -130,7 +130,7 @@ The following table lists the configurable parameters of the LWS chart and their
 | `nameOverride`                             | nameOverride                                   | ``                                                  |
 | `fullnameOverride`                         | fullnameOverride                               | ``                                                  |
 | `enablePrometheus`                         | enable Prometheus                              | `false`                                             |
-| `serviceMonitor.extraLabels`               | Inject labels for prometheus selector rules    | `{}`                                             |
+| `serviceMonitor.extraLabels`               | Extra labels added to the ServiceMonitor (requires `enablePrometheus=true`) | `{}`                                                |
 | `enableCertManager`                        | enable CertManager                             | `false`                                             |
 | `enableDisaggregatedSet`                   | install DisaggregatedSet editor/viewer/admin ClusterRoles and validating webhook (the CRD, bundled controller, and its required RBAC rules are always installed) | `false` |
 | `imagePullSecrets`                         | Image pull secrets                             | `[]`                                                |

--- a/charts/lws/templates/prometheus/monitor.yaml
+++ b/charts/lws/templates/prometheus/monitor.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     control-plane: controller-manager
     {{- include "lws.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "lws.fullname" . }}-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/lws/templates/prometheus/monitor.yaml
+++ b/charts/lws/templates/prometheus/monitor.yaml
@@ -6,8 +6,10 @@ metadata:
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     control-plane: controller-manager
     {{- include "lws.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- with .Values.serviceMonitor }}
+    {{- with .extraLabels }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- end }}
   name: {{ include "lws.fullname" . }}-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}

--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -6,8 +6,8 @@ nameOverride: ""
 fullnameOverride: ""
 enablePrometheus: false
 serviceMonitor:
-  extraLabels:
-    release: my-prometheus-sm-selector
+  extraLabels: {}
+    # release: my-prometheus-sm-selector
 enableCertManager: false
 # enableDisaggregatedSet installs the DisaggregatedSet editor/viewer/admin
 # ClusterRoles and the validating webhook. The CRD (under crds/), the

--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -5,6 +5,9 @@
 nameOverride: ""
 fullnameOverride: ""
 enablePrometheus: false
+serviceMonitor:
+  extraLabels:
+    release: my-prometheus-sm-selector
 enableCertManager: false
 # enableDisaggregatedSet installs the DisaggregatedSet editor/viewer/admin
 # ClusterRoles and the validating webhook. The CRD (under crds/), the

--- a/charts/lws/values.yaml
+++ b/charts/lws/values.yaml
@@ -7,7 +7,9 @@ fullnameOverride: ""
 enablePrometheus: false
 serviceMonitor:
   extraLabels: {}
-    # release: my-prometheus-sm-selector
+  # Example override:
+  #   extraLabels:
+  #     release: my-prometheus-sm-selector
 enableCertManager: false
 # enableDisaggregatedSet installs the DisaggregatedSet editor/viewer/admin
 # ClusterRoles and the validating webhook. The CRD (under crds/), the


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it
As it exists now, the chart hardcodes its servicemonitor. If an existing Prometheus only scrapes servicemonitors with specific labels, this allows simple injection of those labels for gitops style deployment.

#### Special notes for your reviewer
Tested with local `helm lint` and `helm template --debug`

#### Does this PR introduce a user-facing change?
```release-note
Allows injecting custom extraLabels to servicemonitor
```
