### PR TITLE
Add Available/Progressing conditions to DisaggregatedSet status

### DIFF
--- a/api/disaggregatedset/v1/disaggregatedset_types.go
+++ b/api/disaggregatedset/v1/disaggregatedset_types.go
@@ -199,7 +199,6 @@ type DisaggregatedSetStatus struct {
 	// Standard condition types include:
 	// - "Available": the resource is fully functional
 	// - "Progressing": the resource is being created or updated
-	// - "Degraded": the resource failed to reach or maintain its desired state
 	//
 	// The status of each condition is one of True, False, or Unknown.
 	// +listType=map
@@ -207,6 +206,23 @@ type DisaggregatedSetStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// DisaggregatedSetConditionType is a valid value for DisaggregatedSetStatus.Conditions[].Type.
+type DisaggregatedSetConditionType string
+
+// These are built-in conditions of a DisaggregatedSet.
+const (
+	// DisaggregatedSetAvailable means every role has reached its desired replica
+	// count (across all slices), with all of those replicas ready and updated to
+	// the current revision. A role with a desired replica count of 0 (the
+	// all-roles-paused state) is satisfied once it has fully drained to 0.
+	DisaggregatedSetAvailable DisaggregatedSetConditionType = "Available"
+
+	// DisaggregatedSetProgressing means at least one role has not yet reached its
+	// desired replica count, or has replicas that are not ready or not updated to
+	// the current revision.
+	DisaggregatedSetProgressing DisaggregatedSetConditionType = "Progressing"
+)
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -16910,7 +16910,6 @@ spec:
                     Standard condition types include:
                     - "Available": the resource is fully functional
                     - "Progressing": the resource is being created or updated
-                    - "Degraded": the resource failed to reach or maintain its desired state
 
                     The status of each condition is one of True, False, or Unknown.
                   items:

--- a/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -18391,7 +18391,6 @@ spec:
                   Standard condition types include:
                   - "Available": the resource is fully functional
                   - "Progressing": the resource is being created or updated
-                  - "Degraded": the resource failed to reach or maintain its desired state
 
                   The status of each condition is one of True, False, or Unknown.
                 items:

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -285,7 +285,10 @@ func setDisaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.Disaggreg
 			}
 			continue
 		}
-		if cond.Status == metav1.ConditionTrue && exclusiveConditionTypes(cond.Type, newCondition.Type) {
+		if !exclusiveConditionTypes(cond.Type, newCondition.Type) {
+			continue
+		}
+		if cond.Status == metav1.ConditionTrue {
 			// newCondition becoming true is exactly why this mutually-exclusive
 			// condition is now false, so it explains the flip with the same
 			// Reason/Message rather than leaving this condition's old (now
@@ -295,6 +298,12 @@ func setDisaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.Disaggreg
 			disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
 			disaggregatedSet.Status.Conditions[i].Reason = newCondition.Reason
 			disaggregatedSet.Status.Conditions[i].Message = newCondition.Message
+			changed = true
+		} else if cond.ObservedGeneration != newCondition.ObservedGeneration {
+			// Already false and staying false — no real transition, so only
+			// ObservedGeneration needs to catch up; Reason/Message still
+			// accurately describe why it became false and don't need to change.
+			disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
 			changed = true
 		}
 	}

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -182,10 +182,19 @@ func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggreg
 		}
 		roleStatuses = append(roleStatuses, roleStatus)
 
+		// An External role with no scaler in the map (e.g. its generated name
+		// collided with a foreign, non-owned object — see #981 for the analogous
+		// LWS case) has no known target: getTargetReplicas would fall back to a
+		// literal 0, which can spuriously read as satisfied if the role also has
+		// 0 actual replicas. Treat that as explicitly Progressing instead of
+		// guessing a target that might accidentally match.
+		if isExternal(disaggregatedSet, role) && scalers[role] == nil {
+			available = false
+			continue
+		}
+
 		// getTargetReplicas resolves the *effective* per-slice target: spec.replicas
-		// for Static roles, the scaler's resolved value for External roles. Falling
-		// back to 0 when an External role's scaler is unexpectedly missing is
-		// conservative — it reads as Progressing rather than guessing a target.
+		// for Static roles, the scaler's resolved value for External roles.
 		desired := int32(getTargetReplicas(disaggregatedSet, role, scalers, 0)) * sliceCount
 		if roleStatus.Replicas != desired || roleStatus.ReadyReplicas != desired || roleStatus.UpdatedReplicas != desired {
 			available = false
@@ -235,8 +244,22 @@ func disaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.Disaggregate
 	}
 }
 
+// exclusiveConditionTypes reports whether t1 and t2 are a mutually-exclusive
+// pair, where one being true means the other must be false. Only
+// Available/Progressing are exclusive today; a condition type outside that
+// pair (added later, or written by another controller) is left untouched by
+// setDisaggregatedSetCondition rather than being clobbered just because it
+// happened to also be true.
+func exclusiveConditionTypes(t1, t2 string) bool {
+	pair := func(a, b disaggregatedsetv1.DisaggregatedSetConditionType) bool {
+		return (t1 == string(a) && t2 == string(b)) || (t1 == string(b) && t2 == string(a))
+	}
+	return pair(disaggregatedsetv1.DisaggregatedSetAvailable, disaggregatedsetv1.DisaggregatedSetProgressing)
+}
+
 // setDisaggregatedSetCondition records newCondition as true and, since Available and
-// Progressing are mutually exclusive, marks any other true condition as false.
+// Progressing are mutually exclusive, marks the other one of that specific pair as
+// false (see exclusiveConditionTypes) — any other condition type is left alone.
 // LastTransitionTime is only touched when a condition's Status actually flips, per
 // the metav1.Condition contract; a same-Status update (e.g. only ObservedGeneration
 // changed) must not look like a fresh transition to clients. Returns whether the
@@ -262,7 +285,7 @@ func setDisaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.Disaggreg
 			}
 			continue
 		}
-		if cond.Status == metav1.ConditionTrue {
+		if cond.Status == metav1.ConditionTrue && exclusiveConditionTypes(cond.Type, newCondition.Type) {
 			// newCondition becoming true is exactly why this mutually-exclusive
 			// condition is now false, so it explains the flip with the same
 			// Reason/Message rather than leaving this condition's old (now

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -147,7 +147,7 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Status reflects the state observed above regardless of per-slice errors, so
 	// a role that failed to reconcile is still visible to clients instead of being
 	// silently left out of .status.
-	if statusErr := r.updateStatus(ctx, disaggregatedSet, roleNames, revision); statusErr != nil {
+	if statusErr := r.updateStatus(ctx, disaggregatedSet, roleNames, revision, scalers); statusErr != nil {
 		return ctrl.Result{}, errors.Join(reconcileErr, fmt.Errorf("failed to update status: %w", statusErr))
 	}
 
@@ -159,9 +159,8 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // slices and revisions), and persists the result if anything changed. roleNames is
 // always the current spec.roles: a role removed from spec has no RoleStatuses entry
 // even while its old LWS objects are still draining down to 0 (see RoleStatuses doc).
-func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, roleNames []string, revision string) error {
+func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, roleNames []string, revision string, scalers map[string]*disaggregatedsetv1.DisaggregatedSetRoleScaler) error {
 	roleStatuses := make([]disaggregatedsetv1.RoleStatus, 0, len(roleNames))
-	roleConfigs := disaggregatedsetutils.GetRoleConfigs(disaggregatedSet)
 	sliceCount := disaggregatedsetutils.GetSlices(disaggregatedSet)
 	available := true
 
@@ -183,7 +182,11 @@ func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggreg
 		}
 		roleStatuses = append(roleStatuses, roleStatus)
 
-		desired := desiredReplicas(roleConfigs[role]) * sliceCount
+		// getTargetReplicas resolves the *effective* per-slice target: spec.replicas
+		// for Static roles, the scaler's resolved value for External roles. Falling
+		// back to 0 when an External role's scaler is unexpectedly missing is
+		// conservative — it reads as Progressing rather than guessing a target.
+		desired := int32(getTargetReplicas(disaggregatedSet, role, scalers, 0)) * sliceCount
 		if roleStatus.Replicas != desired || roleStatus.ReadyReplicas != desired || roleStatus.UpdatedReplicas != desired {
 			available = false
 		}
@@ -213,15 +216,6 @@ func setRoleStatuses(disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, role
 	}
 	disaggregatedSet.Status.RoleStatuses = roleStatuses
 	return true
-}
-
-// desiredReplicas returns the per-slice group count a role's spec asks for,
-// defaulting to 1 — matching reconcileRoleSimple's own default.
-func desiredReplicas(config *disaggregatedsetv1.DisaggregatedRoleSpec) int32 {
-	if config.Spec.Replicas == nil {
-		return 1
-	}
-	return *config.Spec.Replicas
 }
 
 func disaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, available bool) metav1.Condition {
@@ -258,16 +252,26 @@ func setDisaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.Disaggreg
 				newCondition.LastTransitionTime = now
 				disaggregatedSet.Status.Conditions[i] = newCondition
 				changed = true
-			} else if cond.ObservedGeneration != newCondition.ObservedGeneration {
+			} else if cond.ObservedGeneration != newCondition.ObservedGeneration || cond.Reason != newCondition.Reason || cond.Message != newCondition.Message {
+				// Status is unchanged, so LastTransitionTime is preserved, but every
+				// other field still syncs to the latest computed condition.
 				disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
+				disaggregatedSet.Status.Conditions[i].Reason = newCondition.Reason
+				disaggregatedSet.Status.Conditions[i].Message = newCondition.Message
 				changed = true
 			}
 			continue
 		}
 		if cond.Status == metav1.ConditionTrue {
+			// newCondition becoming true is exactly why this mutually-exclusive
+			// condition is now false, so it explains the flip with the same
+			// Reason/Message rather than leaving this condition's old (now
+			// contradictory) ones in place.
 			disaggregatedSet.Status.Conditions[i].Status = metav1.ConditionFalse
 			disaggregatedSet.Status.Conditions[i].LastTransitionTime = now
 			disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
+			disaggregatedSet.Status.Conditions[i].Reason = newCondition.Reason
+			disaggregatedSet.Status.Conditions[i].Message = newCondition.Message
 			changed = true
 		}
 	}

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -153,13 +154,16 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return result, reconcileErr
 }
 
-// updateStatus recomputes per-role replica counts from the LWS objects the
-// DisaggregatedSet owns (aggregated across all slices and revisions), and
-// persists the result if anything changed. roleNames is always the current
-// spec.roles: a role removed from spec has no RoleStatuses entry even while its
-// old LWS objects are still draining down to 0 (see RoleStatuses doc).
+// updateStatus recomputes per-role replica counts and the Available/Progressing
+// condition from the LWS objects the DisaggregatedSet owns (aggregated across all
+// slices and revisions), and persists the result if anything changed. roleNames is
+// always the current spec.roles: a role removed from spec has no RoleStatuses entry
+// even while its old LWS objects are still draining down to 0 (see RoleStatuses doc).
 func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, roleNames []string, revision string) error {
 	roleStatuses := make([]disaggregatedsetv1.RoleStatus, 0, len(roleNames))
+	roleConfigs := disaggregatedsetutils.GetRoleConfigs(disaggregatedSet)
+	sliceCount := disaggregatedsetutils.GetSlices(disaggregatedSet)
+	available := true
 
 	for _, role := range roleNames {
 		lwsList, err := r.LWSManager.List(ctx, disaggregatedSet, -1, role)
@@ -178,9 +182,17 @@ func (r *DisaggregatedSetReconciler) updateStatus(ctx context.Context, disaggreg
 			}
 		}
 		roleStatuses = append(roleStatuses, roleStatus)
+
+		desired := desiredReplicas(roleConfigs[role]) * sliceCount
+		if roleStatus.Replicas != desired || roleStatus.ReadyReplicas != desired || roleStatus.UpdatedReplicas != desired {
+			available = false
+		}
 	}
 
 	changed := setRoleStatuses(disaggregatedSet, roleStatuses)
+	if setDisaggregatedSetCondition(disaggregatedSet, disaggregatedSetCondition(disaggregatedSet, available)) {
+		changed = true
+	}
 	if disaggregatedSet.Status.ObservedGeneration != disaggregatedSet.Generation {
 		disaggregatedSet.Status.ObservedGeneration = disaggregatedSet.Generation
 		changed = true
@@ -201,6 +213,72 @@ func setRoleStatuses(disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, role
 	}
 	disaggregatedSet.Status.RoleStatuses = roleStatuses
 	return true
+}
+
+// desiredReplicas returns the per-slice group count a role's spec asks for,
+// defaulting to 1 — matching reconcileRoleSimple's own default.
+func desiredReplicas(config *disaggregatedsetv1.DisaggregatedRoleSpec) int32 {
+	if config.Spec.Replicas == nil {
+		return 1
+	}
+	return *config.Spec.Replicas
+}
+
+func disaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, available bool) metav1.Condition {
+	condType := disaggregatedsetv1.DisaggregatedSetProgressing
+	reason, message := "RolloutInProgress", "Not all roles have reached their desired replica count, ready and updated to the current revision"
+	if available {
+		condType = disaggregatedsetv1.DisaggregatedSetAvailable
+		reason, message = "AllRolesReady", "All roles have reached their desired replica count, ready and updated to the current revision"
+	}
+
+	return metav1.Condition{
+		Type:               string(condType),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: disaggregatedSet.Generation,
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// setDisaggregatedSetCondition records newCondition as true and, since Available and
+// Progressing are mutually exclusive, marks any other true condition as false.
+// LastTransitionTime is only touched when a condition's Status actually flips, per
+// the metav1.Condition contract; a same-Status update (e.g. only ObservedGeneration
+// changed) must not look like a fresh transition to clients. Returns whether the
+// status changed.
+func setDisaggregatedSetCondition(disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, newCondition metav1.Condition) bool {
+	now := metav1.Now()
+	changed, found := false, false
+
+	for i, cond := range disaggregatedSet.Status.Conditions {
+		if cond.Type == newCondition.Type {
+			found = true
+			if cond.Status != newCondition.Status {
+				newCondition.LastTransitionTime = now
+				disaggregatedSet.Status.Conditions[i] = newCondition
+				changed = true
+			} else if cond.ObservedGeneration != newCondition.ObservedGeneration {
+				disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
+				changed = true
+			}
+			continue
+		}
+		if cond.Status == metav1.ConditionTrue {
+			disaggregatedSet.Status.Conditions[i].Status = metav1.ConditionFalse
+			disaggregatedSet.Status.Conditions[i].LastTransitionTime = now
+			disaggregatedSet.Status.Conditions[i].ObservedGeneration = newCondition.ObservedGeneration
+			changed = true
+		}
+	}
+
+	if !found {
+		newCondition.LastTransitionTime = now
+		disaggregatedSet.Status.Conditions = append(disaggregatedSet.Status.Conditions, newCondition)
+		changed = true
+	}
+
+	return changed
 }
 
 // seedForRole returns a callback that yields the initial spec.replicas value

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -636,6 +636,64 @@ func TestStatusAvailableWhenPausedAtZero(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 }
 
+// TestStatusUsesScalerTargetForExternalRoles: for a role with scaling.mode:
+// External, the effective desired count comes from its DisaggregatedSetRoleScaler,
+// not the role's inline spec.replicas (which is documented as ignored in that
+// mode). Comparing against the ignored inline value would leave the role stuck
+// Progressing forever even once it's fully satisfied at its real, scaler-driven
+// target (Copilot review on #980).
+func TestStatusUsesScalerTargetForExternalRoles(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("external-scaling", "default").
+		WithRole(testControllerRolePrefill, 5, "nginx:1.0"). // inline 5 must be ignored: External mode.
+		WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+		Obj()
+	disaggregatedSet.Spec.Roles[0].Scaling = &disaggregatedsetv1.RoleScaling{Mode: disaggregatedsetv1.RoleScalingExternal}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet).
+		WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}, &disaggregatedsetv1.DisaggregatedSetRoleScaler{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "first reconcile should succeed")
+
+	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
+
+	prefillLWS, err := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	require.NoError(t, err)
+	require.NotNil(t, prefillLWS)
+	require.EqualValues(t, 1, *prefillLWS.Spec.Replicas, "a fresh External role's LWS should be created at the scaler-seeded target (1), not the ignored inline replicas (5)")
+
+	// Simulate the LWS reporting itself fully ready/updated at that scaler-driven target.
+	prefillLWS.Status.Replicas, prefillLWS.Status.ReadyReplicas, prefillLWS.Status.UpdatedReplicas = 1, 1, 1
+	require.NoError(t, fakeClient.Status().Update(ctx, prefillLWS))
+
+	decodeLWS, err := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRoleDecode))
+	require.NoError(t, err)
+	require.NotNil(t, decodeLWS)
+	decodeLWS.Status.Replicas, decodeLWS.Status.ReadyReplicas, decodeLWS.Status.UpdatedReplicas = 2, 2, 2
+	require.NoError(t, fakeClient.Status().Update(ctx, decodeLWS))
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "second reconcile should succeed")
+
+	var got disaggregatedsetv1.DisaggregatedSet
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}, &got))
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable))
+	require.NotNil(t, cond, "Available should be set once the External role is ready at its scaler-driven target (1), not stuck Progressing by comparing against the ignored inline replicas (5)")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+}
+
 // TestStatusDropsRemovedRoleEvenWhileItsLWSStillDrains: roleStatuses mirrors the
 // current spec.roles contract (RoleStatuses doc, #868 review). Removing a role
 // from spec.roles must drop it from status.roleStatuses on the very next reconcile,

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -694,6 +694,65 @@ func TestStatusUsesScalerTargetForExternalRoles(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 }
 
+// TestStatusProgressingWhenExternalRoleScalerMissing: an External role whose
+// generated scaler name collides with a foreign, non-owned
+// DisaggregatedSetRoleScaler is left out of the scalers map entirely (the
+// ScalerManager declines to adopt it — same class of name-collision issue as
+// #981 for LWS). Its target is then genuinely unknown, so status must read
+// Progressing rather than falling back to a literal 0 that could spuriously
+// match a role that also happens to have 0 actual replicas (Copilot review
+// on #980).
+func TestStatusProgressingWhenExternalRoleScalerMissing(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("scaler-collision", "default").
+		WithRole(testControllerRolePrefill, 1, "nginx:1.0").
+		Obj()
+	disaggregatedSet.Spec.Roles[0].Scaling = &disaggregatedsetv1.RoleScaling{Mode: disaggregatedsetv1.RoleScalingExternal}
+
+	// A scaler already occupies the name this role would generate, but it's
+	// owned by a different DisaggregatedSet UID — ScalerManager won't adopt it.
+	foreignScaler := &disaggregatedsetv1.DisaggregatedSetRoleScaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controller.ScalerName(disaggregatedSet.Name, testControllerRolePrefill),
+			Namespace: disaggregatedSet.Namespace,
+			Labels: map[string]string{
+				disaggregatedsetv1.SetNameLabelKey: disaggregatedSet.Name,
+				disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: disaggregatedsetv1.GroupVersion.String(),
+				Kind:       "DisaggregatedSet",
+				Name:       "some-other-ds",
+				UID:        "some-other-uid",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet, foreignScaler).
+		WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}, &disaggregatedsetv1.DisaggregatedSetRoleScaler{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "Reconcile should succeed even though the scaler couldn't be created")
+
+	var got disaggregatedsetv1.DisaggregatedSet
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}, &got))
+
+	progressing := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	require.NotNil(t, progressing, "a role with an unknown (missing/uncreatable) scaler target must read Progressing")
+	assert.Equal(t, metav1.ConditionTrue, progressing.Status)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable)), "must not read Available just because the role also has 0 actual replicas")
+}
+
 // TestStatusDropsRemovedRoleEvenWhileItsLWSStillDrains: roleStatuses mirrors the
 // current spec.roles contract (RoleStatuses doc, #868 review). Removing a role
 // from spec.roles must drop it from status.roleStatuses on the very next reconcile,

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -668,7 +668,7 @@ func TestStatusUsesScalerTargetForExternalRoles(t *testing.T) {
 	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
-	prefillLWS, err := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	prefillLWS, err := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	require.NoError(t, err)
 	require.NotNil(t, prefillLWS)
 	require.EqualValues(t, 1, *prefillLWS.Spec.Replicas, "a fresh External role's LWS should be created at the scaler-seeded target (1), not the ignored inline replicas (5)")
@@ -677,7 +677,7 @@ func TestStatusUsesScalerTargetForExternalRoles(t *testing.T) {
 	prefillLWS.Status.Replicas, prefillLWS.Status.ReadyReplicas, prefillLWS.Status.UpdatedReplicas = 1, 1, 1
 	require.NoError(t, fakeClient.Status().Update(ctx, prefillLWS))
 
-	decodeLWS, err := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRoleDecode))
+	decodeLWS, err := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRoleDecode))
 	require.NoError(t, err)
 	require.NotNil(t, decodeLWS)
 	decodeLWS.Status.Replicas, decodeLWS.Status.ReadyReplicas, decodeLWS.Status.UpdatedReplicas = 2, 2, 2

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -719,7 +719,7 @@ func TestStatusProgressingWhenExternalRoleScalerMissing(t *testing.T) {
 			Namespace: disaggregatedSet.Namespace,
 			Labels: map[string]string{
 				disaggregatedsetv1.SetNameLabelKey: disaggregatedSet.Name,
-				disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
+				disaggregatedsetv1.RoleLabelKey:    testControllerRolePrefill,
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: disaggregatedsetv1.GroupVersion.String(),

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -470,6 +471,11 @@ func TestStatusPopulatedOnFreshDeployment(t *testing.T) {
 	}
 
 	assert.Equal(t, got.Generation, got.Status.ObservedGeneration, "observedGeneration should track .metadata.generation")
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	require.NotNil(t, cond, "Progressing condition should be set")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable)), "Available should not be set yet")
 }
 
 // TestStatusRoleCountsAggregateFromOwnedLWS: roleStatuses sums replicas/ready/updated
@@ -528,6 +534,106 @@ func TestStatusRoleCountsAggregateFromOwnedLWS(t *testing.T) {
 		assert.EqualValues(t, 2, rs.ReadyReplicas, "role %s readyReplicas", rs.Name)
 		assert.EqualValues(t, 2, rs.UpdatedReplicas, "role %s updatedReplicas", rs.Name)
 	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable))
+	require.NotNil(t, cond, "Available condition should be set once every role is at its desired count, ready and updated")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+
+	progressing := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	if progressing != nil {
+		assert.Equal(t, metav1.ConditionFalse, progressing.Status, "Progressing must not also be true once Available")
+	}
+}
+
+// TestStatusProgressingWhenUnderDesiredCount: a role whose running replicas are all
+// ready and updated is still Progressing if it hasn't reached its *desired* replica
+// count yet — internal consistency alone isn't enough to call it Available.
+func TestStatusProgressingWhenUnderDesiredCount(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("under-scaled", "default").
+		WithRole(testControllerRolePrefill, 3, "nginx:1.0").
+		WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+		Obj()
+	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+
+	// prefill wants 3 but only 1 has come up so far; decode is fully at its desired 2.
+	partialLWS := func(role string, replicas int32) *leaderworkersetv1.LeaderWorkerSet {
+		return wrappers.BuildBasicLeaderWorkerSet(disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, role), disaggregatedSet.Namespace).
+			Labels(disaggregatedsetutils.GenerateLabels(disaggregatedSet.Name, 0, revision, role)).
+			Replica(int(replicas)).
+			Size(1).
+			StatusReplicas(replicas).
+			ReadyReplicas(replicas).
+			UpdatedReplicas(replicas).
+			OwnerReference(metav1.OwnerReference{
+				APIVersion: disaggregatedsetv1.GroupVersion.String(),
+				Kind:       "DisaggregatedSet",
+				Name:       disaggregatedSet.Name,
+				UID:        disaggregatedSet.UID,
+				Controller: ptr.To(true),
+			}).
+			WorkerTemplateSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:1.0"}}}).
+			Obj()
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		disaggregatedSet,
+		partialLWS(testControllerRolePrefill, 1),
+		partialLWS(testControllerRoleDecode, 2),
+	).WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "Reconcile should succeed")
+
+	var got disaggregatedsetv1.DisaggregatedSet
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}, &got))
+
+	progressing := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	require.NotNil(t, progressing, "under-desired-count role should keep the set Progressing")
+	assert.Equal(t, metav1.ConditionTrue, progressing.Status)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable)), "Available must not be set while prefill is under its desired count")
+}
+
+// TestStatusAvailableWhenPausedAtZero: the documented all-roles-zero pause state
+// (XValidation on DisaggregatedSetSpec) should read as Available once fully
+// drained, not stuck Progressing forever just because desired is 0.
+func TestStatusAvailableWhenPausedAtZero(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("paused", "default").
+		WithRole(testControllerRolePrefill, 0, "nginx:1.0").
+		WithRole(testControllerRoleDecode, 0, "nginx:1.0").
+		Obj()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet).
+		WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "Reconcile should succeed")
+
+	var got disaggregatedsetv1.DisaggregatedSet
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}, &got))
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable))
+	require.NotNil(t, cond, "a fully-drained, all-roles-zero DisaggregatedSet should be Available, not stuck Progressing")
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
 }
 
 // TestStatusDropsRemovedRoleEvenWhileItsLWSStillDrains: roleStatuses mirrors the

--- a/pkg/controllers/disaggregatedset/status_test.go
+++ b/pkg/controllers/disaggregatedset/status_test.go
@@ -97,10 +97,48 @@ func TestSetDisaggregatedSetCondition_StatusFlipUpdatesTransitionTime(t *testing
 	require.NotNil(t, available)
 	assert.Equal(t, metav1.ConditionFalse, available.Status)
 	assert.True(t, available.LastTransitionTime.Time.After(original.Time), "a real Status flip must refresh LastTransitionTime")
+	assert.Equal(t, newCondition.Reason, available.Reason, "the flipped-to-false condition must not keep a Reason that contradicts its new Status")
+	assert.Equal(t, newCondition.Message, available.Message)
+	assert.EqualValues(t, 1, available.ObservedGeneration)
 
 	progressing := findCondition(ds.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
 	require.NotNil(t, progressing)
 	assert.Equal(t, metav1.ConditionTrue, progressing.Status)
+}
+
+// TestSetDisaggregatedSetCondition_SameStatusSyncsReasonAndMessage verifies that
+// Reason/Message stay in sync with the newly-computed condition even when Status
+// doesn't change (only LastTransitionTime is preserved in that case).
+func TestSetDisaggregatedSetCondition_SameStatusSyncsReasonAndMessage(t *testing.T) {
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Status: disaggregatedsetv1.DisaggregatedSetStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: original,
+				Reason:             "Stale",
+				Message:            "stale message from a previous reconcile",
+			}},
+		},
+	}
+
+	newCondition := metav1.Condition{
+		Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 1,
+		Reason:             "AllRolesReady",
+		Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+	}
+
+	changed := setDisaggregatedSetCondition(ds, newCondition)
+
+	assert.True(t, changed)
+	require.Len(t, ds.Status.Conditions, 1)
+	assert.Equal(t, "AllRolesReady", ds.Status.Conditions[0].Reason)
+	assert.Equal(t, newCondition.Message, ds.Status.Conditions[0].Message)
+	assert.Equal(t, original.Time, ds.Status.Conditions[0].LastTransitionTime.Time, "LastTransitionTime must not change when Status didn't transition")
 }
 
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {

--- a/pkg/controllers/disaggregatedset/status_test.go
+++ b/pkg/controllers/disaggregatedset/status_test.go
@@ -141,6 +141,60 @@ func TestSetDisaggregatedSetCondition_SameStatusSyncsReasonAndMessage(t *testing
 	assert.Equal(t, original.Time, ds.Status.Conditions[0].LastTransitionTime.Time, "LastTransitionTime must not change when Status didn't transition")
 }
 
+// TestSetDisaggregatedSetCondition_StaleFalseConditionObservedGenerationCatchesUp
+// is a regression test for #980 review feedback: the *other* condition in the
+// exclusive pair, once it has settled to Status=False, was only ever touched by
+// the Status-flip branch — so if it stays False across further reconciles while
+// spec generation keeps advancing, its ObservedGeneration froze at whatever it
+// was on the last flip. That's misleading for a client reading
+// conditions[Progressing].observedGeneration expecting it to track how current
+// the reported state is. Reason/Message must NOT change, since they still
+// accurately describe why the condition became false.
+func TestSetDisaggregatedSetCondition_StaleFalseConditionObservedGenerationCatchesUp(t *testing.T) {
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Status: disaggregatedsetv1.DisaggregatedSetStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 2,
+					LastTransitionTime: original,
+					Reason:             "AllRolesReady",
+					Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+				},
+				{
+					Type:               string(disaggregatedsetv1.DisaggregatedSetProgressing),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1, // stale: set on an earlier reconcile, before Available flipped true.
+					LastTransitionTime: original,
+					Reason:             "AllRolesReady",
+					Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+				},
+			},
+		},
+	}
+
+	// Available stays true on a later reconcile (generation advanced, no flip).
+	newCondition := metav1.Condition{
+		Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 3,
+		Reason:             "AllRolesReady",
+		Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+	}
+
+	changed := setDisaggregatedSetCondition(ds, newCondition)
+
+	assert.True(t, changed)
+	progressing := findCondition(ds.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	require.NotNil(t, progressing)
+	assert.Equal(t, metav1.ConditionFalse, progressing.Status, "must not flip back to true")
+	assert.EqualValues(t, 3, progressing.ObservedGeneration, "ObservedGeneration must catch up even while staying False")
+	assert.Equal(t, original.Time, progressing.LastTransitionTime.Time, "LastTransitionTime must not change when Status didn't transition")
+	assert.Equal(t, "AllRolesReady", progressing.Reason, "Reason must not change: it still accurately describes why this became false")
+}
+
 // TestSetDisaggregatedSetCondition_LeavesUnrelatedConditionTypeUntouched guards
 // against a broader mutual-exclusivity bug: setDisaggregatedSetCondition must
 // only flip the specific Available/Progressing pair, not any other Status=True

--- a/pkg/controllers/disaggregatedset/status_test.go
+++ b/pkg/controllers/disaggregatedset/status_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disaggregatedset
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+)
+
+// TestSetDisaggregatedSetCondition_ObservedGenerationOnlyDoesNotResetTransitionTime
+// guards against a condition-transition-time bug: bumping only ObservedGeneration
+// while a condition's Status stays the same must not look like a fresh transition
+// to clients (metav1.Condition contract), so LastTransitionTime must be preserved.
+func TestSetDisaggregatedSetCondition_ObservedGenerationOnlyDoesNotResetTransitionTime(t *testing.T) {
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Status: disaggregatedsetv1.DisaggregatedSetStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: original,
+				Reason:             "AllRolesReady",
+				Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+			}},
+		},
+	}
+
+	newCondition := metav1.Condition{
+		Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 2, // spec generation advanced, but the condition's Status did not change.
+		Reason:             "AllRolesReady",
+		Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+	}
+
+	changed := setDisaggregatedSetCondition(ds, newCondition)
+
+	assert.True(t, changed, "ObservedGeneration bump should still be reported as a status change")
+	require.Len(t, ds.Status.Conditions, 1)
+	assert.EqualValues(t, 2, ds.Status.Conditions[0].ObservedGeneration, "ObservedGeneration should be updated")
+	assert.Equal(t, original.Time, ds.Status.Conditions[0].LastTransitionTime.Time, "LastTransitionTime must not change when Status didn't transition")
+}
+
+// TestSetDisaggregatedSetCondition_StatusFlipUpdatesTransitionTime verifies the
+// opposite case: an actual Status flip (Available -> Progressing) must refresh
+// LastTransitionTime on both the newly-true and newly-false conditions.
+func TestSetDisaggregatedSetCondition_StatusFlipUpdatesTransitionTime(t *testing.T) {
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Status: disaggregatedsetv1.DisaggregatedSetStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: original,
+				Reason:             "AllRolesReady",
+				Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+			}},
+		},
+	}
+
+	newCondition := metav1.Condition{
+		Type:               string(disaggregatedsetv1.DisaggregatedSetProgressing),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 1,
+		Reason:             "RolloutInProgress",
+		Message:            "Not all roles have reached their desired replica count, ready and updated to the current revision",
+	}
+
+	changed := setDisaggregatedSetCondition(ds, newCondition)
+
+	assert.True(t, changed)
+	require.Len(t, ds.Status.Conditions, 2)
+
+	available := findCondition(ds.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetAvailable))
+	require.NotNil(t, available)
+	assert.Equal(t, metav1.ConditionFalse, available.Status)
+	assert.True(t, available.LastTransitionTime.Time.After(original.Time), "a real Status flip must refresh LastTransitionTime")
+
+	progressing := findCondition(ds.Status.Conditions, string(disaggregatedsetv1.DisaggregatedSetProgressing))
+	require.NotNil(t, progressing)
+	assert.Equal(t, metav1.ConditionTrue, progressing.Status)
+}
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/controllers/disaggregatedset/status_test.go
+++ b/pkg/controllers/disaggregatedset/status_test.go
@@ -141,6 +141,44 @@ func TestSetDisaggregatedSetCondition_SameStatusSyncsReasonAndMessage(t *testing
 	assert.Equal(t, original.Time, ds.Status.Conditions[0].LastTransitionTime.Time, "LastTransitionTime must not change when Status didn't transition")
 }
 
+// TestSetDisaggregatedSetCondition_LeavesUnrelatedConditionTypeUntouched guards
+// against a broader mutual-exclusivity bug: setDisaggregatedSetCondition must
+// only flip the specific Available/Progressing pair, not any other Status=True
+// condition it happens to find (Copilot review on #980) — otherwise a future
+// condition type, or one written by another controller, would get silently
+// clobbered just for being true when Available/Progressing changes.
+func TestSetDisaggregatedSetCondition_LeavesUnrelatedConditionTypeUntouched(t *testing.T) {
+	original := metav1.NewTime(time.Now().Add(-time.Hour))
+	ds := &disaggregatedsetv1.DisaggregatedSet{
+		Status: disaggregatedsetv1.DisaggregatedSetStatus{
+			Conditions: []metav1.Condition{{
+				Type:               "SomeUnrelatedCondition",
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				LastTransitionTime: original,
+				Reason:             "Unrelated",
+				Message:            "set by something else entirely",
+			}},
+		},
+	}
+
+	newCondition := metav1.Condition{
+		Type:               string(disaggregatedsetv1.DisaggregatedSetAvailable),
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 1,
+		Reason:             "AllRolesReady",
+		Message:            "All roles have reached their desired replica count, ready and updated to the current revision",
+	}
+
+	setDisaggregatedSetCondition(ds, newCondition)
+
+	unrelated := findCondition(ds.Status.Conditions, "SomeUnrelatedCondition")
+	require.NotNil(t, unrelated)
+	assert.Equal(t, metav1.ConditionTrue, unrelated.Status, "a condition type outside the Available/Progressing pair must not be flipped")
+	assert.Equal(t, original.Time, unrelated.LastTransitionTime.Time)
+	assert.Equal(t, "Unrelated", unrelated.Reason)
+}
+
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == condType {

--- a/site/content/en/docs/reference/disaggregatedset.v1.md
+++ b/site/content/en/docs/reference/disaggregatedset.v1.md
@@ -318,7 +318,6 @@ Each condition has a unique type and reflects the status of a specific aspect of
 <ul>
 <li>&quot;Available&quot;: the resource is fully functional</li>
 <li>&quot;Progressing&quot;: the resource is being created or updated</li>
-<li>&quot;Degraded&quot;: the resource failed to reach or maintain its desired state</li>
 </ul>
 <p>The status of each condition is one of True, False, or Unknown.</p>
 </td>


### PR DESCRIPTION
/kind feature
/kind api-change

#### What this PR does / why we need it

Follow-up to #933, which added `status.observedGeneration` and per-role `status.roleStatuses`. Per @yankay's review on that PR, the `Available`/`Progressing` condition model was split out for its own focused design discussion:

- `Available`: every role has reached its desired replica count (its per-slice `spec.roles[].replicas`, or 1 by default, multiplied across all slices), with all of those replicas ready and updated to the current revision.
- `Progressing`: otherwise.

Two things I specifically addressed, since they were open questions in the original discussion:

- **Desired count, not just self-consistency.** A role whose running replicas are internally consistent (`ready == updated == running`) but below its desired count still reads as `Progressing`. Comparing against the desired count (rather than just checking the three counters agree with each other) is what's needed to get the next point right.
- **Zero-replica pause state.** `DisaggregatedSetSpec` has an `XValidation` allowing all roles to be paused at `replicas: 0`. With desired-count-based comparison, that state naturally reads as `Available` once fully drained (0 desired == 0 actual), rather than being stuck `Progressing` forever just because "desired" happens to be 0.

`Available` and `Progressing` are mutually exclusive. `LastTransitionTime` only changes on an actual `Status` flip (true → false or vice versa), not on every `ObservedGeneration` bump — this was flagged by Copilot on the original PR and is carried forward here with its regression tests.

#### Which issue(s) this PR fixes
Fixes #868

#### Special notes for your reviewer

- Deliberately no `Degraded` condition. Distinguishing "still rolling out" from "genuinely stuck/failed" needs a stronger signal (pod failure reasons, timeout heuristics) than what's derivable from the owned LWS statuses today. Happy to follow up if there's an existing convention in the codebase I should reuse instead of inventing one.
- Test coverage added for the two specific edge cases above (`TestStatusProgressingWhenUnderDesiredCount`, `TestStatusAvailableWhenPausedAtZero`), plus the existing fresh-deployment/fully-ready/role-removal cases extended with condition assertions.
- Regenerated CRD manifests and API reference docs to match (removes the "Degraded" bullet from the `Conditions` doc comment, since that condition type isn't implemented).

#### Does this PR introduce a user-facing change?
```release-note
DisaggregatedSet: the controller now reports an `Available`/`Progressing` condition in `status.conditions`, reflecting whether every role has reached its desired replica count with all replicas ready and updated to the current revision.
```
