### PR TITLE
Verify controller ownership before GetForRole/Scale/legacy-slice0 mutate an LWS

### DIFF
--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -497,9 +497,9 @@ func (r *DisaggregatedSetReconciler) recreateLegacySlice0(
 	log := logf.FromContext(ctx)
 
 	for _, role := range roleNames {
-		// getOwned (not a raw Get): a foreign object occupying the legacy name
-		// must not be adopted/deleted here — see #981.
-		lws, err := r.LWSManager.getOwned(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role))
+		// Get is ownership-filtered: a foreign object occupying the legacy
+		// name must not be adopted/deleted here.
+		lws, err := r.LWSManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role))
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -408,7 +408,7 @@ func (r *DisaggregatedSetReconciler) reconcileRoleSimple(ctx context.Context, di
 	}
 	if existingReplicas != desiredReplicas {
 		log.Info("Scaling LWS", "role", role, "name", existing.Name, "from", existingReplicas, "to", desiredReplicas)
-		if err := r.LWSManager.Scale(ctx, disaggregatedSet.Namespace, existing.Name, int(desiredReplicas)); err != nil {
+		if err := r.LWSManager.Scale(ctx, disaggregatedSet, existing.Name, int(desiredReplicas)); err != nil {
 			return fmt.Errorf("failed to scale LWS %s: %w", existing.Name, err)
 		}
 	}
@@ -497,7 +497,9 @@ func (r *DisaggregatedSetReconciler) recreateLegacySlice0(
 	log := logf.FromContext(ctx)
 
 	for _, role := range roleNames {
-		lws, err := r.LWSManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role))
+		// getOwned (not a raw Get): a foreign object occupying the legacy name
+		// must not be adopted/deleted here — see #981.
+		lws, err := r.LWSManager.getOwned(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role))
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -123,11 +123,11 @@ func TestFreshDeploymentNoRollingUpdate(t *testing.T) {
 	newRevision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
-	prefillInfo, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRolePrefill))
+	prefillInfo, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRolePrefill))
 	require.NotNil(t, prefillInfo, "prefill LWS should exist")
 	assert.Equal(t, 3, int(*prefillInfo.Spec.Replicas), "prefill replicas")
 
-	decodeInfo, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRoleDecode))
+	decodeInfo, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRoleDecode))
 	require.NotNil(t, decodeInfo, "decode LWS should exist")
 	assert.Equal(t, 2, int(*decodeInfo.Spec.Replicas), "decode replicas")
 }
@@ -160,11 +160,11 @@ func TestScalingWithoutRollingUpdate(t *testing.T) {
 
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
-	prefillInfo, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	prefillInfo, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	require.NotNil(t, prefillInfo, "prefill LWS should exist")
 	assert.Equal(t, 5, int(*prefillInfo.Spec.Replicas), "prefill replicas should be scaled to 5")
 
-	decodeInfo, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRoleDecode))
+	decodeInfo, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRoleDecode))
 	require.NotNil(t, decodeInfo, "decode LWS should exist")
 	assert.Equal(t, 4, int(*decodeInfo.Spec.Replicas), "decode replicas should be scaled to 4")
 }
@@ -216,12 +216,12 @@ func TestSlicesCreateOneSetPerSlice(t *testing.T) {
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
 	for slice := range 2 {
-		prefill, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, slice, revision, testControllerRolePrefill))
+		prefill, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, slice, revision, testControllerRolePrefill))
 		require.NotNil(t, prefill, "prefill LWS should exist for slice %d", slice)
 		assert.Equal(t, 2, int(*prefill.Spec.Replicas), "prefill replicas slice %d", slice)
 		assert.Equal(t, strconv.Itoa(slice), prefill.Labels[disaggregatedsetv1.SliceLabelKey], "slice label slice %d", slice)
 
-		decode, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, slice, revision, testControllerRoleDecode))
+		decode, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, slice, revision, testControllerRoleDecode))
 		require.NotNil(t, decode, "decode LWS should exist for slice %d", slice)
 		assert.Equal(t, 3, int(*decode.Spec.Replicas), "decode replicas slice %d", slice)
 	}
@@ -264,13 +264,13 @@ func TestSlicesScaleDownDeletesRemovedSlice(t *testing.T) {
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
 	// Slice 0 is kept.
-	s0, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	require.NotNil(t, s0, "slice 0 prefill should be kept")
 
 	// Slice 1 (>= desired) is deleted.
-	s1p, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	s1p, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
 	assert.Nil(t, s1p, "slice 1 prefill should be deleted")
-	s1d, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRoleDecode))
+	s1d, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRoleDecode))
 	assert.Nil(t, s1d, "slice 1 decode should be deleted")
 }
 
@@ -305,11 +305,11 @@ func TestLegacyAdoptedInPlace(t *testing.T) {
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
 	// Legacy LWS kept under its legacy name.
-	legacy, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill))
+	legacy, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill))
 	require.NotNil(t, legacy, "legacy prefill LWS should be adopted in place")
 
 	// No slice-aware duplicate created.
-	dup, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	dup, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	assert.Nil(t, dup, "no slice-aware duplicate should be created over a legacy LWS")
 
 	var all leaderworkersetv1.LeaderWorkerSetList
@@ -351,12 +351,12 @@ func TestLegacyMigratesToSliceAwareOnRollout(t *testing.T) {
 
 	// The rollout creates the new revision in slice-aware form: the name carries the
 	// -0- slice segment and the object carries the slice label.
-	migrated, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRolePrefill))
+	migrated, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, newRevision, testControllerRolePrefill))
 	require.NotNil(t, migrated, "slice-aware prefill LWS at the new revision should be created")
 	assert.Equal(t, "0", migrated.Labels[disaggregatedsetv1.SliceLabelKey], "migrated LWS should carry the slice label")
 
 	// The legacy (label-less) object keeps its old name while it drains.
-	legacy, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, oldRevision, testControllerRolePrefill))
+	legacy, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, oldRevision, testControllerRolePrefill))
 	assert.NotNil(t, legacy, "legacy prefill LWS should still exist while draining")
 }
 
@@ -412,9 +412,9 @@ func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
 	// Legacy slice-0 LWS deleted for both roles.
-	legacyP, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill))
+	legacyP, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill))
 	assert.Nil(t, legacyP, "legacy slice-0 prefill LWS should be deleted")
-	legacyD, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRoleDecode))
+	legacyD, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRoleDecode))
 	assert.Nil(t, legacyD, "legacy slice-0 decode LWS should be deleted")
 
 	// Legacy slice-agnostic service deleted (before any sibling could be selected).
@@ -422,9 +422,9 @@ func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 	assert.Error(t, err, "legacy slice-agnostic service should be deleted")
 
 	// Slice 0 recreated slice-aware, and sibling slice 1 created in the same pass.
-	s0, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	require.NotNil(t, s0, "slice-aware slice-0 prefill should be recreated")
-	s1, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
 	require.NotNil(t, s1, "sibling slice 1 prefill should be created (no blocking)")
 }
 
@@ -582,7 +582,7 @@ func TestStatusDropsRemovedRoleEvenWhileItsLWSStillDrains(t *testing.T) {
 
 	// The old role's LWS is still there — status dropping it is a status-contract
 	// choice, not a side effect of the LWS actually being gone.
-	extraLWS, _ := controller.NewLeaderWorkerSetManager(fakeClient).Get(ctx, got.Namespace, extraLWSName)
+	extraLWS, _ := controller.NewLeaderWorkerSetManager(fakeClient).Get(ctx, &got, extraLWSName)
 	assert.NotNil(t, extraLWS, "removed role's old LWS is expected to still exist; this test pins the status contract, not cleanup")
 }
 
@@ -619,11 +619,11 @@ func TestSlicesIncreaseWithRolloutNotBlocked(t *testing.T) {
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
 	// Slice 0 rolls toward the new revision (slice-aware new-revision LWS created).
-	s0, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, targetRevision, testControllerRolePrefill))
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, targetRevision, testControllerRolePrefill))
 	require.NotNil(t, s0, "slice 0 should start rolling to the new revision")
 
 	// Sibling slice is NOT blocked: it is created at the new revision.
-	s1, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, targetRevision, testControllerRolePrefill))
+	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, targetRevision, testControllerRolePrefill))
 	require.NotNil(t, s1, "slice 1 should be created at the new revision without blocking")
 }
 
@@ -684,8 +684,10 @@ func TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0(t *testing.T) {
 
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
-	// The foreign object at the legacy name must survive untouched.
-	foreignAfter, err := lwsManager.Get(ctx, "default", foreignLegacyPrefill.Name)
+	// The foreign object at the legacy name must survive untouched. Get is
+	// ownership-filtered, so fetch it as its actual owner (foreignDS) rather
+	// than as disaggregatedSet, which would now correctly see it as absent.
+	foreignAfter, err := lwsManager.Get(ctx, foreignDS, foreignLegacyPrefill.Name)
 	require.NoError(t, err)
 	require.NotNil(t, foreignAfter, "foreign-owned legacy LWS must not be deleted")
 	require.Len(t, foreignAfter.OwnerReferences, 1)
@@ -693,8 +695,8 @@ func TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0(t *testing.T) {
 
 	// This DisaggregatedSet's own slice-aware LWS are still created normally at
 	// both slices — the foreign object at the legacy name did not block anything.
-	s0, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
 	assert.NotNil(t, s0, "slice-aware slice-0 prefill should still be created")
-	s1, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
 	assert.NotNil(t, s1, "sibling slice 1 prefill should still be created")
 }

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -626,3 +626,75 @@ func TestSlicesIncreaseWithRolloutNotBlocked(t *testing.T) {
 	s1, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, targetRevision, testControllerRolePrefill))
 	require.NotNil(t, s1, "slice 1 should be created at the new revision without blocking")
 }
+
+// TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0 is a regression test for
+// #981: recreateLegacySlice0 must not delete/migrate a legacy-named LWS that
+// exists but is owned by a different DisaggregatedSet (e.g. left over from a
+// same-named DisaggregatedSet that was deleted and recreated before GC ran).
+// The foreign object is left untouched, and the normal create path still
+// proceeds for this DisaggregatedSet's own slice-aware LWS at both slices —
+// increasing slices must not get stuck just because the legacy name is
+// occupied by something else.
+func TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("legacy-foreign", "default").
+		Slices(2).
+		WithRole(testControllerRolePrefill, 2, "nginx:1.0").
+		WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+		Obj()
+	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+
+	foreignDS := wrappers.BuildDisaggregatedSet("some-other-ds", "default").Obj()
+	foreignOwnerRef := metav1.OwnerReference{
+		APIVersion: disaggregatedsetv1.GroupVersion.String(),
+		Kind:       "DisaggregatedSet",
+		Name:       foreignDS.Name,
+		UID:        foreignDS.UID,
+		Controller: ptr.To(true),
+	}
+	foreignLegacyPrefill := wrappers.BuildBasicLeaderWorkerSet(
+		disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill), "default").
+		Labels(map[string]string{
+			disaggregatedsetv1.SetNameLabelKey:  disaggregatedSet.Name,
+			disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
+			disaggregatedsetv1.RevisionLabelKey: revision,
+		}).
+		Replica(2).
+		Size(1).
+		OwnerReference(foreignOwnerRef).
+		WorkerTemplateSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:1.0"}}}).
+		Obj()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		disaggregatedSet,
+		foreignLegacyPrefill,
+	).WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "Reconcile should succeed even though the legacy name is occupied by a foreign LWS")
+
+	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
+
+	// The foreign object at the legacy name must survive untouched.
+	foreignAfter, err := lwsManager.Get(ctx, "default", foreignLegacyPrefill.Name)
+	require.NoError(t, err)
+	require.NotNil(t, foreignAfter, "foreign-owned legacy LWS must not be deleted")
+	require.Len(t, foreignAfter.OwnerReferences, 1)
+	assert.Equal(t, foreignDS.UID, foreignAfter.OwnerReferences[0].UID, "foreign LWS ownership must be unchanged")
+
+	// This DisaggregatedSet's own slice-aware LWS are still created normally at
+	// both slices — the foreign object at the legacy name did not block anything.
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	assert.NotNil(t, s0, "slice-aware slice-0 prefill should still be created")
+	s1, _ := lwsManager.Get(ctx, disaggregatedSet.Namespace, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	assert.NotNil(t, s1, "sibling slice 1 prefill should still be created")
+}

--- a/pkg/controllers/disaggregatedset/executor.go
+++ b/pkg/controllers/disaggregatedset/executor.go
@@ -459,7 +459,7 @@ func (executor *RollingUpdateExecutor) ensureNewLWSExists(
 	initialReplicas int,
 ) (bool, error) {
 	lwsName := disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role)
-	existing, err := executor.LWSManager.Get(ctx, ds.Namespace, lwsName)
+	existing, err := executor.LWSManager.Get(ctx, ds, lwsName)
 	if err != nil {
 		return false, fmt.Errorf("failed to get LWS %s: %w", lwsName, err)
 	}

--- a/pkg/controllers/disaggregatedset/executor.go
+++ b/pkg/controllers/disaggregatedset/executor.go
@@ -359,7 +359,7 @@ func (executor *RollingUpdateExecutor) scaleUpNew(
 		}
 		lwsName := disaggregatedsetutils.GenerateName(ds.Name, slice, newRevision.Revision, name)
 		log.Info("Scaling up", "lws", lwsName, "from", current[i], "to", target[i])
-		if err := executor.LWSManager.Scale(ctx, ds.Namespace, lwsName, target[i]); err != nil {
+		if err := executor.LWSManager.Scale(ctx, ds, lwsName, target[i]); err != nil {
 			return fmt.Errorf("failed to scale %s: %w", lwsName, err)
 		}
 		executor.Record.Eventf(ds, nil, corev1.EventTypeNormal, EventReasonScalingUp,
@@ -425,7 +425,7 @@ func (executor *RollingUpdateExecutor) scaleDownOld(
 			// Address by the LWS's actual name so a legacy slice-0 object drains too.
 			lwsName := lws.Name
 			log.Info("Scaling down", "lws", lwsName, "from", replicas, "to", newReplicas[name])
-			if err := executor.LWSManager.Scale(ctx, ds.Namespace, lwsName, newReplicas[name]); err != nil {
+			if err := executor.LWSManager.Scale(ctx, ds, lwsName, newReplicas[name]); err != nil {
 				return fmt.Errorf("failed to scale %s: %w", lwsName, err)
 			}
 			executor.Record.Eventf(ds, nil, corev1.EventTypeNormal, EventReasonScalingDown,

--- a/pkg/controllers/disaggregatedset/executor_test.go
+++ b/pkg/controllers/disaggregatedset/executor_test.go
@@ -81,6 +81,19 @@ func newTestExecutor(fakeClient client.Client) *RollingUpdateExecutor {
 	}
 }
 
+// testDSOwnerRef is the controller OwnerReference matching the "test"/"uid"
+// DisaggregatedSet fixture convention used throughout this file (see
+// setupABCScenario and the inline `ds := &disaggregatedsetv1.DisaggregatedSet{
+// ObjectMeta: metav1.ObjectMeta{Name: "test", ...}}` fixtures) — Scale checks
+// ownership (#981), so LWS fixtures built via buildTestLWS must carry it too.
+var testDSOwnerRef = metav1.OwnerReference{
+	APIVersion: disaggregatedsetv1.GroupVersion.String(),
+	Kind:       "DisaggregatedSet",
+	Name:       "test",
+	UID:        "uid",
+	Controller: ptr.To(true),
+}
+
 func buildTestLWS(name, namespace, role, revision string) *wrappers.LeaderWorkerSetWrapper {
 	return wrappers.BuildBasicLeaderWorkerSet(name, namespace).
 		Labels(map[string]string{
@@ -88,7 +101,8 @@ func buildTestLWS(name, namespace, role, revision string) *wrappers.LeaderWorker
 			disaggregatedsetv1.SetNameLabelKey:  "test",
 			disaggregatedsetv1.SliceLabelKey:    "0",
 			disaggregatedsetv1.RevisionLabelKey: revision,
-		})
+		}).
+		OwnerReference(testDSOwnerRef)
 }
 
 // getTestLWSReplicas is a helper to get the current replica count from a LWS.
@@ -898,7 +912,7 @@ func TestScaleDownOld(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(testSchemeForUnit()).
 				WithObjects(objects...).WithStatusSubresource(&leaderworkersetv1.LeaderWorkerSet{}).Build()
 			executor := newTestExecutor(fakeClient)
-			ds := &disaggregatedsetv1.DisaggregatedSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace}}
+			ds := &disaggregatedsetv1.DisaggregatedSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace, UID: "uid"}}
 
 			// Convert budget to current/target format
 			current := RoleReplicaState{
@@ -994,7 +1008,7 @@ func TestScaleDownOldWithMissingRole(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(testSchemeForUnit()).
 				WithObjects(objects...).WithStatusSubresource(&leaderworkersetv1.LeaderWorkerSet{}).Build()
 			executor := newTestExecutor(fakeClient)
-			ds := &disaggregatedsetv1.DisaggregatedSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace}}
+			ds := &disaggregatedsetv1.DisaggregatedSet{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace, UID: "uid"}}
 
 			// Convert budget to current/target format for 3 roles
 			current := RoleReplicaState{
@@ -1059,7 +1073,7 @@ func TestScaleUpNew(t *testing.T) {
 			executor := newTestExecutor(fakeClient)
 
 			ds := &disaggregatedsetv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: namespace, UID: "uid"},
 			}
 
 			newRevision := disaggregatedsetutils.RevisionRoles{
@@ -1212,7 +1226,7 @@ func TestReconcileRollingUpdateABCScenario(t *testing.T) {
 				{Name: testRoleDecode, LeaderWorkerSetTemplateSpec: leaderworkersetv1.LeaderWorkerSetTemplateSpec{Spec: leaderworkersetv1.LeaderWorkerSetSpec{Replicas: ptr.To(int32(4))}}},
 			}
 			deployment := &disaggregatedsetv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace, UID: "uid"},
 				Spec:       disaggregatedsetv1.DisaggregatedSetSpec{Roles: roles},
 			}
 

--- a/pkg/controllers/disaggregatedset/executor_test.go
+++ b/pkg/controllers/disaggregatedset/executor_test.go
@@ -1147,7 +1147,7 @@ func TestEnsureNewLWSExists(t *testing.T) {
 				},
 			}
 			deployment := &disaggregatedsetv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace, UID: "test-uid"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace, UID: "uid"},
 				Spec:       disaggregatedsetv1.DisaggregatedSetSpec{Roles: roles},
 			}
 

--- a/pkg/controllers/disaggregatedset/lws_manager.go
+++ b/pkg/controllers/disaggregatedset/lws_manager.go
@@ -99,10 +99,24 @@ func (manager *LeaderWorkerSetManager) Create(ctx context.Context, params disagg
 	}
 
 	if err := manager.client.Create(ctx, leaderWorkerSet); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create LeaderWorkerSet %s: %w", lwsName, err)
 		}
-		return fmt.Errorf("failed to create LeaderWorkerSet %s: %w", lwsName, err)
+		// Name is taken. If we already own it, a concurrent reconcile of this
+		// same DisaggregatedSet beat us to it — no-op. If it's foreign-owned
+		// (see #981), error instead of silently no-oping: this DS's watches
+		// won't fire again for a foreign object it doesn't own, so a silent
+		// return here could leave the role permanently missing an LWS until
+		// some unrelated trigger causes another reconcile. Returning an error
+		// requeues instead.
+		existing := &leaderworkersetv1.LeaderWorkerSet{}
+		if getErr := manager.client.Get(ctx, types.NamespacedName{Name: lwsName, Namespace: params.DisaggregatedSet.Namespace}, existing); getErr != nil {
+			return fmt.Errorf("failed to get existing LeaderWorkerSet %s after create conflict: %w", lwsName, getErr)
+		}
+		if !metav1.IsControlledBy(existing, params.DisaggregatedSet) {
+			return fmt.Errorf("LeaderWorkerSet %s exists but is not controlled by DisaggregatedSet %s; refusing to adopt it", lwsName, params.DisaggregatedSet.Name)
+		}
+		return nil
 	}
 
 	log := logf.FromContext(ctx)
@@ -110,10 +124,18 @@ func (manager *LeaderWorkerSetManager) Create(ctx context.Context, params disagg
 	return nil
 }
 
-func (manager *LeaderWorkerSetManager) Scale(ctx context.Context, namespace, name string, replicas int) error {
+// Scale patches the LWS named name to replicas, but only if it's actually
+// controller-owned by ds. A same-named LWS that exists but isn't owned by ds
+// — e.g. left over from a same-named DisaggregatedSet that was deleted and
+// recreated before garbage collection ran — is refused rather than mutated;
+// see #981.
+func (manager *LeaderWorkerSetManager) Scale(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, name string, replicas int) error {
 	leaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-	if err := manager.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, leaderWorkerSet); err != nil {
+	if err := manager.client.Get(ctx, types.NamespacedName{Name: name, Namespace: ds.Namespace}, leaderWorkerSet); err != nil {
 		return fmt.Errorf("failed to get LeaderWorkerSet %s for scaling: %w", name, err)
+	}
+	if !metav1.IsControlledBy(leaderWorkerSet, ds) {
+		return fmt.Errorf("LeaderWorkerSet %s exists but is not controlled by DisaggregatedSet %s; refusing to scale it", name, ds.Name)
 	}
 
 	if int(getLWSReplicas(leaderWorkerSet)) == replicas {
@@ -173,18 +195,36 @@ func (manager *LeaderWorkerSetManager) List(ctx context.Context, disaggregatedSe
 	return result, nil
 }
 
-// GetForRole returns the existing LWS for (slice, revision, role), or nil if none.
-// It looks up the slice-aware name and, for slice 0, falls back to the legacy
-// (pre-slices) name so a legacy object is adopted in place rather than duplicated.
+// getOwned returns the LWS named name, but only if it's actually
+// controller-owned by ds. A same-named LWS that exists but isn't owned by ds
+// is treated as absent (nil, nil), matching List's ownership filtering —
+// see #981.
+func (manager *LeaderWorkerSetManager) getOwned(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, name string) (*leaderworkersetv1.LeaderWorkerSet, error) {
+	lws, err := manager.Get(ctx, ds.Namespace, name)
+	if err != nil || lws == nil {
+		return lws, err
+	}
+	if !metav1.IsControlledBy(lws, ds) {
+		return nil, nil
+	}
+	return lws, nil
+}
+
+// GetForRole returns the existing LWS for (slice, revision, role) that is
+// actually controller-owned by ds, or nil if none. It looks up the
+// slice-aware name and, for slice 0, falls back to the legacy (pre-slices)
+// name so a legacy object is adopted in place rather than duplicated. A
+// same-named LWS occupied by a foreign object is treated as absent rather
+// than returned for the caller to mutate.
 func (manager *LeaderWorkerSetManager) GetForRole(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, slice int, revision, role string) (*leaderworkersetv1.LeaderWorkerSet, error) {
-	lws, err := manager.Get(ctx, ds.Namespace, disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role))
+	lws, err := manager.getOwned(ctx, ds, disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role))
 	if err != nil {
 		return nil, err
 	}
 	if lws != nil || slice != 0 {
 		return lws, nil
 	}
-	return manager.Get(ctx, ds.Namespace, disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role))
+	return manager.getOwned(ctx, ds, disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role))
 }
 
 func (manager *LeaderWorkerSetManager) Delete(ctx context.Context, namespace, name string) error {

--- a/pkg/controllers/disaggregatedset/lws_manager.go
+++ b/pkg/controllers/disaggregatedset/lws_manager.go
@@ -152,14 +152,23 @@ func (manager *LeaderWorkerSetManager) Scale(ctx context.Context, ds *disaggrega
 	return nil
 }
 
-func (manager *LeaderWorkerSetManager) Get(ctx context.Context, namespace, name string) (*leaderworkersetv1.LeaderWorkerSet, error) {
+// Get returns the LWS named name, but only if it's actually controller-owned
+// by ds — consistent with List's ownership filtering. A same-named LWS that
+// exists but isn't owned by ds (e.g. left over from a same-named
+// DisaggregatedSet that was deleted and recreated before garbage collection
+// ran) is treated as absent (nil, nil) rather than returned for the caller to
+// read or mutate as if it were this DisaggregatedSet's own.
+func (manager *LeaderWorkerSetManager) Get(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, name string) (*leaderworkersetv1.LeaderWorkerSet, error) {
 	lws := &leaderworkersetv1.LeaderWorkerSet{}
-	err := manager.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, lws)
+	err := manager.client.Get(ctx, types.NamespacedName{Name: name, Namespace: ds.Namespace}, lws)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get LeaderWorkerSet %s: %w", name, err)
+	}
+	if !metav1.IsControlledBy(lws, ds) {
+		return nil, nil
 	}
 	return lws, nil
 }
@@ -195,21 +204,6 @@ func (manager *LeaderWorkerSetManager) List(ctx context.Context, disaggregatedSe
 	return result, nil
 }
 
-// getOwned returns the LWS named name, but only if it's actually
-// controller-owned by ds. A same-named LWS that exists but isn't owned by ds
-// is treated as absent (nil, nil), matching List's ownership filtering —
-// see #981.
-func (manager *LeaderWorkerSetManager) getOwned(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, name string) (*leaderworkersetv1.LeaderWorkerSet, error) {
-	lws, err := manager.Get(ctx, ds.Namespace, name)
-	if err != nil || lws == nil {
-		return lws, err
-	}
-	if !metav1.IsControlledBy(lws, ds) {
-		return nil, nil
-	}
-	return lws, nil
-}
-
 // GetForRole returns the existing LWS for (slice, revision, role) that is
 // actually controller-owned by ds, or nil if none. It looks up the
 // slice-aware name and, for slice 0, falls back to the legacy (pre-slices)
@@ -217,14 +211,14 @@ func (manager *LeaderWorkerSetManager) getOwned(ctx context.Context, ds *disaggr
 // same-named LWS occupied by a foreign object is treated as absent rather
 // than returned for the caller to mutate.
 func (manager *LeaderWorkerSetManager) GetForRole(ctx context.Context, ds *disaggregatedsetv1.DisaggregatedSet, slice int, revision, role string) (*leaderworkersetv1.LeaderWorkerSet, error) {
-	lws, err := manager.getOwned(ctx, ds, disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role))
+	lws, err := manager.Get(ctx, ds, disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role))
 	if err != nil {
 		return nil, err
 	}
 	if lws != nil || slice != 0 {
 		return lws, nil
 	}
-	return manager.getOwned(ctx, ds, disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role))
+	return manager.Get(ctx, ds, disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role))
 }
 
 func (manager *LeaderWorkerSetManager) Delete(ctx context.Context, namespace, name string) error {

--- a/pkg/controllers/disaggregatedset/lws_manager_test.go
+++ b/pkg/controllers/disaggregatedset/lws_manager_test.go
@@ -41,10 +41,10 @@ var managerTestLabels = map[string]string{
 	disaggregatedsetv1.RevisionLabelKey: "abc123",
 }
 
-func buildManagerTestLWS(name string, replicas int32, annotations map[string]string) *leaderworkersetv1.LeaderWorkerSet {
-	return wrappers.BuildBasicLeaderWorkerSet(name, "default").
+func buildManagerTestLWS(annotations map[string]string) *leaderworkersetv1.LeaderWorkerSet {
+	return wrappers.BuildBasicLeaderWorkerSet("test-lws", "default").
 		Labels(managerTestLabels).
-		Replica(int(replicas)).
+		Replica(3).
 		Annotation(annotations).
 		Obj()
 }
@@ -172,7 +172,7 @@ func TestManagerDelete(t *testing.T) {
 	require.NoError(t, leaderworkersetv1.AddToScheme(scheme))
 
 	t.Run("successfully deletes existing LWS", func(t *testing.T) {
-		existingLWS := buildManagerTestLWS("test-lws", 3, nil)
+		existingLWS := buildManagerTestLWS(nil)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -272,7 +272,6 @@ func TestManagerSetInitialReplicas(t *testing.T) {
 
 	t.Run("skips update when value already correct", func(t *testing.T) {
 		existingLWS := buildManagerTestLWS(
-			"test-lws", 3,
 			map[string]string{disaggregatedsetv1.InitialReplicasAnnotationKey: "5"},
 		)
 
@@ -291,7 +290,6 @@ func TestManagerSetInitialReplicas(t *testing.T) {
 
 	t.Run("updates when overwriting different value", func(t *testing.T) {
 		existingLWS := buildManagerTestLWS(
-			"test-lws", 3,
 			map[string]string{disaggregatedsetv1.InitialReplicasAnnotationKey: "5"},
 		)
 
@@ -309,7 +307,7 @@ func TestManagerSetInitialReplicas(t *testing.T) {
 	})
 
 	t.Run("sets annotation when not present", func(t *testing.T) {
-		existingLWS := buildManagerTestLWS("test-lws", 3, nil)
+		existingLWS := buildManagerTestLWS(nil)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/controllers/disaggregatedset/lws_manager_test.go
+++ b/pkg/controllers/disaggregatedset/lws_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +46,34 @@ func buildManagerTestLWS(name string, replicas int32, annotations map[string]str
 		Labels(managerTestLabels).
 		Replica(int(replicas)).
 		Annotation(annotations).
+		Obj()
+}
+
+// testManagerDS returns a minimal DisaggregatedSet fixture for ownership
+// checks in Scale/GetForRole tests.
+func testManagerDS(name string) *disaggregatedsetv1.DisaggregatedSet {
+	return wrappers.BuildDisaggregatedSet(name, "default").Obj()
+}
+
+// ownerRefFor builds the controller OwnerReference this package's own
+// LeaderWorkerSetManager.Create sets, so fixtures match real objects.
+func ownerRefFor(ds *disaggregatedsetv1.DisaggregatedSet) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: disaggregatedsetv1.GroupVersion.String(),
+		Kind:       "DisaggregatedSet",
+		Name:       ds.Name,
+		UID:        ds.UID,
+		Controller: ptr.To(true),
+	}
+}
+
+// buildOwnedManagerTestLWS is buildManagerTestLWS plus a controller
+// OwnerReference to owner, for ownership-check tests.
+func buildOwnedManagerTestLWS(name string, replicas int32, owner *disaggregatedsetv1.DisaggregatedSet) *leaderworkersetv1.LeaderWorkerSet {
+	return wrappers.BuildBasicLeaderWorkerSet(name, "default").
+		Labels(managerTestLabels).
+		Replica(int(replicas)).
+		OwnerReference(ownerRefFor(owner)).
 		Obj()
 }
 
@@ -172,9 +201,10 @@ func TestManagerDelete(t *testing.T) {
 func TestManagerScale(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, leaderworkersetv1.AddToScheme(scheme))
+	ds := testManagerDS("test-deployment")
 
 	t.Run("skips patch when already at desired scale", func(t *testing.T) {
-		existingLWS := buildManagerTestLWS("test-lws", 5, nil)
+		existingLWS := buildOwnedManagerTestLWS("test-lws", 5, ds)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -182,13 +212,13 @@ func TestManagerScale(t *testing.T) {
 			Build()
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
-		err := manager.Scale(context.Background(), "default", "test-lws", 5)
+		err := manager.Scale(context.Background(), ds, "test-lws", 5)
 
 		require.NoError(t, err)
 	})
 
 	t.Run("scales to new replica count", func(t *testing.T) {
-		existingLWS := buildManagerTestLWS("test-lws", 3, nil)
+		existingLWS := buildOwnedManagerTestLWS("test-lws", 3, ds)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -196,7 +226,7 @@ func TestManagerScale(t *testing.T) {
 			Build()
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
-		err := manager.Scale(context.Background(), "default", "test-lws", 5)
+		err := manager.Scale(context.Background(), ds, "test-lws", 5)
 
 		require.NoError(t, err)
 	})
@@ -207,9 +237,31 @@ func TestManagerScale(t *testing.T) {
 			Build()
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
-		err := manager.Scale(context.Background(), "default", "nonexistent", 5)
+		err := manager.Scale(context.Background(), ds, "nonexistent", 5)
 
 		require.Error(t, err)
+	})
+
+	// Regression test for #981: a same-named LWS that exists but is owned by a
+	// different DisaggregatedSet (e.g. left over from a same-named
+	// DisaggregatedSet that was deleted and recreated before GC ran) must be
+	// refused, not mutated.
+	t.Run("refuses to scale a foreign-owned LWS with the same name", func(t *testing.T) {
+		foreignDS := testManagerDS("some-other-ds")
+		foreignLWS := buildOwnedManagerTestLWS("test-lws", 3, foreignDS)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(foreignLWS).
+			Build()
+
+		manager := NewLeaderWorkerSetManager(fakeClient)
+		err := manager.Scale(context.Background(), ds, "test-lws", 5)
+		require.Error(t, err, "scaling a foreign-owned LWS must be refused")
+
+		var got leaderworkersetv1.LeaderWorkerSet
+		require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "test-lws"}, &got))
+		assert.EqualValues(t, 3, *got.Spec.Replicas, "the foreign LWS must not have been mutated")
 	})
 }
 
@@ -289,8 +341,18 @@ func TestManagerCreate(t *testing.T) {
 	require.NoError(t, leaderworkersetv1.AddToScheme(scheme))
 	require.NoError(t, disaggregatedsetv1.AddToScheme(scheme))
 
-	t.Run("returns nil when LWS already exists (idempotent)", func(t *testing.T) {
-		existingLWS := buildManagerTestLWS("test-deploy-0-abc123-prefill", 3, nil)
+	testDeploy := &disaggregatedsetv1.DisaggregatedSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+
+	t.Run("returns nil when LWS already exists and is owned by this DS (idempotent)", func(t *testing.T) {
+		// Represents a concurrent reconcile of this same DisaggregatedSet
+		// having already created it.
+		existingLWS := buildOwnedManagerTestLWS("test-deploy-0-abc123-prefill", 3, testDeploy)
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -299,16 +361,10 @@ func TestManagerCreate(t *testing.T) {
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
 		params := disaggregatedsetutils.CreateParams{
-			DisaggregatedSet: &disaggregatedsetv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-deploy",
-					Namespace: "default",
-					UID:       "test-uid",
-				},
-			},
-			Role:     "prefill",
-			Revision: "abc123",
-			Replicas: 3,
+			DisaggregatedSet: testDeploy,
+			Role:             "prefill",
+			Revision:         "abc123",
+			Replicas:         3,
 			Labels: map[string]string{
 				disaggregatedsetv1.SetNameLabelKey:  "test-deploy",
 				disaggregatedsetv1.RoleLabelKey:     "prefill",
@@ -325,6 +381,45 @@ func TestManagerCreate(t *testing.T) {
 
 		err := manager.Create(context.Background(), params)
 		require.NoError(t, err) // Should not error, creation is idempotent
+	})
+
+	// Regression test for #981 (Copilot review on #983): a same-named LWS that
+	// exists but is owned by a different DisaggregatedSet must not be silently
+	// treated as "already created" — this DS's owned-object watches will never
+	// fire for a foreign object, so silently returning nil here could leave the
+	// role permanently missing an LWS. Create must error so the reconcile
+	// requeues instead.
+	t.Run("errors when the name is taken by a foreign-owned LWS", func(t *testing.T) {
+		foreignDS := testManagerDS("some-other-ds")
+		foreignLWS := buildOwnedManagerTestLWS("test-deploy-0-abc123-prefill", 3, foreignDS)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(foreignLWS).
+			Build()
+
+		manager := NewLeaderWorkerSetManager(fakeClient)
+		params := disaggregatedsetutils.CreateParams{
+			DisaggregatedSet: testDeploy,
+			Role:             "prefill",
+			Revision:         "abc123",
+			Replicas:         3,
+			Labels: map[string]string{
+				disaggregatedsetv1.SetNameLabelKey:  "test-deploy",
+				disaggregatedsetv1.RoleLabelKey:     "prefill",
+				disaggregatedsetv1.RevisionLabelKey: "abc123",
+			},
+			Config: &disaggregatedsetv1.DisaggregatedRoleSpec{
+				LeaderWorkerSetTemplateSpec: leaderworkersetv1.LeaderWorkerSetTemplateSpec{Spec: leaderworkersetv1.LeaderWorkerSetSpec{
+					LeaderWorkerTemplate: leaderworkersetv1.LeaderWorkerTemplate{
+						Size: ptr.To(int32(1)),
+					},
+				}},
+			},
+		}
+
+		err := manager.Create(context.Background(), params)
+		require.Error(t, err, "must not silently no-op when the name is taken by a foreign-owned LWS")
 	})
 
 	t.Run("successfully creates new LWS", func(t *testing.T) {
@@ -679,5 +774,59 @@ func TestManagerListSliceBucketing(t *testing.T) {
 		got, err := manager.List(context.Background(), ds, -1, "")
 		require.NoError(t, err)
 		require.ElementsMatch(t, []string{"s0", "s1", "legacy"}, names(got))
+	})
+}
+
+// TestManagerGetForRoleIgnoresForeignOwnedLWS is a regression test for #981:
+// GetForRole must treat a same-named LWS occupying either the slice-aware or
+// the legacy name as absent when it's owned by a different DisaggregatedSet
+// (e.g. left over from a same-named DisaggregatedSet that was deleted and
+// recreated before GC ran), rather than returning it for the caller to scale.
+func TestManagerGetForRoleIgnoresForeignOwnedLWS(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, leaderworkersetv1.AddToScheme(scheme))
+
+	ds := testManagerDS("test-deployment")
+	foreignDS := testManagerDS("some-other-ds")
+	const revision, role = "abc123", "prefill"
+
+	t.Run("slice-aware name occupied by a foreign LWS reads as absent", func(t *testing.T) {
+		slice := 0
+		name := disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role)
+		foreignLWS := buildOwnedManagerTestLWS(name, 3, foreignDS)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(foreignLWS).Build()
+		manager := NewLeaderWorkerSetManager(fakeClient)
+
+		got, err := manager.GetForRole(context.Background(), ds, slice, revision, role)
+		require.NoError(t, err)
+		assert.Nil(t, got, "a foreign-owned LWS at the generated name must not be returned")
+	})
+
+	t.Run("legacy name occupied by a foreign LWS reads as absent", func(t *testing.T) {
+		slice := 0
+		legacyName := disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role)
+		foreignLWS := buildOwnedManagerTestLWS(legacyName, 3, foreignDS)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(foreignLWS).Build()
+		manager := NewLeaderWorkerSetManager(fakeClient)
+
+		got, err := manager.GetForRole(context.Background(), ds, slice, revision, role)
+		require.NoError(t, err)
+		assert.Nil(t, got, "a foreign-owned LWS at the legacy name must not be returned")
+	})
+
+	t.Run("owned LWS at the generated name is still returned normally", func(t *testing.T) {
+		slice := 0
+		name := disaggregatedsetutils.GenerateName(ds.Name, slice, revision, role)
+		ownedLWS := buildOwnedManagerTestLWS(name, 3, ds)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ownedLWS).Build()
+		manager := NewLeaderWorkerSetManager(fakeClient)
+
+		got, err := manager.GetForRole(context.Background(), ds, slice, revision, role)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, name, got.Name)
 	})
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it

Fixes #981, raised by @yankay during review of #933.

`LeaderWorkerSetManager.GetForRole` and `Scale` looked up an LWS by its generated name only, with no check that the found object is actually controller-owned by the `DisaggregatedSet` calling them. During rapid same-name recreation — a `DisaggregatedSet` named `foo` is deleted and a new one also named `foo` is created before garbage collection removes the old one's LWS objects — the new controller's `reconcileRoleSimple` could find and then `Scale` the *old* `foo`'s still-present LWS, mutating an object it doesn't own. This is the same class of bug #933 fixed for `List` via `metav1.IsControlledBy`; `GetForRole`/`Scale` are a separate code path that fix didn't cover.

While fixing this I found the identical gap in `recreateLegacySlice0`: it fetched a legacy-named LWS by a raw `Get` with no ownership check before deleting it to make way for the slice-aware migration — same root cause, different call site, so I fixed it too rather than leaving an equally real instance of the same bug next to the one the issue names.

#### What changed

- Added `LeaderWorkerSetManager.getOwned`, an ownership-filtered wrapper around `Get` (mirrors `List`'s existing filtering). `GetForRole` now uses it for both the slice-aware and legacy-name lookups; a foreign-owned LWS at either name is treated as absent rather than returned for the caller to mutate.
- `Scale` now takes the `DisaggregatedSet` (instead of a bare namespace) and refuses to patch a same-named LWS that isn't controller-owned by it, returning an error instead of silently mutating a foreign object. Updated all three call sites (`reconcileRoleSimple`, `scaleUpNew`, and the scale-down path in `executor.go`).
- `recreateLegacySlice0` uses `getOwned` instead of a raw `Get` before deleting a legacy-named LWS.

#### Which issue(s) this PR fixes
Fixes #981

#### Special notes for your reviewer

- Test fixtures across `lws_manager_test.go` and `executor_test.go` that built LWS objects without a matching controller `OwnerReference` needed updating to carry one (matching what the real `Create()` path already always sets), since `Scale`'s new ownership check depends on it. I found these by running the full suite after the change and fixing whatever broke — none of the fixture changes reflect a behavior change, only making the fixtures match what production objects actually look like.
- Added regression tests: `GetForRole`/`Scale`/`recreateLegacySlice0` each ignore a same-named LWS owned by a different `DisaggregatedSet`, and normal operation is unaffected when ownership is intact.
- No API surface change, no CRD/docs regen needed.

#### Does this PR introduce a user-facing change?
```release-note
DisaggregatedSet: GetForRole, Scale, and the legacy slice-0 migration path now verify controller ownership before reading or mutating a same-named LeaderWorkerSet, closing a rare race where a rapidly recreated DisaggregatedSet could mutate a still-draining LWS left over from a previous DisaggregatedSet of the same name.
```
