### PR TITLE
[feat] Add groupIdentity Hash mode with Deployment managed leaders

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -109,11 +109,9 @@ const (
 	// can tell the identity scheme apart without fetching the LWS object.
 	GroupIdentityAnnotationKey string = "leaderworkerset.sigs.k8s.io/group-identity"
 
-	// LeaderAddressAnnotationKey carries the leader address on worker pods when
-	// GroupIdentity=Hash: the leader's DNS name derived from the group key, or the
-	// leader pod IP for groups admitted before hostnames were assigned. The address
-	// only needs to be stable for one group generation because the whole group is
-	// recreated together.
+	// LeaderAddressAnnotationKey carries the leader's DNS address on worker pods
+	// in both group identity modes, so that pod admission can inject
+	// LWS_LEADER_ADDRESS without recomputing it.
 	LeaderAddressAnnotationKey string = "leaderworkerset.sigs.k8s.io/leader-address"
 )
 

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -304,11 +304,17 @@ const (
 	// will share. The host names look like:
 	// Replica 0: my-lws-0.my-lws, my-lws-0-1.my-lws
 	// Replica 1: my-lws-1.my-lws, my-lws-1-1.my-lws
+	// With groupIdentity Hash, the leader host name is an 8 character prefix of
+	// the group key and worker host names extend the leader pod name:
+	// Group a1b2c3d4...: a1b2c3d4.my-lws, my-lws-7d9f8b6c4-x2kkp-1.my-lws
 	SubdomainShared SubdomainPolicy = "Shared"
 	// UniquePerReplica will create a headless service per replica
 	// The pod host names look like:
 	// Replica 0: my-lws-0.my-lws-0,my-lws-0-1.my-lws-0, my-lws-0-2.my-lws-0
 	// Replica 1: my-lws-1.my-lws-1,my-lws-1-1.my-lws-1, my-lws-1-2.my-lws-1
+	// With groupIdentity Hash, the per replica service is named with the group
+	// key prefix instead of the replica ordinal:
+	// Group a1b2c3d4...: a1b2c3d4.my-lws-a1b2c3d4, my-lws-7d9f8b6c4-x2kkp-1.my-lws-a1b2c3d4
 	SubdomainUniquePerReplica SubdomainPolicy = "UniquePerReplica"
 )
 

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -103,7 +103,24 @@ const (
 	// Enables feature where the group will be restarted after pod failure if and only if
 	// all pods in the group are not pending
 	RecreateGroupAfterStartAnnotationKey string = "leaderworkerset.sigs.k8s.io/experimental-recreate-group-after-start"
+
+	// GroupIdentityAnnotationKey is set on leader and worker pod templates when the
+	// LeaderWorkerSet runs with GroupIdentity=Hash so that admission and controllers
+	// can tell the identity scheme apart without fetching the LWS object.
+	GroupIdentityAnnotationKey string = "leaderworkerset.sigs.k8s.io/group-identity"
+
+	// LeaderAddressAnnotationKey carries the leader address (pod IP) on worker pods
+	// when GroupIdentity=Hash. With hash-named leaders there is no per-pod DNS record,
+	// and the address only needs to be stable for one group generation because the
+	// whole group is recreated together.
+	LeaderAddressAnnotationKey string = "leaderworkerset.sigs.k8s.io/leader-address"
 )
+
+// GroupReadyConditionType is the pod readiness gate condition set on leader pods when
+// GroupIdentity=Hash. The pod controller marks it True once the group's worker
+// statefulset is ready, which makes Deployment rollout pacing count whole groups
+// instead of bare leader pods.
+const GroupReadyConditionType corev1.PodConditionType = "leaderworkerset.sigs.k8s.io/group-ready"
 
 // One group consists of a single leader and M workers, and the total number of pods in a group is M+1.
 // LeaderWorkerSet will create N replicas of leader-worker pod groups (hereinafter referred to as group).
@@ -147,7 +164,31 @@ type LeaderWorkerSetSpec struct {
 	// networkConfig defines the network configuration of the group
 	// +optional
 	NetworkConfig *NetworkConfig `json:"networkConfig,omitempty"`
+
+	// groupIdentity determines how group identities are assigned.
+	// Ordinal (default) manages leaders through a StatefulSet: groups are named
+	// <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+	// Hash manages leaders through a Deployment: group names are hash-suffixed,
+	// scale down prefers unscheduled and not-ready groups over healthy ones, and
+	// rollouts are paced by a group readiness gate on the leader pods.
+	// This field is immutable.
+	// +kubebuilder:default=Ordinal
+	// +kubebuilder:validation:Enum={Ordinal,Hash}
+	// +optional
+	GroupIdentity GroupIdentityType `json:"groupIdentity,omitempty"`
 }
+
+// GroupIdentityType defines how group identities are assigned.
+type GroupIdentityType string
+
+const (
+	// GroupIdentityOrdinal names groups by contiguous StatefulSet ordinals.
+	GroupIdentityOrdinal GroupIdentityType = "Ordinal"
+
+	// GroupIdentityHash names groups by hash-suffixed leader pod names managed
+	// through a Deployment.
+	GroupIdentityHash GroupIdentityType = "Hash"
+)
 
 // Template of the leader/worker pods, the group will include at least one leader pod.
 // Defaults to the worker template if not specified. The idea is to allow users to create a

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -304,17 +304,18 @@ const (
 	// will share. The host names look like:
 	// Replica 0: my-lws-0.my-lws, my-lws-0-1.my-lws
 	// Replica 1: my-lws-1.my-lws, my-lws-1-1.my-lws
-	// With groupIdentity Hash, the leader host name is an 8 character prefix of
-	// the group key and worker host names extend the leader pod name:
-	// Group a1b2c3d4...: a1b2c3d4.my-lws, my-lws-7d9f8b6c4-x2kkp-1.my-lws
+	// With groupIdentity Hash, the leader host name is the lws name plus an 8
+	// character prefix of the group key and worker host names extend the leader
+	// pod name:
+	// Group a1b2c3d4...: my-lws-a1b2c3d4.my-lws, my-lws-7d9f8b6c4-x2kkp-1.my-lws
 	SubdomainShared SubdomainPolicy = "Shared"
 	// UniquePerReplica will create a headless service per replica
 	// The pod host names look like:
 	// Replica 0: my-lws-0.my-lws-0,my-lws-0-1.my-lws-0, my-lws-0-2.my-lws-0
 	// Replica 1: my-lws-1.my-lws-1,my-lws-1-1.my-lws-1, my-lws-1-2.my-lws-1
-	// With groupIdentity Hash, the per replica service is named with the group
-	// key prefix instead of the replica ordinal:
-	// Group a1b2c3d4...: a1b2c3d4.my-lws-a1b2c3d4, my-lws-7d9f8b6c4-x2kkp-1.my-lws-a1b2c3d4
+	// With groupIdentity Hash, the per replica service name matches the leader
+	// host name:
+	// Group a1b2c3d4...: my-lws-a1b2c3d4.my-lws-a1b2c3d4, my-lws-7d9f8b6c4-x2kkp-1.my-lws-a1b2c3d4
 	SubdomainUniquePerReplica SubdomainPolicy = "UniquePerReplica"
 )
 

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -109,10 +109,11 @@ const (
 	// can tell the identity scheme apart without fetching the LWS object.
 	GroupIdentityAnnotationKey string = "leaderworkerset.sigs.k8s.io/group-identity"
 
-	// LeaderAddressAnnotationKey carries the leader address (pod IP) on worker pods
-	// when GroupIdentity=Hash. With hash-named leaders there is no per-pod DNS record,
-	// and the address only needs to be stable for one group generation because the
-	// whole group is recreated together.
+	// LeaderAddressAnnotationKey carries the leader address on worker pods when
+	// GroupIdentity=Hash: the leader's DNS name derived from the group key, or the
+	// leader pod IP for groups admitted before hostnames were assigned. The address
+	// only needs to be stable for one group generation because the whole group is
+	// recreated together.
 	LeaderAddressAnnotationKey string = "leaderworkerset.sigs.k8s.io/leader-address"
 )
 

--- a/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -119,6 +119,20 @@ spec:
                       spec:
                         description: spec defines the behavior of an LWS.
                         properties:
+                          groupIdentity:
+                            default: Ordinal
+                            description: |-
+                              groupIdentity determines how group identities are assigned.
+                              Ordinal (default) manages leaders through a StatefulSet: groups are named
+                              <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+                              Hash manages leaders through a Deployment: group names are hash-suffixed,
+                              scale down prefers unscheduled and not-ready groups over healthy ones, and
+                              rollouts are paced by a group readiness gate on the leader pods.
+                              This field is immutable.
+                            enum:
+                              - Ordinal
+                              - Hash
+                            type: string
                           leaderWorkerTemplate:
                             description: leaderWorkerTemplate defines the template for leader/worker pods
                             properties:

--- a/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -69,6 +69,20 @@ spec:
             spec:
               description: spec defines the desired behavior of LeaderWorkerSet.
               properties:
+                groupIdentity:
+                  default: Ordinal
+                  description: |-
+                    groupIdentity determines how group identities are assigned.
+                    Ordinal (default) manages leaders through a StatefulSet: groups are named
+                    <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+                    Hash manages leaders through a Deployment: group names are hash-suffixed,
+                    scale down prefers unscheduled and not-ready groups over healthy ones, and
+                    rollouts are paced by a group readiness gate on the leader pods.
+                    This field is immutable.
+                  enum:
+                    - Ordinal
+                    - Hash
+                  type: string
                 leaderWorkerTemplate:
                   description: leaderWorkerTemplate defines the template for leader/worker pods
                   properties:

--- a/charts/lws/templates/rbac/clusterrole.yaml
+++ b/charts/lws/templates/rbac/clusterrole.yaml
@@ -58,6 +58,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get
@@ -78,6 +86,7 @@ rules:
       - apps
     resources:
       - controllerrevisions
+      - deployments
       - statefulsets
     verbs:
       - create
@@ -98,6 +107,7 @@ rules:
       - apps
     resources:
       - controllerrevisions/status
+      - deployments/status
       - statefulsets/status
     verbs:
       - get

--- a/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetspec.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/leaderworkersetspec.go
@@ -52,6 +52,14 @@ type LeaderWorkerSetSpecApplyConfiguration struct {
 	StartupPolicy *leaderworkersetv1.StartupPolicyType `json:"startupPolicy,omitempty"`
 	// networkConfig defines the network configuration of the group
 	NetworkConfig *NetworkConfigApplyConfiguration `json:"networkConfig,omitempty"`
+	// groupIdentity determines how group identities are assigned.
+	// Ordinal (default) manages leaders through a StatefulSet: groups are named
+	// <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+	// Hash manages leaders through a Deployment: group names are hash-suffixed,
+	// scale down prefers unscheduled and not-ready groups over healthy ones, and
+	// rollouts are paced by a group readiness gate on the leader pods.
+	// This field is immutable.
+	GroupIdentity *leaderworkersetv1.GroupIdentityType `json:"groupIdentity,omitempty"`
 }
 
 // LeaderWorkerSetSpecApplyConfiguration constructs a declarative configuration of the LeaderWorkerSetSpec type for use with
@@ -97,5 +105,13 @@ func (b *LeaderWorkerSetSpecApplyConfiguration) WithStartupPolicy(value leaderwo
 // If called multiple times, the NetworkConfig field is set to the value of the last call.
 func (b *LeaderWorkerSetSpecApplyConfiguration) WithNetworkConfig(value *NetworkConfigApplyConfiguration) *LeaderWorkerSetSpecApplyConfiguration {
 	b.NetworkConfig = value
+	return b
+}
+
+// WithGroupIdentity sets the GroupIdentity field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the GroupIdentity field is set to the value of the last call.
+func (b *LeaderWorkerSetSpecApplyConfiguration) WithGroupIdentity(value leaderworkersetv1.GroupIdentityType) *LeaderWorkerSetSpecApplyConfiguration {
+	b.GroupIdentity = &value
 	return b
 }

--- a/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -118,6 +118,20 @@ spec:
                     spec:
                       description: spec defines the behavior of an LWS.
                       properties:
+                        groupIdentity:
+                          default: Ordinal
+                          description: |-
+                            groupIdentity determines how group identities are assigned.
+                            Ordinal (default) manages leaders through a StatefulSet: groups are named
+                            <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+                            Hash manages leaders through a Deployment: group names are hash-suffixed,
+                            scale down prefers unscheduled and not-ready groups over healthy ones, and
+                            rollouts are paced by a group readiness gate on the leader pods.
+                            This field is immutable.
+                          enum:
+                          - Ordinal
+                          - Hash
+                          type: string
                         leaderWorkerTemplate:
                           description: leaderWorkerTemplate defines the template for
                             leader/worker pods

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -57,6 +57,20 @@ spec:
           spec:
             description: spec defines the desired behavior of LeaderWorkerSet.
             properties:
+              groupIdentity:
+                default: Ordinal
+                description: |-
+                  groupIdentity determines how group identities are assigned.
+                  Ordinal (default) manages leaders through a StatefulSet: groups are named
+                  <lws>-0..<lws>-N-1 and scale down always removes the highest ordinal.
+                  Hash manages leaders through a Deployment: group names are hash-suffixed,
+                  scale down prefers unscheduled and not-ready groups over healthy ones, and
+                  rollouts are paced by a group readiness gate on the leader pods.
+                  This field is immutable.
+                enum:
+                - Ordinal
+                - Hash
+                type: string
               leaderWorkerTemplate:
                 description: leaderWorkerTemplate defines the template for leader/worker
                   pods

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
@@ -78,6 +86,7 @@ rules:
   - apps
   resources:
   - controllerrevisions
+  - deployments
   - statefulsets
   verbs:
   - create
@@ -98,6 +107,7 @@ rules:
   - apps
   resources:
   - controllerrevisions/status
+  - deployments/status
   - statefulsets/status
   verbs:
   - get

--- a/keps/898-group-identity/README.md
+++ b/keps/898-group-identity/README.md
@@ -66,7 +66,7 @@ The ordinal system makes it impossible to remove or relocate one specific group.
 
 Add `spec.groupIdentity` with values `Ordinal` and `Hash`, defaulted to `Ordinal` by the webhook and immutable after creation.
 
-In hash mode the controller manages leader pods through a Deployment named after the LeaderWorkerSet. Each new leader pod is assigned a random 40 character group key at admission, stored in both the `group-index` and `group-key` labels. The webhook also sets the leader's hostname to an 8 character prefix of the group key, while the Deployment template sets its subdomain to the LeaderWorkerSet headless service, giving each leader a DNS name for its lifetime. The per-group worker StatefulSet is named after its leader pod, and workers reach their leader through that DNS name in the `LWS_LEADER_ADDRESS` environment variable, the same form as ordinal mode.
+In hash mode the controller manages leader pods through a Deployment named after the LeaderWorkerSet. Each new leader pod is assigned a random 40 character group key at admission, stored in both the `group-index` and `group-key` labels. The webhook also sets the leader's hostname to the LeaderWorkerSet name plus an 8 character prefix of the group key, while the Deployment template sets its subdomain to the LeaderWorkerSet headless service, giving each leader a DNS name for its lifetime. The per-group worker StatefulSet is named after its leader pod, and workers reach their leader through that DNS name in the `LWS_LEADER_ADDRESS` environment variable, the same form as ordinal mode.
 
 Scale down is delegated to the ReplicaSet, which deletes unscheduled and not-ready pods before healthy ones. Since a leader pod is only fully ready once its whole group is ready (via a readiness gate, described below), the ReplicaSet's ranking operates on group health.
 
@@ -133,7 +133,7 @@ Leader pods carry a `leaderworkerset.sigs.k8s.io/group-ready` readiness gate. Th
 
 The pod webhook assigns each new leader pod a group key, a SHA1 over the namespace and a random 16 character string. A random input is required because leader pods are created through `generateName`, so at mutating admission time the pod has no name or UID to derive a key from. The key is stored in both the `group-index` and `group-key` labels on the leader and inherited by its workers. Exclusive placement continues to key off `group-key` exactly as in ordinal mode.
 
-The webhook also sets the leader's `hostname` to an 8 character prefix of the group key, while the Deployment template sets its `subdomain` to the LeaderWorkerSet headless service, which gives each leader a per-pod DNS record under the service. The key is truncated because the full 40 characters would consume most of the 63 character service name budget. Under `subdomainPolicy: UniquePerReplica` the per-replica headless service is named from the LeaderWorkerSet name plus the same prefix, since Service names must begin with a letter and the raw key cannot be used as a name.
+The webhook also sets the leader's `hostname` to the LeaderWorkerSet name plus an 8 character prefix of the group key, while the Deployment template sets its `subdomain` to the LeaderWorkerSet headless service, which gives each leader a per-pod DNS record under the service. The key is truncated because the full 40 characters would consume most of the 63 character service name budget. Under `subdomainPolicy: UniquePerReplica` the per-replica headless service name matches the leader host name.
 
 ### Worker StatefulSets and Leader Address
 

--- a/keps/898-group-identity/README.md
+++ b/keps/898-group-identity/README.md
@@ -66,7 +66,7 @@ The ordinal system makes it impossible to remove or relocate one specific group.
 
 Add `spec.groupIdentity` with values `Ordinal` and `Hash`, defaulted to `Ordinal` by the webhook and immutable after creation.
 
-In hash mode the controller manages leader pods through a Deployment named after the LeaderWorkerSet. Each new leader pod is assigned a random 40 character group key at admission, stored in both the `group-index` and `group-key` labels. The webhook also sets the leader's hostname to an 8 character prefix of the group key and its subdomain to the LeaderWorkerSet headless service, giving each leader a DNS name for its lifetime. The per-group worker StatefulSet is named after its leader pod, and workers reach their leader through that DNS name in the `LWS_LEADER_ADDRESS` environment variable, the same form as ordinal mode.
+In hash mode the controller manages leader pods through a Deployment named after the LeaderWorkerSet. Each new leader pod is assigned a random 40 character group key at admission, stored in both the `group-index` and `group-key` labels. The webhook also sets the leader's hostname to an 8 character prefix of the group key, while the Deployment template sets its subdomain to the LeaderWorkerSet headless service, giving each leader a DNS name for its lifetime. The per-group worker StatefulSet is named after its leader pod, and workers reach their leader through that DNS name in the `LWS_LEADER_ADDRESS` environment variable, the same form as ordinal mode.
 
 Scale down is delegated to the ReplicaSet, which deletes unscheduled and not-ready pods before healthy ones. Since a leader pod is only fully ready once its whole group is ready (via a readiness gate, described below), the ReplicaSet's ranking operates on group health.
 
@@ -133,7 +133,7 @@ Leader pods carry a `leaderworkerset.sigs.k8s.io/group-ready` readiness gate. Th
 
 The pod webhook assigns each new leader pod a group key, a SHA1 over the namespace and a random 16 character string. A random input is required because leader pods are created through `generateName`, so at mutating admission time the pod has no name or UID to derive a key from. The key is stored in both the `group-index` and `group-key` labels on the leader and inherited by its workers. Exclusive placement continues to key off `group-key` exactly as in ordinal mode.
 
-The webhook also sets the leader's `hostname` to an 8 character prefix of the group key and its `subdomain` to the LeaderWorkerSet headless service, which gives each leader a per-pod DNS record under the service. The key is truncated because the full 40 characters would consume most of the 63 character service name budget. Under `subdomainPolicy: UniquePerReplica` the per-replica headless service is named from the LeaderWorkerSet name plus the same prefix, since Service names must begin with a letter and the raw key cannot be used as a name.
+The webhook also sets the leader's `hostname` to an 8 character prefix of the group key, while the Deployment template sets its `subdomain` to the LeaderWorkerSet headless service, which gives each leader a per-pod DNS record under the service. The key is truncated because the full 40 characters would consume most of the 63 character service name budget. Under `subdomainPolicy: UniquePerReplica` the per-replica headless service is named from the LeaderWorkerSet name plus the same prefix, since Service names must begin with a letter and the raw key cannot be used as a name.
 
 ### Worker StatefulSets and Leader Address
 

--- a/pkg/controllers/disaggregatedset/lws_manager_test.go
+++ b/pkg/controllers/disaggregatedset/lws_manager_test.go
@@ -866,7 +866,7 @@ func TestManagerCreateGroupIdentityPassthrough(t *testing.T) {
 	require.NoError(t, manager.Create(context.Background(), params))
 
 	lwsName := disaggregatedsetutils.GenerateName("test-deploy", params.Slice, "abc123", "prefill")
-	lws, err := manager.Get(context.Background(), "default", lwsName)
+	lws, err := manager.Get(context.Background(), params.DisaggregatedSet, lwsName)
 	require.NoError(t, err)
 	require.NotNil(t, lws)
 	require.Equal(t, leaderworkersetv1.GroupIdentityHash, lws.Spec.GroupIdentity)

--- a/pkg/controllers/disaggregatedset/lws_manager_test.go
+++ b/pkg/controllers/disaggregatedset/lws_manager_test.go
@@ -828,3 +828,76 @@ func TestManagerGetForRoleIgnoresForeignOwnedLWS(t *testing.T) {
 		assert.Equal(t, name, got.Name)
 	})
 }
+
+func TestManagerCreateGroupIdentityPassthrough(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, leaderworkersetv1.AddToScheme(scheme))
+	require.NoError(t, disaggregatedsetv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	manager := NewLeaderWorkerSetManager(fakeClient)
+
+	params := disaggregatedsetutils.CreateParams{
+		DisaggregatedSet: &disaggregatedsetv1.DisaggregatedSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deploy",
+				Namespace: "default",
+				UID:       "test-uid",
+			},
+		},
+		Role:     "prefill",
+		Revision: "abc123",
+		Replicas: 2,
+		Labels: map[string]string{
+			disaggregatedsetv1.SetNameLabelKey:  "test-deploy",
+			disaggregatedsetv1.RoleLabelKey:     "prefill",
+			disaggregatedsetv1.RevisionLabelKey: "abc123",
+		},
+		Config: &disaggregatedsetv1.DisaggregatedRoleSpec{
+			LeaderWorkerSetTemplateSpec: leaderworkersetv1.LeaderWorkerSetTemplateSpec{Spec: leaderworkersetv1.LeaderWorkerSetSpec{
+				GroupIdentity: leaderworkersetv1.GroupIdentityHash,
+				LeaderWorkerTemplate: leaderworkersetv1.LeaderWorkerTemplate{
+					Size: ptr.To(int32(2)),
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, manager.Create(context.Background(), params))
+
+	lwsName := disaggregatedsetutils.GenerateName("test-deploy", params.Slice, "abc123", "prefill")
+	lws, err := manager.Get(context.Background(), "default", lwsName)
+	require.NoError(t, err)
+	require.NotNil(t, lws)
+	require.Equal(t, leaderworkersetv1.GroupIdentityHash, lws.Spec.GroupIdentity)
+}
+
+func TestComputeRevisionGroupIdentity(t *testing.T) {
+	buildRoles := func(groupIdentity leaderworkersetv1.GroupIdentityType) []disaggregatedsetv1.DisaggregatedRoleSpec {
+		return []disaggregatedsetv1.DisaggregatedRoleSpec{
+			{
+				Name: "prefill",
+				LeaderWorkerSetTemplateSpec: leaderworkersetv1.LeaderWorkerSetTemplateSpec{Spec: leaderworkersetv1.LeaderWorkerSetSpec{
+					GroupIdentity: groupIdentity,
+					LeaderWorkerTemplate: leaderworkersetv1.LeaderWorkerTemplate{
+						Size: ptr.To(int32(1)),
+					},
+				}},
+			},
+		}
+	}
+
+	t.Run("empty and explicit Ordinal produce the same revision", func(t *testing.T) {
+		// Objects persisted before the field existed must keep their revision
+		// once the API server starts defaulting groupIdentity to Ordinal.
+		require.Equal(t,
+			disaggregatedsetutils.ComputeRevision(buildRoles("")),
+			disaggregatedsetutils.ComputeRevision(buildRoles(leaderworkersetv1.GroupIdentityOrdinal)))
+	})
+
+	t.Run("Hash produces a different revision", func(t *testing.T) {
+		require.NotEqual(t,
+			disaggregatedsetutils.ComputeRevision(buildRoles(leaderworkersetv1.GroupIdentityOrdinal)),
+			disaggregatedsetutils.ComputeRevision(buildRoles(leaderworkersetv1.GroupIdentityHash)))
+	})
+}

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -103,6 +103,8 @@ func NewLeaderWorkerSetReconciler(client client.Client, scheme *runtime.Scheme, 
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=controllerrevisions/status,verbs=get;update;patch
@@ -121,6 +123,10 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	log := ctrl.LoggerFrom(ctx).WithValues("leaderworkerset", klog.KObj(lws))
 	ctx = ctrl.LoggerInto(ctx, log)
+
+	if lws.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash {
+		return r.reconcileHash(ctx, lws)
+	}
 
 	leaderSts, err := r.getLeaderStatefulSet(ctx, lws)
 	if err != nil {
@@ -225,6 +231,7 @@ func (r *LeaderWorkerSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&leaderworkerset.LeaderWorkerSet{}).
 		Owns(&appsv1.StatefulSet{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Watches(&appsv1.StatefulSet{},
 			handler.EnqueueRequestsFromMapFunc(enqueueLWSRequests)).

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -153,10 +153,13 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	updatedRevision, err := r.getUpdatedRevision(ctx, leaderSts != nil, lws, revision)
-	if err != nil {
-		log.Error(err, "Validating if LWS has been updated")
-		return ctrl.Result{}, err
+	var updatedRevision *appsv1.ControllerRevision
+	if leaderSts != nil {
+		updatedRevision, err = r.getUpdatedRevision(ctx, lws, revision)
+		if err != nil {
+			log.Error(err, "Validating if LWS has been updated")
+			return ctrl.Result{}, err
+		}
 	}
 	lwsUpdated := updatedRevision != nil
 	if lwsUpdated {
@@ -768,11 +771,7 @@ func (r *LeaderWorkerSetReconciler) getOrCreateRevision(ctx context.Context, rev
 	return newRevision, err
 }
 
-func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, leaderExists bool, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
-	if !leaderExists {
-		return nil, nil
-	}
-
+func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
 	currentRevision, err := revisionutils.NewRevision(ctx, r.Client, lws, "")
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -141,13 +141,19 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Handles two cases:
 	// Case 1: Upgrading the LWS controller from a version that doesn't support controller revision
 	// Case 2: Creating the controller revision for a newly created LWS object
-	revision, err := r.getOrCreateRevisionIfNonExist(ctx, leaderSts, lws, r.Record)
+	revisionKey := ""
+	if leaderSts != nil {
+		// Uses the hash in the leader sts to avoid detecting update in the case where LWS controller is upgraded from a version where
+		// the revisionKey was used to detect update instead of controller revision.
+		revisionKey = revisionutils.GetRevisionKey(leaderSts)
+	}
+	revision, err := r.getOrCreateRevision(ctx, revisionKey, lws)
 	if err != nil {
 		log.Error(err, "Creating controller revision")
 		return ctrl.Result{}, err
 	}
 
-	updatedRevision, err := r.getUpdatedRevision(ctx, leaderSts, lws, revision)
+	updatedRevision, err := r.getUpdatedRevision(ctx, leaderSts != nil, lws, revision)
 	if err != nil {
 		log.Error(err, "Validating if LWS has been updated")
 		return ctrl.Result{}, err
@@ -398,29 +404,28 @@ func (r *LeaderWorkerSetReconciler) SSAWithStatefulset(ctx context.Context, lws 
 		log.Error(err, "Setting controller reference.")
 		return err
 	}
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(leaderStatefulSetApplyConfig)
-	if err != nil {
-		log.Error(err, "Converting StatefulSet configuration to json.")
-		return err
-	}
-	patch := &unstructured.Unstructured{
-		Object: obj,
-	}
-	// Use server side apply and add fieldmanager to the lws owned fields
-	// If there are conflicts in the fields owned by the lws controller, lws will obtain the ownership and force override
-	// these fields to the ones desired by the lws controller
-	// TODO b/316776287 add E2E test for SSA
-	// TODO: Deprecated: Use client.Client.Apply() and client.Client.SubResource("subrsource").Apply() instead.
-	err = r.Patch(ctx, patch, client.Apply, &client.PatchOptions{ //nolint
-		FieldManager: fieldManager,
-		Force:        ptr.To[bool](true),
-	})
-	if err != nil {
+	if err := r.serverSideApply(ctx, leaderStatefulSetApplyConfig); err != nil {
 		log.Error(err, "Using server side apply to update leader statefulset")
 		return err
 	}
 
 	return nil
+}
+
+// serverSideApply applies the configuration with the lws field manager. If there
+// are conflicts in the fields owned by the lws controller, lws obtains the
+// ownership and force overrides them to the desired values.
+// TODO b/316776287 add E2E test for SSA
+// TODO: Deprecated: Use client.Client.Apply() and client.Client.SubResource("subrsource").Apply() instead.
+func (r *LeaderWorkerSetReconciler) serverSideApply(ctx context.Context, applyConfig any) error {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(applyConfig)
+	if err != nil {
+		return err
+	}
+	return r.Patch(ctx, &unstructured.Unstructured{Object: obj}, client.Apply, &client.PatchOptions{ //nolint
+		FieldManager: fieldManager,
+		Force:        ptr.To[bool](true),
+	})
 }
 
 // updates the condition of the leaderworkerset to either Progressing or Available.
@@ -545,22 +550,12 @@ func (r *LeaderWorkerSetReconciler) updateStatus(ctx context.Context, lws *leade
 		updateStatus = true
 	}
 
-	if lws.Status.HPAPodSelector == "" {
-		labelSelector := &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				leaderworkerset.SetNameLabelKey:     lws.Name,
-				leaderworkerset.WorkerIndexLabelKey: "0", // select leaders
-			},
-		}
-		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-		if err != nil {
-			log.Error(err, "Converting label selector to selector")
-			return false, err
-		}
-
-		lws.Status.HPAPodSelector = selector.String()
-		updateStatus = true
+	selectorUpdated, err := ensureHPAPodSelector(lws)
+	if err != nil {
+		log.Error(err, "Converting label selector to selector")
+		return false, err
 	}
+	updateStatus = updateStatus || selectorUpdated
 
 	// check if an update is needed
 	updateConditions, updateDone, err := r.updateConditions(ctx, lws, revisionKey)
@@ -577,6 +572,26 @@ func (r *LeaderWorkerSetReconciler) updateStatus(ctx context.Context, lws *leade
 		}
 	}
 	return updateDone, nil
+}
+
+// ensureHPAPodSelector sets the leader pod selector on the status once. Returns
+// true when the status changed.
+func ensureHPAPodSelector(lws *leaderworkerset.LeaderWorkerSet) (bool, error) {
+	if lws.Status.HPAPodSelector != "" {
+		return false, nil
+	}
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			leaderworkerset.SetNameLabelKey:     lws.Name,
+			leaderworkerset.WorkerIndexLabelKey: "0", // select leaders
+		},
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return false, err
+	}
+	lws.Status.HPAPodSelector = selector.String()
+	return true, nil
 }
 
 type replicaState struct {
@@ -732,15 +747,11 @@ func (r *LeaderWorkerSetReconciler) getLeaderStatefulSet(ctx context.Context, lw
 	return sts, nil
 }
 
-func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Context, sts *appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet, recorder events.EventRecorder) (*appsv1.ControllerRevision, error) {
-	revisionKey := ""
-	if sts != nil {
-		// Uses the hash in the leader sts to avoid detecting update in the case where LWS controller is upgraded from a version where
-		// the revisionKey was used to detect update instead of controller revision.
-		revisionKey = revisionutils.GetRevisionKey(sts)
-	}
-	if stsRevision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); stsRevision != nil || err != nil {
-		return stsRevision, err
+// getOrCreateRevision returns the revision with the given key, creating it when
+// none exists. revisionKey is empty when the leader workload does not exist yet.
+func (r *LeaderWorkerSetReconciler) getOrCreateRevision(ctx context.Context, revisionKey string, lws *leaderworkerset.LeaderWorkerSet) (*appsv1.ControllerRevision, error) {
+	if existingRevision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); existingRevision != nil || err != nil {
+		return existingRevision, err
 	}
 	revision, err := revisionutils.NewRevision(ctx, r.Client, lws, revisionKey)
 	if err != nil {
@@ -752,13 +763,13 @@ func (r *LeaderWorkerSetReconciler) getOrCreateRevisionIfNonExist(ctx context.Co
 		if revisionKey != "" {
 			message = fmt.Sprintf("Creating missing revision with key %s for existing LeaderWorkerSet", revision.Labels[leaderworkerset.RevisionKey])
 		}
-		recorder.Eventf(lws, newRevision, corev1.EventTypeNormal, CreatingRevision, Create, message)
+		r.Record.Eventf(lws, newRevision, corev1.EventTypeNormal, CreatingRevision, Create, message)
 	}
 	return newRevision, err
 }
 
-func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, sts *appsv1.StatefulSet, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
-	if sts == nil {
+func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, leaderExists bool, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
+	if !leaderExists {
 		return nil, nil
 	}
 
@@ -778,15 +789,15 @@ func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, sts 
 	return nil, nil
 }
 
-// constructLeaderStatefulSetApplyConfiguration constructs the applied configuration for the leader StatefulSet
-func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWorkerSet, partition, replicas int32, revisionKey string) (*appsapplyv1.StatefulSetApplyConfiguration, error) {
+// buildLeaderPodTemplateApplyConfiguration constructs the leader pod template
+// shared by the leader statefulset and the leader deployment.
+func buildLeaderPodTemplateApplyConfiguration(lws *leaderworkerset.LeaderWorkerSet, revisionKey string) (*coreapplyv1.PodTemplateSpecApplyConfiguration, error) {
 	var podTemplateSpec corev1.PodTemplateSpec
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
 		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.LeaderTemplate.DeepCopy()
 	} else {
 		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.WorkerTemplate.DeepCopy()
 	}
-	// construct pod template spec configuration
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podTemplateSpec)
 	if err != nil {
 		return nil, err
@@ -822,6 +833,30 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 
 	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
 
+	return &podTemplateApplyConfiguration, nil
+}
+
+// leaderMetadata returns the labels and annotations for the leader workload
+// object, shared by the leader statefulset and the leader deployment.
+func leaderMetadata(lws *leaderworkerset.LeaderWorkerSet, revisionKey string) (map[string]string, map[string]string) {
+	labels := mergeMetadata(lws.Labels, map[string]string{
+		leaderworkerset.SetNameLabelKey: lws.Name,
+		leaderworkerset.RevisionKey:     revisionKey,
+		leaderworkerset.RoleLabelKey:    leaderworkerset.RoleLeader,
+	})
+	annotations := mergeMetadata(lws.Annotations, map[string]string{
+		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
+	})
+	return labels, annotations
+}
+
+// constructLeaderStatefulSetApplyConfiguration constructs the applied configuration for the leader StatefulSet
+func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWorkerSet, partition, replicas int32, revisionKey string) (*appsapplyv1.StatefulSetApplyConfiguration, error) {
+	podTemplateApplyConfiguration, err := buildLeaderPodTemplateApplyConfiguration(lws, revisionKey)
+	if err != nil {
+		return nil, err
+	}
+
 	lwsReplicas := int(*lws.Spec.Replicas)
 	lwsMaxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(&lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable, lwsReplicas, false)
 	if err != nil {
@@ -844,20 +879,13 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 	stsMaxUnavailable := intstr.FromInt32(stsMaxUnavailableInt)
 
 	// construct statefulset apply configuration
-	statefulSetLabels := mergeMetadata(lws.Labels, map[string]string{
-		leaderworkerset.SetNameLabelKey: lws.Name,
-		leaderworkerset.RevisionKey:     revisionKey,
-		leaderworkerset.RoleLabelKey:    leaderworkerset.RoleLeader,
-	})
-	statefulSetAnnotations := mergeMetadata(lws.Annotations, map[string]string{
-		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
-	})
+	statefulSetLabels, statefulSetAnnotations := leaderMetadata(lws, revisionKey)
 	statefulSetConfig := appsapplyv1.StatefulSet(lws.Name, lws.Namespace).
 		WithSpec(appsapplyv1.StatefulSetSpec().
 			WithServiceName(lws.Name).
 			WithReplicas(replicas).
 			WithPodManagementPolicy(appsv1.ParallelPodManagement).
-			WithTemplate(&podTemplateApplyConfiguration).
+			WithTemplate(podTemplateApplyConfiguration).
 			WithUpdateStrategy(appsapplyv1.StatefulSetUpdateStrategy().WithType(appsv1.StatefulSetUpdateStrategyType(lws.Spec.RolloutStrategy.Type)).WithRollingUpdate(
 				appsapplyv1.RollingUpdateStatefulSetStrategy().WithMaxUnavailable(stsMaxUnavailable).WithPartition(partition),
 			)).

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -1211,7 +1211,7 @@ func TestGetUpdatedRevision(t *testing.T) {
 				tc.modifyRevision(revision)
 			}
 
-			updatedRevision, err := reconciler.getUpdatedRevision(context.TODO(), tc.sts, tc.lws, revision)
+			updatedRevision, err := reconciler.getUpdatedRevision(context.TODO(), tc.sts != nil, tc.lws, revision)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -1149,31 +1149,18 @@ func TestGetUpdatedRevision(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		sts            *appsv1.StatefulSet
 		lws            *leaderworkerset.LeaderWorkerSet
 		modifyRevision func(*appsv1.ControllerRevision)
 		expectUpdate   bool
 	}{
 		{
-			name:         "sts is nil, should return nil",
-			sts:          nil,
-			lws:          wrappers.BuildLeaderWorkerSet("default").Obj(),
-			expectUpdate: false,
-		},
-		{
-			name: "revision matches current spec, no update",
-			sts: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
-			},
+			name:         "revision matches current spec, no update",
 			lws:          wrappers.BuildLeaderWorkerSet("default").Obj(),
 			expectUpdate: false,
 		},
 		{
 			name: "revision has old serialization with creationTimestamp null, semantic match, no update",
-			sts: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
-			},
-			lws: wrappers.BuildLeaderWorkerSet("default").Obj(),
+			lws:  wrappers.BuildLeaderWorkerSet("default").Obj(),
 			modifyRevision: func(rev *appsv1.ControllerRevision) {
 				// Simulate old (before v1.34) client-go serialization that includes "creationTimestamp":null
 				rev.Data.Raw = []byte(strings.ReplaceAll(string(rev.Data.Raw), `"metadata":{}`, `"metadata":{"creationTimestamp":null}`))
@@ -1182,10 +1169,7 @@ func TestGetUpdatedRevision(t *testing.T) {
 		},
 		{
 			name: "revision has different spec, should trigger update",
-			sts: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sample", Namespace: "default"},
-			},
-			lws: wrappers.BuildLeaderWorkerSet("default").Obj(),
+			lws:  wrappers.BuildLeaderWorkerSet("default").Obj(),
 			modifyRevision: func(rev *appsv1.ControllerRevision) {
 				// Simulate a real spec change by modifying the container name
 				rev.Data.Raw = []byte(strings.ReplaceAll(string(rev.Data.Raw), `"name":"leader"`, `"name":"changed"`))
@@ -1211,7 +1195,7 @@ func TestGetUpdatedRevision(t *testing.T) {
 				tc.modifyRevision(revision)
 			}
 
-			updatedRevision, err := reconciler.getUpdatedRevision(context.TODO(), tc.sts != nil, tc.lws, revision)
+			updatedRevision, err := reconciler.getUpdatedRevision(context.TODO(), tc.lws, revision)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/controllers/leaderworkerset_hash.go
+++ b/pkg/controllers/leaderworkerset_hash.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
+	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
+)
+
+// reconcileHash reconciles a LeaderWorkerSet with GroupIdentity=Hash. Leaders are
+// managed through a Deployment instead of a StatefulSet: the ReplicaSet picks
+// scale-down victims (unscheduled and not-ready groups before healthy ones) and the
+// Deployment paces rollouts, throttled by the group-ready readiness gate that the
+// pod controller maintains on leader pods.
+func (r *LeaderWorkerSetReconciler) reconcileHash(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	deploy, err := r.getLeaderDeployment(ctx, lws)
+	if err != nil {
+		log.Error(err, "Fetching leader deployment")
+		return ctrl.Result{}, err
+	}
+	if deploy != nil && deploy.DeletionTimestamp != nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	revision, err := r.getOrCreateRevisionForDeployment(ctx, deploy, lws)
+	if err != nil {
+		log.Error(err, "Creating controller revision")
+		return ctrl.Result{}, err
+	}
+
+	updatedRevision, err := r.getUpdatedRevisionForDeployment(ctx, deploy, lws, revision)
+	if err != nil {
+		log.Error(err, "Validating if LWS has been updated")
+		return ctrl.Result{}, err
+	}
+	if updatedRevision != nil {
+		revision, err = revisionutils.CreateRevision(ctx, r.Client, updatedRevision)
+		if err != nil {
+			log.Error(err, "Creating revision for updated LWS")
+			return ctrl.Result{}, err
+		}
+		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, CreatingRevision, Create, fmt.Sprintf("Creating revision with key %s for updated LWS", revisionutils.GetRevisionKey(revision)))
+	}
+
+	if err := r.SSAWithDeployment(ctx, lws, revisionutils.GetRevisionKey(revision)); err != nil {
+		if deploy == nil {
+			r.Record.Eventf(lws, nil, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create leader deployment %s: %v", lws.Name, err))
+		} else {
+			r.Record.Eventf(lws, nil, corev1.EventTypeWarning, FailedUpdate, Update, fmt.Sprintf("Failed to update leader deployment %s: %v", lws.Name, err))
+		}
+		return ctrl.Result{}, err
+	}
+	if deploy == nil {
+		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created leader deployment %s", lws.Name))
+	}
+
+	if err := r.reconcileHeadlessServices(ctx, lws); err != nil {
+		log.Error(err, "Creating headless service.")
+		r.Record.Eventf(lws, nil, corev1.EventTypeWarning, FailedCreate, Create, fmt.Sprintf("Failed to create headless service for error: %v", err))
+		return ctrl.Result{}, err
+	}
+
+	updateDone, err := r.updateStatusHash(ctx, lws)
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if updateDone {
+		if err := revisionutils.TruncateRevisions(ctx, r.Client, lws, revisionutils.GetRevisionKey(revision)); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	log.V(2).Info("Leader Reconcile (hash identity) completed.")
+	return ctrl.Result{}, nil
+}
+
+func (r *LeaderWorkerSetReconciler) getLeaderDeployment(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet) (*appsv1.Deployment, error) {
+	deploy := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, deploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return deploy, nil
+}
+
+// getOrCreateRevisionForDeployment mirrors getOrCreateRevisionIfNonExist with the
+// revision key read from the leader deployment instead of the leader statefulset.
+func (r *LeaderWorkerSetReconciler) getOrCreateRevisionForDeployment(ctx context.Context, deploy *appsv1.Deployment, lws *leaderworkerset.LeaderWorkerSet) (*appsv1.ControllerRevision, error) {
+	revisionKey := ""
+	if deploy != nil {
+		revisionKey = revisionutils.GetRevisionKey(deploy)
+	}
+	if revision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); revision != nil || err != nil {
+		return revision, err
+	}
+	revision, err := revisionutils.NewRevision(ctx, r.Client, lws, revisionKey)
+	if err != nil {
+		return nil, err
+	}
+	newRevision, err := revisionutils.CreateRevision(ctx, r.Client, revision)
+	if err == nil {
+		r.Record.Eventf(lws, newRevision, corev1.EventTypeNormal, CreatingRevision, Create, fmt.Sprintf("Creating revision with key %s", revision.Labels[leaderworkerset.RevisionKey]))
+	}
+	return newRevision, err
+}
+
+func (r *LeaderWorkerSetReconciler) getUpdatedRevisionForDeployment(ctx context.Context, deploy *appsv1.Deployment, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
+	if deploy == nil {
+		return nil, nil
+	}
+	currentRevision, err := revisionutils.NewRevision(ctx, r.Client, lws, "")
+	if err != nil {
+		return nil, err
+	}
+	if !revisionutils.EqualRevision(currentRevision, revision) {
+		if revisionutils.SetMatchesRevision(lws, currentRevision, revision, r.revisionEqualityCache) {
+			return nil, nil
+		}
+		return currentRevision, nil
+	}
+	return nil, nil
+}
+
+func (r *LeaderWorkerSetReconciler) SSAWithDeployment(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, revisionKey string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	deploymentApplyConfig, err := constructLeaderDeploymentApplyConfiguration(lws, revisionKey)
+	if err != nil {
+		log.Error(err, "Constructing Deployment apply configuration.")
+		return err
+	}
+	if err := setControllerReferenceWithDeployment(lws, deploymentApplyConfig, r.Scheme); err != nil {
+		log.Error(err, "Setting controller reference.")
+		return err
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploymentApplyConfig)
+	if err != nil {
+		log.Error(err, "Converting Deployment configuration to json.")
+		return err
+	}
+	patch := &unstructured.Unstructured{Object: obj}
+	err = r.Patch(ctx, patch, client.Apply, &client.PatchOptions{ //nolint
+		FieldManager: fieldManager,
+		Force:        ptr.To[bool](true),
+	})
+	if err != nil {
+		log.Error(err, "Using server side apply to update leader deployment")
+		return err
+	}
+	return nil
+}
+
+// constructLeaderDeploymentApplyConfiguration is the hash-identity analog of
+// constructLeaderStatefulSetApplyConfiguration. Rollout pacing (maxSurge and
+// maxUnavailable) maps directly onto the Deployment strategy; there is no
+// partition equivalent, ordering is delegated to the Deployment controller.
+func constructLeaderDeploymentApplyConfiguration(lws *leaderworkerset.LeaderWorkerSet, revisionKey string) (*appsapplyv1.DeploymentApplyConfiguration, error) {
+	var podTemplateSpec corev1.PodTemplateSpec
+	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.LeaderTemplate.DeepCopy()
+	} else {
+		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.WorkerTemplate.DeepCopy()
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podTemplateSpec)
+	if err != nil {
+		return nil, err
+	}
+	var podTemplateApplyConfiguration coreapplyv1.PodTemplateSpecApplyConfiguration
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj, &podTemplateApplyConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
+	podTemplateApplyConfiguration.WithLabels(map[string]string{
+		leaderworkerset.WorkerIndexLabelKey: "0",
+		leaderworkerset.SetNameLabelKey:     lws.Name,
+		leaderworkerset.RevisionKey:         revisionKey,
+	})
+	podAnnotations := map[string]string{
+		leaderworkerset.SizeAnnotationKey:          strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size)),
+		leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
+	}
+	if lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "" {
+		podAnnotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
+	}
+	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
+
+	// The gate keeps a leader pod not-ready until its worker statefulset is ready,
+	// so the Deployment's maxUnavailable budget counts whole groups.
+	if *lws.Spec.LeaderWorkerTemplate.Size > 1 {
+		if podTemplateApplyConfiguration.Spec == nil {
+			podTemplateApplyConfiguration.Spec = coreapplyv1.PodSpec()
+		}
+		podTemplateApplyConfiguration.Spec.WithReadinessGates(
+			coreapplyv1.PodReadinessGate().WithConditionType(leaderworkerset.GroupReadyConditionType))
+	}
+
+	deploymentLabels := mergeMetadata(lws.Labels, map[string]string{
+		leaderworkerset.SetNameLabelKey: lws.Name,
+		leaderworkerset.RevisionKey:     revisionKey,
+	})
+	deploymentAnnotations := mergeMetadata(lws.Annotations, map[string]string{
+		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
+	})
+
+	deploymentConfig := appsapplyv1.Deployment(lws.Name, lws.Namespace).
+		WithSpec(appsapplyv1.DeploymentSpec().
+			WithReplicas(*lws.Spec.Replicas).
+			WithTemplate(&podTemplateApplyConfiguration).
+			WithStrategy(appsapplyv1.DeploymentStrategy().
+				WithType(appsv1.RollingUpdateDeploymentStrategyType).
+				WithRollingUpdate(appsapplyv1.RollingUpdateDeployment().
+					WithMaxUnavailable(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable).
+					WithMaxSurge(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge))).
+			WithSelector(metaapplyv1.LabelSelector().
+				WithMatchLabels(map[string]string{
+					leaderworkerset.SetNameLabelKey:     lws.Name,
+					leaderworkerset.WorkerIndexLabelKey: "0",
+				}))).
+		WithLabels(deploymentLabels).
+		WithAnnotations(deploymentAnnotations)
+
+	return deploymentConfig, nil
+}
+
+// updateStatusHash computes LWS status from the leader Deployment. Because pod
+// readiness includes the group-ready gate, the Deployment's readyReplicas already
+// counts fully ready groups rather than bare leader pods.
+func (r *LeaderWorkerSetReconciler) updateStatusHash(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	updateStatus := false
+
+	deploy := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, deploy); err != nil {
+		log.Error(err, "Error retrieving leader Deployment")
+		return false, err
+	}
+
+	if lws.Status.Replicas != deploy.Status.Replicas {
+		lws.Status.Replicas = deploy.Status.Replicas
+		updateStatus = true
+	}
+	if lws.Status.ReadyReplicas != deploy.Status.ReadyReplicas {
+		lws.Status.ReadyReplicas = deploy.Status.ReadyReplicas
+		updateStatus = true
+	}
+	if lws.Status.UpdatedReplicas != deploy.Status.UpdatedReplicas {
+		lws.Status.UpdatedReplicas = deploy.Status.UpdatedReplicas
+		updateStatus = true
+	}
+	if lws.Status.ObservedGeneration != lws.Generation {
+		lws.Status.ObservedGeneration = lws.Generation
+		updateStatus = true
+	}
+	if lws.Status.HPAPodSelector == "" {
+		labelSelector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     lws.Name,
+				leaderworkerset.WorkerIndexLabelKey: "0",
+			},
+		}
+		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+		if err != nil {
+			log.Error(err, "Converting label selector to selector")
+			return false, err
+		}
+		lws.Status.HPAPodSelector = selector.String()
+		updateStatus = true
+	}
+
+	var conditions []metav1.Condition
+	lwsReplicas := *lws.Spec.Replicas
+	updateInProgress := deploy.Status.UpdatedReplicas < deploy.Status.Replicas
+	available := deploy.Status.Replicas == lwsReplicas &&
+		deploy.Status.ReadyReplicas == lwsReplicas &&
+		deploy.Status.UpdatedReplicas == lwsReplicas
+	if updateInProgress {
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetUpdateInProgress, lws))
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing, lws))
+	} else if available {
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetAvailable, lws))
+	} else {
+		conditions = append(conditions, makeCondition(leaderworkerset.LeaderWorkerSetProgressing, lws))
+	}
+
+	updateCondition := setConditions(lws, conditions)
+	if updateCondition {
+		r.Record.Eventf(lws, nil, corev1.EventTypeNormal, conditions[0].Reason, Update, conditions[0].Message+fmt.Sprintf(", with %d groups ready of total %d groups", deploy.Status.ReadyReplicas, lwsReplicas))
+	}
+	if updateStatus || updateCondition {
+		if err := r.Status().Update(ctx, lws); err != nil {
+			if !apierrors.IsConflict(err) {
+				log.Error(err, "Updating LeaderWorkerSet status and/or condition.")
+			}
+			return false, err
+		}
+	}
+	return available, nil
+}
+
+// setControllerReferenceWithDeployment sets the controller reference on the
+// Deployment apply configuration.
+func setControllerReferenceWithDeployment(owner metav1.Object, deploy *appsapplyv1.DeploymentApplyConfiguration, scheme *runtime.Scheme) error {
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("%T is not a runtime.Object, cannot call SetOwnerReference", owner)
+	}
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return err
+	}
+	deploy.WithOwnerReferences(metaapplyv1.OwnerReference().
+		WithAPIVersion(gvk.GroupVersion().String()).
+		WithKind(gvk.Kind).
+		WithName(owner.GetName()).
+		WithUID(owner.GetUID()).
+		WithBlockOwnerDeletion(true).
+		WithController(true))
+	return nil
+}

--- a/pkg/controllers/leaderworkerset_hash.go
+++ b/pkg/controllers/leaderworkerset_hash.go
@@ -19,23 +19,17 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
@@ -58,13 +52,17 @@ func (r *LeaderWorkerSetReconciler) reconcileHash(ctx context.Context, lws *lead
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	revision, err := r.getOrCreateRevisionForDeployment(ctx, deploy, lws)
+	revisionKey := ""
+	if deploy != nil {
+		revisionKey = revisionutils.GetRevisionKey(deploy)
+	}
+	revision, err := r.getOrCreateRevision(ctx, revisionKey, lws)
 	if err != nil {
 		log.Error(err, "Creating controller revision")
 		return ctrl.Result{}, err
 	}
 
-	updatedRevision, err := r.getUpdatedRevisionForDeployment(ctx, deploy, lws, revision)
+	updatedRevision, err := r.getUpdatedRevision(ctx, deploy != nil, lws, revision)
 	if err != nil {
 		log.Error(err, "Validating if LWS has been updated")
 		return ctrl.Result{}, err
@@ -123,44 +121,6 @@ func (r *LeaderWorkerSetReconciler) getLeaderDeployment(ctx context.Context, lws
 	return deploy, nil
 }
 
-// getOrCreateRevisionForDeployment mirrors getOrCreateRevisionIfNonExist with the
-// revision key read from the leader deployment instead of the leader statefulset.
-func (r *LeaderWorkerSetReconciler) getOrCreateRevisionForDeployment(ctx context.Context, deploy *appsv1.Deployment, lws *leaderworkerset.LeaderWorkerSet) (*appsv1.ControllerRevision, error) {
-	revisionKey := ""
-	if deploy != nil {
-		revisionKey = revisionutils.GetRevisionKey(deploy)
-	}
-	if revision, err := revisionutils.GetRevision(ctx, r.Client, lws, revisionKey); revision != nil || err != nil {
-		return revision, err
-	}
-	revision, err := revisionutils.NewRevision(ctx, r.Client, lws, revisionKey)
-	if err != nil {
-		return nil, err
-	}
-	newRevision, err := revisionutils.CreateRevision(ctx, r.Client, revision)
-	if err == nil {
-		r.Record.Eventf(lws, newRevision, corev1.EventTypeNormal, CreatingRevision, Create, fmt.Sprintf("Creating revision with key %s", revision.Labels[leaderworkerset.RevisionKey]))
-	}
-	return newRevision, err
-}
-
-func (r *LeaderWorkerSetReconciler) getUpdatedRevisionForDeployment(ctx context.Context, deploy *appsv1.Deployment, lws *leaderworkerset.LeaderWorkerSet, revision *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
-	if deploy == nil {
-		return nil, nil
-	}
-	currentRevision, err := revisionutils.NewRevision(ctx, r.Client, lws, "")
-	if err != nil {
-		return nil, err
-	}
-	if !revisionutils.EqualRevision(currentRevision, revision) {
-		if revisionutils.SetMatchesRevision(lws, currentRevision, revision, r.revisionEqualityCache) {
-			return nil, nil
-		}
-		return currentRevision, nil
-	}
-	return nil, nil
-}
-
 func (r *LeaderWorkerSetReconciler) SSAWithDeployment(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, revisionKey string) error {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -169,21 +129,13 @@ func (r *LeaderWorkerSetReconciler) SSAWithDeployment(ctx context.Context, lws *
 		log.Error(err, "Constructing Deployment apply configuration.")
 		return err
 	}
-	if err := setControllerReferenceWithDeployment(lws, deploymentApplyConfig, r.Scheme); err != nil {
+	ownerRef, err := controllerOwnerReference(lws, r.Scheme)
+	if err != nil {
 		log.Error(err, "Setting controller reference.")
 		return err
 	}
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploymentApplyConfig)
-	if err != nil {
-		log.Error(err, "Converting Deployment configuration to json.")
-		return err
-	}
-	patch := &unstructured.Unstructured{Object: obj}
-	err = r.Patch(ctx, patch, client.Apply, &client.PatchOptions{ //nolint
-		FieldManager: fieldManager,
-		Force:        ptr.To[bool](true),
-	})
-	if err != nil {
+	deploymentApplyConfig.WithOwnerReferences(ownerRef)
+	if err := r.serverSideApply(ctx, deploymentApplyConfig); err != nil {
 		log.Error(err, "Using server side apply to update leader deployment")
 		return err
 	}
@@ -195,35 +147,13 @@ func (r *LeaderWorkerSetReconciler) SSAWithDeployment(ctx context.Context, lws *
 // maxUnavailable) maps directly onto the Deployment strategy; there is no
 // partition equivalent, ordering is delegated to the Deployment controller.
 func constructLeaderDeploymentApplyConfiguration(lws *leaderworkerset.LeaderWorkerSet, revisionKey string) (*appsapplyv1.DeploymentApplyConfiguration, error) {
-	var podTemplateSpec corev1.PodTemplateSpec
-	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.LeaderTemplate.DeepCopy()
-	} else {
-		podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.WorkerTemplate.DeepCopy()
-	}
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podTemplateSpec)
+	podTemplateApplyConfiguration, err := buildLeaderPodTemplateApplyConfiguration(lws, revisionKey)
 	if err != nil {
 		return nil, err
 	}
-	var podTemplateApplyConfiguration coreapplyv1.PodTemplateSpecApplyConfiguration
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj, &podTemplateApplyConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
-	podTemplateApplyConfiguration.WithLabels(map[string]string{
-		leaderworkerset.WorkerIndexLabelKey: "0",
-		leaderworkerset.SetNameLabelKey:     lws.Name,
-		leaderworkerset.RevisionKey:         revisionKey,
-	})
-	podAnnotations := map[string]string{
-		leaderworkerset.SizeAnnotationKey:          strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size)),
+	podTemplateApplyConfiguration.WithAnnotations(map[string]string{
 		leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
-	}
-	if lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "" {
-		podAnnotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
-	}
-	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
+	})
 
 	// Deployments do not propagate a service name into pod subdomains the way
 	// statefulsets do, so the template carries the shared headless service as the
@@ -240,18 +170,12 @@ func constructLeaderDeploymentApplyConfiguration(lws *leaderworkerset.LeaderWork
 			coreapplyv1.PodReadinessGate().WithConditionType(leaderworkerset.GroupReadyConditionType))
 	}
 
-	deploymentLabels := mergeMetadata(lws.Labels, map[string]string{
-		leaderworkerset.SetNameLabelKey: lws.Name,
-		leaderworkerset.RevisionKey:     revisionKey,
-	})
-	deploymentAnnotations := mergeMetadata(lws.Annotations, map[string]string{
-		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),
-	})
+	deploymentLabels, deploymentAnnotations := leaderMetadata(lws, revisionKey)
 
 	deploymentConfig := appsapplyv1.Deployment(lws.Name, lws.Namespace).
 		WithSpec(appsapplyv1.DeploymentSpec().
 			WithReplicas(*lws.Spec.Replicas).
-			WithTemplate(&podTemplateApplyConfiguration).
+			WithTemplate(podTemplateApplyConfiguration).
 			WithStrategy(appsapplyv1.DeploymentStrategy().
 				WithType(appsv1.RollingUpdateDeploymentStrategyType).
 				WithRollingUpdate(appsapplyv1.RollingUpdateDeployment().
@@ -297,21 +221,12 @@ func (r *LeaderWorkerSetReconciler) updateStatusHash(ctx context.Context, lws *l
 		lws.Status.ObservedGeneration = lws.Generation
 		updateStatus = true
 	}
-	if lws.Status.HPAPodSelector == "" {
-		labelSelector := &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				leaderworkerset.SetNameLabelKey:     lws.Name,
-				leaderworkerset.WorkerIndexLabelKey: "0",
-			},
-		}
-		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-		if err != nil {
-			log.Error(err, "Converting label selector to selector")
-			return false, err
-		}
-		lws.Status.HPAPodSelector = selector.String()
-		updateStatus = true
+	selectorUpdated, err := ensureHPAPodSelector(lws)
+	if err != nil {
+		log.Error(err, "Converting label selector to selector")
+		return false, err
 	}
+	updateStatus = updateStatus || selectorUpdated
 
 	var conditions []metav1.Condition
 	lwsReplicas := *lws.Spec.Replicas
@@ -341,25 +256,4 @@ func (r *LeaderWorkerSetReconciler) updateStatusHash(ctx context.Context, lws *l
 		}
 	}
 	return available, nil
-}
-
-// setControllerReferenceWithDeployment sets the controller reference on the
-// Deployment apply configuration.
-func setControllerReferenceWithDeployment(owner metav1.Object, deploy *appsapplyv1.DeploymentApplyConfiguration, scheme *runtime.Scheme) error {
-	ro, ok := owner.(runtime.Object)
-	if !ok {
-		return fmt.Errorf("%T is not a runtime.Object, cannot call SetOwnerReference", owner)
-	}
-	gvk, err := apiutil.GVKForObject(ro, scheme)
-	if err != nil {
-		return err
-	}
-	deploy.WithOwnerReferences(metaapplyv1.OwnerReference().
-		WithAPIVersion(gvk.GroupVersion().String()).
-		WithKind(gvk.Kind).
-		WithName(owner.GetName()).
-		WithUID(owner.GetUID()).
-		WithBlockOwnerDeletion(true).
-		WithController(true))
-	return nil
 }

--- a/pkg/controllers/leaderworkerset_hash.go
+++ b/pkg/controllers/leaderworkerset_hash.go
@@ -62,10 +62,13 @@ func (r *LeaderWorkerSetReconciler) reconcileHash(ctx context.Context, lws *lead
 		return ctrl.Result{}, err
 	}
 
-	updatedRevision, err := r.getUpdatedRevision(ctx, deploy != nil, lws, revision)
-	if err != nil {
-		log.Error(err, "Validating if LWS has been updated")
-		return ctrl.Result{}, err
+	var updatedRevision *appsv1.ControllerRevision
+	if deploy != nil {
+		updatedRevision, err = r.getUpdatedRevision(ctx, lws, revision)
+		if err != nil {
+			log.Error(err, "Validating if LWS has been updated")
+			return ctrl.Result{}, err
+		}
 	}
 	if updatedRevision != nil {
 		revision, err = revisionutils.CreateRevision(ctx, r.Client, updatedRevision)

--- a/pkg/controllers/leaderworkerset_hash.go
+++ b/pkg/controllers/leaderworkerset_hash.go
@@ -225,12 +225,17 @@ func constructLeaderDeploymentApplyConfiguration(lws *leaderworkerset.LeaderWork
 	}
 	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
 
+	// Deployments do not propagate a service name into pod subdomains the way
+	// statefulsets do, so the template carries the shared headless service as the
+	// default. Admission overrides it when subdomainPolicy is UniquePerReplica.
+	if podTemplateApplyConfiguration.Spec == nil {
+		podTemplateApplyConfiguration.Spec = coreapplyv1.PodSpec()
+	}
+	podTemplateApplyConfiguration.Spec.WithSubdomain(lws.Name)
+
 	// The gate keeps a leader pod not-ready until its worker statefulset is ready,
 	// so the Deployment's maxUnavailable budget counts whole groups.
 	if *lws.Spec.LeaderWorkerTemplate.Size > 1 {
-		if podTemplateApplyConfiguration.Spec == nil {
-			podTemplateApplyConfiguration.Spec = coreapplyv1.PodSpec()
-		}
 		podTemplateApplyConfiguration.Spec.WithReadinessGates(
 			coreapplyv1.PodReadinessGate().WithConditionType(leaderworkerset.GroupReadyConditionType))
 	}

--- a/pkg/controllers/leaderworkerset_hash_test.go
+++ b/pkg/controllers/leaderworkerset_hash_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+func TestLeaderDeploymentApplyConfig(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-hash", "default").
+		Replica(4).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				MaxUnavailable: intstr.FromInt32(1),
+				MaxSurge:       intstr.FromInt32(2),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(2).
+		RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj()
+	lws.Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+
+	deployConfig, err := constructLeaderDeploymentApplyConfiguration(lws, "rev-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := *deployConfig.Spec.Replicas; got != 4 {
+		t.Errorf("replicas = %d, want 4", got)
+	}
+	if got := deployConfig.Spec.Selector.MatchLabels[leaderworkerset.SetNameLabelKey]; got != "test-hash" {
+		t.Errorf("selector set-name = %q, want test-hash", got)
+	}
+	if got := deployConfig.Spec.Selector.MatchLabels[leaderworkerset.WorkerIndexLabelKey]; got != "0" {
+		t.Errorf("selector worker-index = %q, want 0", got)
+	}
+	if got := *deployConfig.Spec.Strategy.Type; got != appsv1.RollingUpdateDeploymentStrategyType {
+		t.Errorf("strategy type = %q, want RollingUpdate", got)
+	}
+	if got := *deployConfig.Spec.Strategy.RollingUpdate.MaxUnavailable; got != intstr.FromInt32(1) {
+		t.Errorf("maxUnavailable = %v, want 1", got)
+	}
+	if got := *deployConfig.Spec.Strategy.RollingUpdate.MaxSurge; got != intstr.FromInt32(2) {
+		t.Errorf("maxSurge = %v, want 2", got)
+	}
+
+	template := deployConfig.Spec.Template
+	if got := template.Labels[leaderworkerset.RevisionKey]; got != "rev-1" {
+		t.Errorf("template revision label = %q, want rev-1", got)
+	}
+	if got := template.Labels[leaderworkerset.WorkerIndexLabelKey]; got != "0" {
+		t.Errorf("template worker-index label = %q, want 0", got)
+	}
+	if got := template.Annotations[leaderworkerset.GroupIdentityAnnotationKey]; got != string(leaderworkerset.GroupIdentityHash) {
+		t.Errorf("template group-identity annotation = %q, want Hash", got)
+	}
+	if got := template.Annotations[leaderworkerset.SizeAnnotationKey]; got != "2" {
+		t.Errorf("template size annotation = %q, want 2", got)
+	}
+
+	foundGate := false
+	for _, gate := range template.Spec.ReadinessGates {
+		if gate.ConditionType != nil && *gate.ConditionType == leaderworkerset.GroupReadyConditionType {
+			foundGate = true
+		}
+	}
+	if !foundGate {
+		t.Error("expected group-ready readiness gate on leader template with size > 1")
+	}
+}
+
+func TestLeaderDeploymentApplyConfigSizeOneHasNoGate(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-hash", "default").
+		Replica(2).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				MaxUnavailable: intstr.FromInt32(1),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(1).
+		RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj()
+	lws.Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+
+	deployConfig, err := constructLeaderDeploymentApplyConfiguration(lws, "rev-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, gate := range deployConfig.Spec.Template.Spec.ReadinessGates {
+		if gate.ConditionType != nil && *gate.ConditionType == leaderworkerset.GroupReadyConditionType {
+			t.Error("size 1 groups must not carry the group-ready readiness gate")
+		}
+	}
+}

--- a/pkg/controllers/leaderworkerset_hash_test.go
+++ b/pkg/controllers/leaderworkerset_hash_test.go
@@ -79,6 +79,10 @@ func TestLeaderDeploymentApplyConfig(t *testing.T) {
 		t.Errorf("template size annotation = %q, want 2", got)
 	}
 
+	if got := template.Spec.Subdomain; got == nil || *got != "test-hash" {
+		t.Errorf("template subdomain = %v, want test-hash", got)
+	}
+
 	foundGate := false
 	for _, gate := range template.Spec.ReadinessGates {
 		if gate.ConditionType != nil && *gate.ConditionType == leaderworkerset.GroupReadyConditionType {

--- a/pkg/controllers/leaderworkerset_hash_test.go
+++ b/pkg/controllers/leaderworkerset_hash_test.go
@@ -65,9 +65,16 @@ func TestLeaderDeploymentApplyConfig(t *testing.T) {
 		t.Errorf("maxSurge = %v, want 2", got)
 	}
 
+	if got := deployConfig.Labels[leaderworkerset.RoleLabelKey]; got != leaderworkerset.RoleLeader {
+		t.Errorf("deployment role label = %q, want %q", got, leaderworkerset.RoleLeader)
+	}
+
 	template := deployConfig.Spec.Template
 	if got := template.Labels[leaderworkerset.RevisionKey]; got != "rev-1" {
 		t.Errorf("template revision label = %q, want rev-1", got)
+	}
+	if got := template.Labels[leaderworkerset.RoleLabelKey]; got != leaderworkerset.RoleLeader {
+		t.Errorf("template role label = %q, want %q", got, leaderworkerset.RoleLeader)
 	}
 	if got := template.Labels[leaderworkerset.WorkerIndexLabelKey]; got != "0" {
 		t.Errorf("template worker-index label = %q, want 0", got)
@@ -91,6 +98,40 @@ func TestLeaderDeploymentApplyConfig(t *testing.T) {
 	}
 	if !foundGate {
 		t.Error("expected group-ready readiness gate on leader template with size > 1")
+	}
+}
+
+func TestLeaderDeploymentApplyConfigPolicyAnnotations(t *testing.T) {
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-hash", "default").
+		Replica(2).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				MaxUnavailable: intstr.FromInt32(1),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(4).
+		SubdomainPolicy(leaderworkerset.SubdomainUniquePerReplica).
+		SubGroupType(leaderworkerset.SubGroupPolicyTypeLeaderWorker).
+		SubGroupSize(2).
+		RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj()
+	lws.Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+
+	deployConfig, err := constructLeaderDeploymentApplyConfiguration(lws, "rev-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	annotations := deployConfig.Spec.Template.Annotations
+	if got := annotations[leaderworkerset.SubdomainPolicyAnnotationKey]; got != string(leaderworkerset.SubdomainUniquePerReplica) {
+		t.Errorf("template subdomain policy annotation = %q, want UniquePerReplica", got)
+	}
+	if got := annotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey]; got != string(leaderworkerset.SubGroupPolicyTypeLeaderWorker) {
+		t.Errorf("template subgroup type annotation = %q, want LeaderWorker", got)
+	}
+	if got := annotations[leaderworkerset.SubGroupSizeAnnotationKey]; got != "2" {
+		t.Errorf("template subgroup size annotation = %q, want 2", got)
 	}
 }
 

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -123,14 +123,9 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if leaderWorkerSet.Spec.NetworkConfig != nil && *leaderWorkerSet.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainUniquePerReplica {
-		// In hash mode the per-replica service carries the group key derived name
-		// the webhook stamped as the leader's subdomain, since Service names must
-		// begin with a letter and the pod name is not known at admission.
-		serviceName := pod.Name
-		if leaderWorkerSet.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash && pod.Spec.Subdomain != "" {
-			serviceName = pod.Spec.Subdomain
-		}
-		if err := controllerutils.CreateHeadlessServiceIfNotExists(ctx, r.Client, r.Scheme, &leaderWorkerSet, serviceName, map[string]string{leaderworkerset.SetNameLabelKey: leaderWorkerSet.Name, leaderworkerset.GroupIndexLabelKey: pod.Labels[leaderworkerset.GroupIndexLabelKey]}, &pod); err != nil {
+		// The per-replica service is named after the leader's subdomain: the pod
+		// name in ordinal mode, a group key derived name in hash mode.
+		if err := controllerutils.CreateHeadlessServiceIfNotExists(ctx, r.Client, r.Scheme, &leaderWorkerSet, pod.Spec.Subdomain, map[string]string{leaderworkerset.SetNameLabelKey: leaderWorkerSet.Name, leaderworkerset.GroupIndexLabelKey: pod.Labels[leaderworkerset.GroupIndexLabelKey]}, &pod); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -172,32 +167,27 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		log.V(2).Info(fmt.Sprintf("Revision has not been created yet, requeing reconciler for pod %s", pod.Name))
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
+	// Leader pods always have a DNS identity: the statefulset controller
+	// assigns it in ordinal mode, admission in hash mode. The worker statefulset
+	// service name and the leader address stamped on its template derive from it.
+	if pod.Spec.Hostname == "" || pod.Spec.Subdomain == "" {
+		return ctrl.Result{}, fmt.Errorf("leader pod %s/%s has no hostname or subdomain", pod.Namespace, pod.Name)
+	}
 	statefulSet, err := constructWorkerStatefulSetApplyConfiguration(pod, leaderWorkerSet, revision)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if hashIdentity {
-		// Workers reach the leader through the DNS record the webhook derived
-		// from the group key. Leaders admitted before hostnames were assigned
-		// fall back to the pod IP, which is stable for the group's lifetime
-		// because the whole group is recreated together when the leader is
-		// replaced.
-		var leaderAddress string
-		if pod.Spec.Hostname != "" && pod.Spec.Subdomain != "" {
-			leaderAddress = fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace)
-		} else {
-			if pod.Status.PodIP == "" {
-				log.V(2).Info("waiting for leader pod IP before creating the worker statefulset")
-				return ctrl.Result{RequeueAfter: time.Second}, nil
-			}
-			leaderAddress = pod.Status.PodIP
-		}
-		statefulSet.Spec.Template.WithAnnotations(map[string]string{
-			leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
-			leaderworkerset.LeaderAddressAnnotationKey: leaderAddress,
-		})
+	// Workers reach the leader through its DNS name, stamped on the worker
+	// statefulset template so pod admission can inject LWS_LEADER_ADDRESS
+	// without recomputing it.
+	templateAnnotations := map[string]string{
+		leaderworkerset.LeaderAddressAnnotationKey: fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace),
 	}
+	if hashIdentity {
+		templateAnnotations[leaderworkerset.GroupIdentityAnnotationKey] = string(leaderworkerset.GroupIdentityHash)
+	}
+	statefulSet.Spec.Template.WithAnnotations(templateAnnotations)
 
 	// if exclusive placement is enabled but leader pod is not scheduled, don't create the worker sts
 	if topologyKey, found := leaderWorkerSet.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; found {
@@ -513,14 +503,9 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	}
 	acceleratorutils.AddTPUAnnotations(leaderPod, podAnnotations)
 	podTemplateApplyConfiguration.WithAnnotations(podAnnotations)
-	serviceName := leaderPod.Name
-	if currentLws.Spec.NetworkConfig == nil || *currentLws.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainShared {
-		serviceName = lws.Name
-	} else if currentLws.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash && leaderPod.Spec.Subdomain != "" {
-		// The hash mode per-replica service is named by the leader's subdomain
-		// (group key derived), not the leader pod name.
-		serviceName = leaderPod.Spec.Subdomain
-	}
+	// The service name always matches the leader's subdomain in every mode and
+	// subdomain policy.
+	serviceName := leaderPod.Spec.Subdomain
 	// construct statefulset apply configuration
 	statefulSetLabels := mergeMetadata(lws.Labels, labelMap)
 	statefulSetConfig := appsapplyv1.StatefulSet(leaderPod.Name, leaderPod.Namespace).

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -63,6 +63,7 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 
@@ -139,10 +140,21 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	hashIdentity := leaderWorkerSet.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash
+
 	// logic for handling leader pod
-	if leaderWorkerSet.Spec.StartupPolicy == leaderworkerset.LeaderReadyStartupPolicy && !podutils.IsPodReady(&pod) {
-		log.V(2).Info("defer the creation of the worker statefulset because leader pod is not ready.")
-		return ctrl.Result{}, nil
+	if leaderWorkerSet.Spec.StartupPolicy == leaderworkerset.LeaderReadyStartupPolicy {
+		leaderStarted := podutils.IsPodReady(&pod)
+		if hashIdentity {
+			// With hash identity, full pod readiness includes the group-ready gate,
+			// which in turn waits for the workers. Gate worker creation on container
+			// readiness instead to avoid a deadlock.
+			leaderStarted = podutils.ContainersReady(&pod)
+		}
+		if !leaderStarted {
+			log.V(2).Info("defer the creation of the worker statefulset because leader pod is not ready.")
+			return ctrl.Result{}, nil
+		}
 	}
 	revision, err := revisionutils.GetRevision(ctx, r.Client, &leaderWorkerSet, revisionutils.GetRevisionKey(&pod))
 	if err != nil {
@@ -156,6 +168,20 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	statefulSet, err := constructWorkerStatefulSetApplyConfiguration(pod, leaderWorkerSet, revision)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if hashIdentity {
+		// Hash-named leaders have no per-pod DNS record, so workers get the leader
+		// pod IP instead. The IP is stable for the group's lifetime because the
+		// whole group is recreated together when the leader is replaced.
+		if pod.Status.PodIP == "" {
+			log.V(2).Info("waiting for leader pod IP before creating the worker statefulset")
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+		statefulSet.Spec.Template.WithAnnotations(map[string]string{
+			leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
+			leaderworkerset.LeaderAddressAnnotationKey: pod.Status.PodIP,
+		})
 	}
 
 	// if exclusive placement is enabled but leader pod is not scheduled, don't create the worker sts
@@ -184,6 +210,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		Object: obj,
 	}
 
+	workerStsReady := false
 	var workerSts appsv1.StatefulSet
 	if err := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: leaderWorkerSet.Namespace}, &workerSts); err != nil {
 		if client.IgnoreNotFound(err) != nil {
@@ -196,9 +223,46 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, client.IgnoreAlreadyExists(err)
 		}
 		r.Record.Eventf(&leaderWorkerSet, &pod, corev1.EventTypeNormal, GroupsProgressing, Create, fmt.Sprintf("Created worker statefulset for leader pod %s", pod.Name))
+	} else {
+		workerStsReady = statefulsetutils.StatefulsetReady(workerSts)
+	}
+
+	if hashIdentity {
+		// Maintain the group-ready readiness gate so Deployment rollout pacing
+		// counts whole groups instead of bare leader pods.
+		if err := r.syncGroupReadyCondition(ctx, &pod, workerStsReady); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	log.V(2).Info("Worker Reconcile completed.")
 	return ctrl.Result{}, nil
+}
+
+// syncGroupReadyCondition patches the leader pod's group-ready condition to match
+// the readiness of its worker statefulset.
+func (r *PodReconciler) syncGroupReadyCondition(ctx context.Context, pod *corev1.Pod, ready bool) error {
+	status := corev1.ConditionFalse
+	reason := "WorkerStatefulSetNotReady"
+	if ready {
+		status = corev1.ConditionTrue
+		reason = "WorkerStatefulSetReady"
+	}
+	if _, existing := podutils.GetPodCondition(&pod.Status, leaderworkerset.GroupReadyConditionType); existing != nil && existing.Status == status {
+		return nil
+	}
+	newPod := pod.DeepCopy()
+	condition := corev1.PodCondition{
+		Type:               leaderworkerset.GroupReadyConditionType,
+		Status:             status,
+		Reason:             reason,
+		LastTransitionTime: metav1.Now(),
+	}
+	if idx, _ := podutils.GetPodCondition(&newPod.Status, leaderworkerset.GroupReadyConditionType); idx >= 0 {
+		newPod.Status.Conditions[idx] = condition
+	} else {
+		newPod.Status.Conditions = append(newPod.Status.Conditions, condition)
+	}
+	return r.Status().Patch(ctx, newPod, client.MergeFrom(pod))
 }
 
 func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod, leaderWorkerSet leaderworkerset.LeaderWorkerSet) (bool, error) {
@@ -226,9 +290,15 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 
 	var leader corev1.Pod
 	if !podutils.LeaderPod(pod) {
-		leaderPodName, ordinal := statefulsetutils.GetParentNameAndOrdinal(pod.Name)
-		if ordinal == -1 {
-			return false, fmt.Errorf("parsing pod name for pod %s", pod.Name)
+		// Prefer the annotation over name parsing: with hash identity the leader
+		// name is not ordinal-derived.
+		leaderPodName := pod.Annotations[leaderworkerset.LeaderPodNameAnnotationKey]
+		if leaderPodName == "" {
+			var ordinal int
+			leaderPodName, ordinal = statefulsetutils.GetParentNameAndOrdinal(pod.Name)
+			if ordinal == -1 {
+				return false, fmt.Errorf("parsing pod name for pod %s", pod.Name)
+			}
 		}
 		if err := r.Get(ctx, types.NamespacedName{Name: leaderPodName, Namespace: pod.Namespace}, &leader); err != nil {
 			// If the error is not found, it is likely caused by the fact that the leader was deleted but the worker statefulset

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -123,7 +123,14 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if leaderWorkerSet.Spec.NetworkConfig != nil && *leaderWorkerSet.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainUniquePerReplica {
-		if err := controllerutils.CreateHeadlessServiceIfNotExists(ctx, r.Client, r.Scheme, &leaderWorkerSet, pod.Name, map[string]string{leaderworkerset.SetNameLabelKey: leaderWorkerSet.Name, leaderworkerset.GroupIndexLabelKey: pod.Labels[leaderworkerset.GroupIndexLabelKey]}, &pod); err != nil {
+		// In hash mode the per-replica service carries the group key derived name
+		// the webhook stamped as the leader's subdomain, since Service names must
+		// begin with a letter and the pod name is not known at admission.
+		serviceName := pod.Name
+		if leaderWorkerSet.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash && pod.Spec.Subdomain != "" {
+			serviceName = pod.Spec.Subdomain
+		}
+		if err := controllerutils.CreateHeadlessServiceIfNotExists(ctx, r.Client, r.Scheme, &leaderWorkerSet, serviceName, map[string]string{leaderworkerset.SetNameLabelKey: leaderWorkerSet.Name, leaderworkerset.GroupIndexLabelKey: pod.Labels[leaderworkerset.GroupIndexLabelKey]}, &pod); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -171,16 +178,24 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if hashIdentity {
-		// Hash-named leaders have no per-pod DNS record, so workers get the leader
-		// pod IP instead. The IP is stable for the group's lifetime because the
-		// whole group is recreated together when the leader is replaced.
-		if pod.Status.PodIP == "" {
-			log.V(2).Info("waiting for leader pod IP before creating the worker statefulset")
-			return ctrl.Result{RequeueAfter: time.Second}, nil
+		// Workers reach the leader through the DNS record the webhook derived
+		// from the group key. Leaders admitted before hostnames were assigned
+		// fall back to the pod IP, which is stable for the group's lifetime
+		// because the whole group is recreated together when the leader is
+		// replaced.
+		var leaderAddress string
+		if pod.Spec.Hostname != "" && pod.Spec.Subdomain != "" {
+			leaderAddress = fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace)
+		} else {
+			if pod.Status.PodIP == "" {
+				log.V(2).Info("waiting for leader pod IP before creating the worker statefulset")
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
+			leaderAddress = pod.Status.PodIP
 		}
 		statefulSet.Spec.Template.WithAnnotations(map[string]string{
 			leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
-			leaderworkerset.LeaderAddressAnnotationKey: pod.Status.PodIP,
+			leaderworkerset.LeaderAddressAnnotationKey: leaderAddress,
 		})
 	}
 
@@ -501,6 +516,10 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	serviceName := leaderPod.Name
 	if currentLws.Spec.NetworkConfig == nil || *currentLws.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainShared {
 		serviceName = lws.Name
+	} else if currentLws.Spec.GroupIdentity == leaderworkerset.GroupIdentityHash && leaderPod.Spec.Subdomain != "" {
+		// The hash mode per-replica service is named by the leader's subdomain
+		// (group key derived), not the leader pod name.
+		serviceName = leaderPod.Spec.Subdomain
 	}
 	// construct statefulset apply configuration
 	statefulSetLabels := mergeMetadata(lws.Labels, labelMap)

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -433,23 +433,32 @@ func (r *PodReconciler) pendingPodsInGroup(ctx context.Context, pod corev1.Pod, 
 
 // setControllerReferenceWithStatefulSet set controller reference for the StatefulSet
 func setControllerReferenceWithStatefulSet(owner metav1.Object, sts *appsapplyv1.StatefulSetApplyConfiguration, scheme *runtime.Scheme) error {
-	// Validate the owner.
-	ro, ok := owner.(runtime.Object)
-	if !ok {
-		return fmt.Errorf("%T is not a runtime.Object, cannot call SetOwnerReference", owner)
-	}
-	gvk, err := apiutil.GVKForObject(ro, scheme)
+	ownerRef, err := controllerOwnerReference(owner, scheme)
 	if err != nil {
 		return err
 	}
-	sts.WithOwnerReferences(metaapplyv1.OwnerReference().
+	sts.WithOwnerReferences(ownerRef)
+	return nil
+}
+
+// controllerOwnerReference builds the owner reference apply configuration that
+// marks owner as the managing controller.
+func controllerOwnerReference(owner metav1.Object, scheme *runtime.Scheme) (*metaapplyv1.OwnerReferenceApplyConfiguration, error) {
+	ro, ok := owner.(runtime.Object)
+	if !ok {
+		return nil, fmt.Errorf("%T is not a runtime.Object, cannot call SetOwnerReference", owner)
+	}
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return nil, err
+	}
+	return metaapplyv1.OwnerReference().
 		WithAPIVersion(gvk.GroupVersion().String()).
 		WithKind(gvk.Kind).
 		WithName(owner.GetName()).
 		WithUID(owner.GetUID()).
 		WithBlockOwnerDeletion(true).
-		WithController(true))
-	return nil
+		WithController(true), nil
 }
 
 // constructWorkerStatefulSetApplyConfiguration constructs the applied configuration for the leader StatefulSet

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -690,3 +690,47 @@ func TestReconcileLeaderPodDeletingSkipsHeadlessService(t *testing.T) {
 		t.Errorf("expected 0 services created for deleting leader pod, got %d", len(svcList.Items))
 	}
 }
+
+func TestConstructWorkerStatefulSetServiceNameHashUniquePerReplica(t *testing.T) {
+	client := fake.NewClientBuilder().Build()
+
+	subdomainPolicy := leaderworkerset.SubdomainUniquePerReplica
+	lws := wrappers.BuildLeaderWorkerSet("default").
+		Name("test-sample").
+		Replica(1).
+		Size(2).
+		SubdomainPolicy(subdomainPolicy).
+		Obj()
+	lws.Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+
+	revision, err := revisionutils.NewRevision(context.TODO(), client, lws, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leaderPod := corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-sample-7d9f8b6c4-x2kkp",
+			Namespace: "default",
+			Labels: map[string]string{
+				leaderworkerset.WorkerIndexLabelKey:     "0",
+				leaderworkerset.SetNameLabelKey:         "test-sample",
+				leaderworkerset.GroupIndexLabelKey:      "test-key",
+				leaderworkerset.GroupUniqueHashLabelKey: "test-key",
+				leaderworkerset.RevisionKey:             revisionutils.GetRevisionKey(revision),
+			},
+		},
+		Spec: corev1.PodSpec{
+			Hostname:  "9f2ac71b",
+			Subdomain: "test-sample-9f2ac71b",
+		},
+	}
+
+	cfg, err := constructWorkerStatefulSetApplyConfiguration(leaderPod, *lws, revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := *cfg.Spec.ServiceName; got != "test-sample-9f2ac71b" {
+		t.Errorf("expected the worker StatefulSet to use the group key derived service name, got %q", got)
+	}
+}

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -737,7 +737,7 @@ func TestConstructWorkerStatefulSetServiceNameHashUniquePerReplica(t *testing.T)
 			},
 		},
 		Spec: corev1.PodSpec{
-			Hostname:  "9f2ac71b",
+			Hostname:  "test-sample-9f2ac71b",
 			Subdomain: "test-sample-9f2ac71b",
 		},
 	}

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -71,6 +71,10 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 					},
 				},
+				Spec: corev1.PodSpec{
+					Hostname:  "test-sample",
+					Subdomain: "test-sample",
+				},
 			},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 				Replica(1).
@@ -145,6 +149,10 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 					},
+				},
+				Spec: corev1.PodSpec{
+					Hostname:  "test-sample",
+					Subdomain: "test-sample",
 				},
 			},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
@@ -226,6 +234,10 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 					},
+				},
+				Spec: corev1.PodSpec{
+					Hostname:  "test-sample",
+					Subdomain: "test-sample",
 				},
 			},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
@@ -309,6 +321,10 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
 					},
+				},
+				Spec: corev1.PodSpec{
+					Hostname:  "test-sample",
+					Subdomain: "test-sample",
 				},
 			},
 			lws: wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").

--- a/pkg/utils/accelerators/tpu.go
+++ b/pkg/utils/accelerators/tpu.go
@@ -96,6 +96,20 @@ func getContainerRequestingTPUs(spec *corev1.PodSpec) *corev1.Container {
 	return nil
 }
 
+// leaderDNSHostname returns the DNS host name of the group's leader pod. Leader
+// pods carry it in their spec, worker pods carry the full leader address in an
+// annotation. Pods with neither use leaderPodName, their leader's host name
+// matches its pod name.
+func leaderDNSHostname(pod *corev1.Pod, leaderPodName string) string {
+	if pod.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" && pod.Spec.Hostname != "" {
+		return pod.Spec.Hostname
+	}
+	if address := pod.Annotations[leaderworkerset.LeaderAddressAnnotationKey]; address != "" {
+		return strings.Split(address, ".")[0]
+	}
+	return leaderPodName
+}
+
 func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 	container := getContainerRequestingTPUs(&pod.Spec)
 	if container == nil {
@@ -143,8 +157,9 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 
 	if pod.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" {
 		// The leader requests TPU resources, so it should be included in hostnames.
-		hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderName, pod.Spec.Subdomain))
-		hostnamesAddresses = append(hostnamesAddresses, fmt.Sprintf("%s.%s:%s", leaderName, pod.Spec.Subdomain, tpuProcessPort))
+		leaderHostname := leaderDNSHostname(pod, leaderName)
+		hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderHostname, pod.Spec.Subdomain))
+		hostnamesAddresses = append(hostnamesAddresses, fmt.Sprintf("%s.%s:%s", leaderHostname, pod.Spec.Subdomain, tpuProcessPort))
 		end -= 1
 	} else {
 		leaderName, _ = statefulsetutils.GetParentNameAndOrdinal(pod.Name)
@@ -155,8 +170,9 @@ func addTPUVariablesSubGroup(pod *corev1.Pod) error {
 			// SubGroup 0 contains the leader, and the leader is requesting TPU resources, so
 			// the hostname list should shift to the left by one
 			end -= 1
-			hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderName, pod.Spec.Subdomain))
-			hostnamesAddresses = append(hostnamesAddresses, fmt.Sprintf("%s.%s:%s", leaderName, pod.Spec.Subdomain, tpuProcessPort))
+			leaderHostname := leaderDNSHostname(pod, leaderName)
+			hostnames = append(hostnames, fmt.Sprintf("%s.%s", leaderHostname, pod.Spec.Subdomain))
+			hostnamesAddresses = append(hostnamesAddresses, fmt.Sprintf("%s.%s:%s", leaderHostname, pod.Spec.Subdomain, tpuProcessPort))
 		} else if pod.Annotations[LeaderRequestsTPUsAnnotationKey] == "true" {
 			// Since the first subGroup has been shifted to the left by one, all other subsequent
 			// subGroups should be shifted as well
@@ -250,7 +266,7 @@ func AddTPUVariables(pod *corev1.Pod, size int) error {
 	var hostnames []string
 	var hostnamesAddresses []string
 	if pod.Annotations[LeaderRequestsTPUsAnnotationKey] == "true" || pod.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" {
-		leaderPodHostname := fmt.Sprintf("%s.%s", leaderPodName, pod.Spec.Subdomain)
+		leaderPodHostname := fmt.Sprintf("%s.%s", leaderDNSHostname(pod, leaderPodName), pod.Spec.Subdomain)
 		// For now we assume that the leader has the same number of containers
 		// as the current pod, although this may not always be the case.
 		for i := range numContainers {

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -126,6 +126,55 @@ func TestAddTPUVariables(t *testing.T) {
 			expectedTpuProcessPort:      "8476",
 		},
 		{
+			name: "Hash identity, leader pod with assigned host name",
+			pod: &corev1.Pod{
+				Spec: func() corev1.PodSpec {
+					spec := wrappers.MakeLeaderPodSpecWithTPUResource()
+					spec.Hostname = "9f2ac71b"
+					return spec
+				}(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-sample-7d9f8b6c4-x2kkp",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey: "0",
+					},
+					Annotations: map[string]string{
+						LeaderRequestsTPUsAnnotationKey: "true",
+					},
+				},
+			},
+			size:                        2,
+			expectedTpuWorkerId:         "0",
+			expectedTpuWorkerHostNames:  "9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
+			expectedTpuName:             "test-sample-7d9f8b6c4-x2kkp",
+			expectedTpuProcessAddresses: "9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
+			name: "Hash identity, worker pod with leader address annotation",
+			pod: &corev1.Pod{
+				Spec: wrappers.MakeLeaderPodSpecWithTPUResource(),
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-sample-7d9f8b6c4-x2kkp-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						leaderworkerset.WorkerIndexLabelKey: "1",
+					},
+					Annotations: map[string]string{
+						LeaderRequestsTPUsAnnotationKey:            "true",
+						leaderworkerset.LeaderAddressAnnotationKey: "9f2ac71b.default.default",
+					},
+				},
+			},
+			size:                        2,
+			expectedTpuWorkerId:         "1",
+			expectedTpuWorkerHostNames:  "9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
+			expectedTpuName:             "test-sample-7d9f8b6c4-x2kkp",
+			expectedTpuProcessAddresses: "9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
+			expectedTpuProcessPort:      "8476",
+		},
+		{
 			name: "Test multi-container TPU_PROCESS_ADDRESSES, leader pod",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{

--- a/pkg/utils/accelerators/tpu_test.go
+++ b/pkg/utils/accelerators/tpu_test.go
@@ -130,7 +130,7 @@ func TestAddTPUVariables(t *testing.T) {
 			pod: &corev1.Pod{
 				Spec: func() corev1.PodSpec {
 					spec := wrappers.MakeLeaderPodSpecWithTPUResource()
-					spec.Hostname = "9f2ac71b"
+					spec.Hostname = "test-sample-9f2ac71b"
 					return spec
 				}(),
 				ObjectMeta: v1.ObjectMeta{
@@ -146,9 +146,9 @@ func TestAddTPUVariables(t *testing.T) {
 			},
 			size:                        2,
 			expectedTpuWorkerId:         "0",
-			expectedTpuWorkerHostNames:  "9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
+			expectedTpuWorkerHostNames:  "test-sample-9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
 			expectedTpuName:             "test-sample-7d9f8b6c4-x2kkp",
-			expectedTpuProcessAddresses: "9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
+			expectedTpuProcessAddresses: "test-sample-9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
 			expectedTpuProcessPort:      "8476",
 		},
 		{
@@ -163,15 +163,15 @@ func TestAddTPUVariables(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						LeaderRequestsTPUsAnnotationKey:            "true",
-						leaderworkerset.LeaderAddressAnnotationKey: "9f2ac71b.default.default",
+						leaderworkerset.LeaderAddressAnnotationKey: "test-sample-9f2ac71b.default.default",
 					},
 				},
 			},
 			size:                        2,
 			expectedTpuWorkerId:         "1",
-			expectedTpuWorkerHostNames:  "9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
+			expectedTpuWorkerHostNames:  "test-sample-9f2ac71b.default,test-sample-7d9f8b6c4-x2kkp-1.default",
 			expectedTpuName:             "test-sample-7d9f8b6c4-x2kkp",
-			expectedTpuProcessAddresses: "9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
+			expectedTpuProcessAddresses: "test-sample-9f2ac71b.default:8476,test-sample-7d9f8b6c4-x2kkp-1.default:8476",
 			expectedTpuProcessPort:      "8476",
 		},
 		{

--- a/pkg/utils/disaggregatedset/utils.go
+++ b/pkg/utils/disaggregatedset/utils.go
@@ -143,15 +143,24 @@ const revisionLength = 8
 
 func ComputeRevision(roles []disaggregatedsetv1.DisaggregatedRoleSpec) string {
 	type roleTemplate struct {
-		Name     string                                 `json:"name"`
-		Template leaderworkersetv1.LeaderWorkerTemplate `json:"template"`
+		Name string `json:"name"`
+		// GroupIdentity is normalized so "" and the CRD default Ordinal hash
+		// identically: objects persisted before the field existed must keep
+		// their revision once the API server starts defaulting it on reads.
+		GroupIdentity leaderworkersetv1.GroupIdentityType    `json:"groupIdentity,omitempty"`
+		Template      leaderworkersetv1.LeaderWorkerTemplate `json:"template"`
 	}
 
 	templates := make([]roleTemplate, 0, len(roles))
 	for _, role := range roles {
+		groupIdentity := role.Spec.GroupIdentity
+		if groupIdentity == leaderworkersetv1.GroupIdentityOrdinal {
+			groupIdentity = ""
+		}
 		templates = append(templates, roleTemplate{
-			Name:     role.Name,
-			Template: role.Spec.LeaderWorkerTemplate,
+			Name:          role.Name,
+			GroupIdentity: groupIdentity,
+			Template:      role.Spec.LeaderWorkerTemplate,
 		})
 	}
 

--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -145,20 +145,28 @@ func AddLWSVariables(pod *corev1.Pod) error {
 		Value: fmt.Sprintf("%s-%s.%s.%s", lwsName, groupIndex, pod.Spec.Subdomain, pod.ObjectMeta.Namespace),
 	}
 	if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
-		// Hash-named leaders have no ordinal DNS record. Workers carry the leader
-		// pod IP in an annotation; the leader itself resolves its own address
-		// through the downward API.
+		// Hash leaders have no ordinal DNS record. Their DNS name comes from the
+		// hostname and subdomain the webhook derives from the group key; workers
+		// carry it in an annotation. Pods admitted before hostnames were assigned
+		// fall back to the leader pod IP.
 		if addr := pod.Annotations[leaderworkerset.LeaderAddressAnnotationKey]; addr != "" {
 			leaderAddressEnvVar = corev1.EnvVar{
 				Name:  leaderworkerset.LwsLeaderAddress,
 				Value: addr,
 			}
 		} else if LeaderPod(*pod) {
-			leaderAddressEnvVar = corev1.EnvVar{
-				Name: leaderworkerset.LwsLeaderAddress,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-				},
+			if pod.Spec.Hostname != "" && pod.Spec.Subdomain != "" {
+				leaderAddressEnvVar = corev1.EnvVar{
+					Name:  leaderworkerset.LwsLeaderAddress,
+					Value: fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.ObjectMeta.Namespace),
+				}
+			} else {
+				leaderAddressEnvVar = corev1.EnvVar{
+					Name: leaderworkerset.LwsLeaderAddress,
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+					},
+				}
 			}
 		}
 	}

--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -128,47 +128,12 @@ func addEnvVarsIfNotExists(c *corev1.Container, firstEnv corev1.EnvVar, e ...cor
 	c.Env = newEnvVars
 }
 
-// AddLWSVariables adds environment variable to every container.
-func AddLWSVariables(pod *corev1.Pod) error {
-	lwsName, found := pod.Labels[leaderworkerset.SetNameLabelKey]
-	if !found {
-		return fmt.Errorf("Failure constructing environment variables, no name label found for pod %v", klog.KObj(pod))
-	}
-
-	groupIndex, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]
-	if !found {
-		return fmt.Errorf("Failure constructing environment variables, no group index label found for pod %v", klog.KObj(pod))
-	}
-
+// AddLWSVariables adds environment variable to every container. leaderAddress
+// is the DNS address of the group's leader pod.
+func AddLWSVariables(pod *corev1.Pod, leaderAddress string) error {
 	leaderAddressEnvVar := corev1.EnvVar{
 		Name:  leaderworkerset.LwsLeaderAddress,
-		Value: fmt.Sprintf("%s-%s.%s.%s", lwsName, groupIndex, pod.Spec.Subdomain, pod.ObjectMeta.Namespace),
-	}
-	if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
-		// Hash leaders have no ordinal DNS record. Their DNS name comes from the
-		// hostname and subdomain the webhook derives from the group key; workers
-		// carry it in an annotation. Pods admitted before hostnames were assigned
-		// fall back to the leader pod IP.
-		if addr := pod.Annotations[leaderworkerset.LeaderAddressAnnotationKey]; addr != "" {
-			leaderAddressEnvVar = corev1.EnvVar{
-				Name:  leaderworkerset.LwsLeaderAddress,
-				Value: addr,
-			}
-		} else if LeaderPod(*pod) {
-			if pod.Spec.Hostname != "" && pod.Spec.Subdomain != "" {
-				leaderAddressEnvVar = corev1.EnvVar{
-					Name:  leaderworkerset.LwsLeaderAddress,
-					Value: fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.ObjectMeta.Namespace),
-				}
-			} else {
-				leaderAddressEnvVar = corev1.EnvVar{
-					Name: leaderworkerset.LwsLeaderAddress,
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					},
-				}
-			}
-		}
+		Value: leaderAddress,
 	}
 
 	size, found := pod.Annotations[leaderworkerset.SizeAnnotationKey]

--- a/pkg/utils/pod/pod_utils.go
+++ b/pkg/utils/pod/pod_utils.go
@@ -144,6 +144,24 @@ func AddLWSVariables(pod *corev1.Pod) error {
 		Name:  leaderworkerset.LwsLeaderAddress,
 		Value: fmt.Sprintf("%s-%s.%s.%s", lwsName, groupIndex, pod.Spec.Subdomain, pod.ObjectMeta.Namespace),
 	}
+	if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
+		// Hash-named leaders have no ordinal DNS record. Workers carry the leader
+		// pod IP in an annotation; the leader itself resolves its own address
+		// through the downward API.
+		if addr := pod.Annotations[leaderworkerset.LeaderAddressAnnotationKey]; addr != "" {
+			leaderAddressEnvVar = corev1.EnvVar{
+				Name:  leaderworkerset.LwsLeaderAddress,
+				Value: addr,
+			}
+		} else if LeaderPod(*pod) {
+			leaderAddressEnvVar = corev1.EnvVar{
+				Name: leaderworkerset.LwsLeaderAddress,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+				},
+			}
+		}
+	}
 
 	size, found := pod.Annotations[leaderworkerset.SizeAnnotationKey]
 	if !found {
@@ -181,6 +199,13 @@ func AddLWSVariables(pod *corev1.Pod) error {
 // IsPodReady returns true if a pod is ready; false otherwise.
 func IsPodReady(pod *corev1.Pod) bool {
 	return IsPodReadyConditionTrue(pod.Status)
+}
+
+// ContainersReady returns true if all of the pod's containers are ready,
+// regardless of readiness gates.
+func ContainersReady(pod *corev1.Pod) bool {
+	_, condition := GetPodCondition(&pod.Status, corev1.ContainersReady)
+	return condition != nil && condition.Status == corev1.ConditionTrue
 }
 
 // IsPodReadyConditionTrue returns true if a pod is ready; false otherwise.

--- a/pkg/utils/pod/pod_utils_test.go
+++ b/pkg/utils/pod/pod_utils_test.go
@@ -154,7 +154,7 @@ func TestAddLWSVariables(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := AddLWSVariables(tc.pod)
+			err := AddLWSVariables(tc.pod, tc.expectedLwsLeaderAddress)
 			if err != nil {
 				t.Fatalf("Error parsing parent: %s", err.Error())
 			}

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -73,6 +73,9 @@ func (w *DisaggregatedSetWebhook) validate(obj *disaggv1.DisaggregatedSet) (admi
 	for i, role := range obj.Spec.Roles {
 		rolePath := rolesPath.Index(i)
 		allErrs = append(allErrs, w.validateRoleRolloutStrategy(role, rolePath)...)
+		// Reject hash-mode feature combinations the LWS webhook would reject, so
+		// they fail at DisaggregatedSet admission instead of at LWS creation time.
+		allErrs = append(allErrs, webhooks.ValidateGroupIdentity(rolePath.Child("spec"), &role.Spec)...)
 
 		if role.Scaling == nil || role.Scaling.Mode != disaggv1.RoleScalingExternal {
 			continue

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -823,7 +823,7 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 	webhook := &DisaggregatedSetWebhook{}
 	ctx := context.Background()
 
-	buildDS := func(spec leaderworkerset.LeaderWorkerSetSpec) *disaggv1.DisaggregatedSet {
+	buildDisaggregatedSet := func(spec leaderworkerset.LeaderWorkerSetSpec) *disaggv1.DisaggregatedSet {
 		return &disaggv1.DisaggregatedSet{
 			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 			Spec: disaggv1.DisaggregatedSetSpec{
@@ -845,7 +845,7 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 	}{
 		{
 			name: "hash role is accepted",
-			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+			obj: buildDisaggregatedSet(leaderworkerset.LeaderWorkerSetSpec{
 				Replicas:      ptr.To(int32(2)),
 				GroupIdentity: leaderworkerset.GroupIdentityHash,
 			}),
@@ -853,7 +853,7 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 		},
 		{
 			name: "hash role with subGroupPolicy is rejected",
-			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+			obj: buildDisaggregatedSet(leaderworkerset.LeaderWorkerSetSpec{
 				Replicas:      ptr.To(int32(2)),
 				GroupIdentity: leaderworkerset.GroupIdentityHash,
 				LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
@@ -867,7 +867,7 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 		},
 		{
 			name: "ordinal role with subGroupPolicy is accepted",
-			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+			obj: buildDisaggregatedSet(leaderworkerset.LeaderWorkerSetSpec{
 				Replicas:      ptr.To(int32(2)),
 				GroupIdentity: leaderworkerset.GroupIdentityOrdinal,
 				LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -818,3 +818,77 @@ func TestValidateExternalScalingRules(t *testing.T) {
 		require.Contains(t, err.Error(), "253 characters")
 	})
 }
+
+func TestValidateCreateGroupIdentity(t *testing.T) {
+	webhook := &DisaggregatedSetWebhook{}
+	ctx := context.Background()
+
+	buildDS := func(spec leaderworkerset.LeaderWorkerSetSpec) *disaggv1.DisaggregatedSet {
+		return &disaggv1.DisaggregatedSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: disaggv1.DisaggregatedSetSpec{
+				Roles: []disaggv1.DisaggregatedRoleSpec{
+					{
+						Name:                        "prefill",
+						LeaderWorkerSetTemplateSpec: leaderworkerset.LeaderWorkerSetTemplateSpec{Spec: spec},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		obj         *disaggv1.DisaggregatedSet
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "hash role is accepted",
+			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+				Replicas:      ptr.To(int32(2)),
+				GroupIdentity: leaderworkerset.GroupIdentityHash,
+			}),
+			expectError: false,
+		},
+		{
+			name: "hash role with subGroupPolicy is rejected",
+			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+				Replicas:      ptr.To(int32(2)),
+				GroupIdentity: leaderworkerset.GroupIdentityHash,
+				LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+					SubGroupPolicy: &leaderworkerset.SubGroupPolicy{
+						SubGroupSize: ptr.To(int32(2)),
+					},
+				},
+			}),
+			expectError: true,
+			errorMsg:    "subGroupPolicy is not supported with groupIdentity Hash",
+		},
+		{
+			name: "ordinal role with subGroupPolicy is accepted",
+			obj: buildDS(leaderworkerset.LeaderWorkerSetSpec{
+				Replicas:      ptr.To(int32(2)),
+				GroupIdentity: leaderworkerset.GroupIdentityOrdinal,
+				LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+					SubGroupPolicy: &leaderworkerset.SubGroupPolicy{
+						SubGroupSize: ptr.To(int32(2)),
+					},
+				},
+			}),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := webhook.ValidateCreate(ctx, tc.obj)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -852,7 +852,7 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "hash role with subGroupPolicy is rejected",
+			name: "hash role with subGroupPolicy is accepted",
 			obj: buildDisaggregatedSet(leaderworkerset.LeaderWorkerSetSpec{
 				Replicas:      ptr.To(int32(2)),
 				GroupIdentity: leaderworkerset.GroupIdentityHash,
@@ -862,8 +862,19 @@ func TestValidateCreateGroupIdentity(t *testing.T) {
 					},
 				},
 			}),
+			expectError: false,
+		},
+		{
+			name: "hash role with volumeClaimTemplates is rejected",
+			obj: buildDisaggregatedSet(leaderworkerset.LeaderWorkerSetSpec{
+				Replicas:      ptr.To(int32(2)),
+				GroupIdentity: leaderworkerset.GroupIdentityHash,
+				LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{}},
+				},
+			}),
 			expectError: true,
-			errorMsg:    "subGroupPolicy is not supported with groupIdentity Hash",
+			errorMsg:    "volumeClaimTemplates are not supported with groupIdentity Hash",
 		},
 		{
 			name: "ordinal role with subGroupPolicy is accepted",

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -206,26 +206,21 @@ func normalizeGroupIdentity(gi v1.GroupIdentityType) v1.GroupIdentityType {
 	return gi
 }
 
-// ValidateGroupIdentity rejects the parts of the API surface that depend on
-// ordinal leader names and are not supported when leaders are Deployment-managed.
-// It is a no-op unless the spec asks for groupIdentity Hash. Exported so the
-// DisaggregatedSet webhook can run the same checks against each role's inline
-// LeaderWorkerSet spec at DisaggregatedSet admission time, where a bad combination
-// would otherwise only surface as LWS creation failures during reconciliation.
+// ValidateGroupIdentity rejects the parts of the API surface whose semantics
+// depend on stable StatefulSet identity and are not supported when leaders are
+// Deployment-managed. It is a no-op unless the spec asks for groupIdentity Hash.
+// Exported so the DisaggregatedSet webhook can run the same checks against each
+// role's inline LeaderWorkerSet spec at DisaggregatedSet admission time, where a
+// bad combination would otherwise only surface as LWS creation failures during
+// reconciliation.
 func ValidateGroupIdentity(specPath *field.Path, spec *v1.LeaderWorkerSetSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if normalizeGroupIdentity(spec.GroupIdentity) != v1.GroupIdentityHash {
 		return allErrs
 	}
 	giPath := specPath.Child("groupIdentity")
-	if spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
-		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "subGroupPolicy is not supported with groupIdentity Hash"))
-	}
 	if len(spec.LeaderWorkerTemplate.VolumeClaimTemplates) > 0 {
 		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "volumeClaimTemplates are not supported with groupIdentity Hash"))
-	}
-	if spec.NetworkConfig != nil && spec.NetworkConfig.SubdomainPolicy != nil && *spec.NetworkConfig.SubdomainPolicy == v1.SubdomainUniquePerReplica {
-		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "subdomainPolicy UniquePerReplica is not supported with groupIdentity Hash"))
 	}
 	if spec.RolloutStrategy.RollingUpdateConfiguration != nil && spec.RolloutStrategy.RollingUpdateConfiguration.Partition != nil && *spec.RolloutStrategy.RollingUpdateConfiguration.Partition != 0 {
 		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "rollingUpdateConfiguration.partition is not supported with groupIdentity Hash"))

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -194,9 +194,7 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 		}
 	}
 
-	if normalizeGroupIdentity(lws.Spec.GroupIdentity) == v1.GroupIdentityHash {
-		allErrs = append(allErrs, validateHashGroupIdentity(specPath, lws)...)
-	}
+	allErrs = append(allErrs, ValidateGroupIdentity(specPath, &lws.Spec)...)
 
 	return allErrs
 }
@@ -208,22 +206,29 @@ func normalizeGroupIdentity(gi v1.GroupIdentityType) v1.GroupIdentityType {
 	return gi
 }
 
-// validateHashGroupIdentity rejects the parts of the API surface that depend on
+// ValidateGroupIdentity rejects the parts of the API surface that depend on
 // ordinal leader names and are not supported when leaders are Deployment-managed.
-func validateHashGroupIdentity(specPath *field.Path, lws *v1.LeaderWorkerSet) field.ErrorList {
+// It is a no-op unless the spec asks for groupIdentity Hash. Exported so the
+// DisaggregatedSet webhook can run the same checks against each role's inline
+// LeaderWorkerSet spec at DisaggregatedSet admission time, where a bad combination
+// would otherwise only surface as LWS creation failures during reconciliation.
+func ValidateGroupIdentity(specPath *field.Path, spec *v1.LeaderWorkerSetSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if normalizeGroupIdentity(spec.GroupIdentity) != v1.GroupIdentityHash {
+		return allErrs
+	}
 	giPath := specPath.Child("groupIdentity")
-	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
-		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "subGroupPolicy is not supported with groupIdentity Hash"))
+	if spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "subGroupPolicy is not supported with groupIdentity Hash"))
 	}
-	if len(lws.Spec.LeaderWorkerTemplate.VolumeClaimTemplates) > 0 {
-		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "volumeClaimTemplates are not supported with groupIdentity Hash"))
+	if len(spec.LeaderWorkerTemplate.VolumeClaimTemplates) > 0 {
+		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "volumeClaimTemplates are not supported with groupIdentity Hash"))
 	}
-	if lws.Spec.NetworkConfig != nil && lws.Spec.NetworkConfig.SubdomainPolicy != nil && *lws.Spec.NetworkConfig.SubdomainPolicy == v1.SubdomainUniquePerReplica {
-		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "subdomainPolicy UniquePerReplica is not supported with groupIdentity Hash"))
+	if spec.NetworkConfig != nil && spec.NetworkConfig.SubdomainPolicy != nil && *spec.NetworkConfig.SubdomainPolicy == v1.SubdomainUniquePerReplica {
+		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "subdomainPolicy UniquePerReplica is not supported with groupIdentity Hash"))
 	}
-	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != nil && *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != 0 {
-		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "rollingUpdateConfiguration.partition is not supported with groupIdentity Hash"))
+	if spec.RolloutStrategy.RollingUpdateConfiguration != nil && spec.RolloutStrategy.RollingUpdateConfiguration.Partition != nil && *spec.RolloutStrategy.RollingUpdateConfiguration.Partition != 0 {
+		allErrs = append(allErrs, field.Invalid(giPath, spec.GroupIdentity, "rollingUpdateConfiguration.partition is not supported with groupIdentity Hash"))
 	}
 	return allErrs
 }

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -54,6 +54,10 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, lws *v1.LeaderWork
 		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.RecreateGroupOnPodRestart
 	}
 
+	if lws.Spec.GroupIdentity == "" {
+		lws.Spec.GroupIdentity = v1.GroupIdentityOrdinal
+	}
+
 	if lws.Spec.LeaderWorkerTemplate.RestartPolicy == v1.DeprecatedDefaultRestartPolicy {
 		lws.Spec.LeaderWorkerTemplate.RestartPolicy = v1.NoneRestartPolicy
 	}
@@ -110,6 +114,10 @@ func (r *LeaderWorkerSetWebhook) ValidateUpdate(ctx context.Context, oldLws, new
 	}
 	if newLws.Spec.NetworkConfig != nil && newLws.Spec.NetworkConfig.SubdomainPolicy == nil {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("networkConfig", "subdomainPolicy"), oldLws.Spec.NetworkConfig.SubdomainPolicy, "cannot set subdomainPolicy as null"))
+	}
+
+	if normalizeGroupIdentity(newLws.Spec.GroupIdentity) != normalizeGroupIdentity(oldLws.Spec.GroupIdentity) {
+		allErrs = append(allErrs, field.Invalid(specPath.Child("groupIdentity"), newLws.Spec.GroupIdentity, "groupIdentity is immutable"))
 	}
 
 	return nil, allErrs.ToAggregate()
@@ -186,6 +194,37 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 		}
 	}
 
+	if normalizeGroupIdentity(lws.Spec.GroupIdentity) == v1.GroupIdentityHash {
+		allErrs = append(allErrs, validateHashGroupIdentity(specPath, lws)...)
+	}
+
+	return allErrs
+}
+
+func normalizeGroupIdentity(gi v1.GroupIdentityType) v1.GroupIdentityType {
+	if gi == "" {
+		return v1.GroupIdentityOrdinal
+	}
+	return gi
+}
+
+// validateHashGroupIdentity rejects the parts of the API surface that depend on
+// ordinal leader names and are not supported when leaders are Deployment-managed.
+func validateHashGroupIdentity(specPath *field.Path, lws *v1.LeaderWorkerSet) field.ErrorList {
+	allErrs := field.ErrorList{}
+	giPath := specPath.Child("groupIdentity")
+	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "subGroupPolicy is not supported with groupIdentity Hash"))
+	}
+	if len(lws.Spec.LeaderWorkerTemplate.VolumeClaimTemplates) > 0 {
+		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "volumeClaimTemplates are not supported with groupIdentity Hash"))
+	}
+	if lws.Spec.NetworkConfig != nil && lws.Spec.NetworkConfig.SubdomainPolicy != nil && *lws.Spec.NetworkConfig.SubdomainPolicy == v1.SubdomainUniquePerReplica {
+		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "subdomainPolicy UniquePerReplica is not supported with groupIdentity Hash"))
+	}
+	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != nil && *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition != 0 {
+		allErrs = append(allErrs, field.Invalid(giPath, lws.Spec.GroupIdentity, "rollingUpdateConfiguration.partition is not supported with groupIdentity Hash"))
+	}
 	return allErrs
 }
 

--- a/pkg/webhooks/leaderworkerset_webhook_hash_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_hash_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+func hashLws(name string) *v1.LeaderWorkerSet {
+	lws := wrappers.BuildBasicLeaderWorkerSet(name, "default").
+		Replica(2).
+		RolloutStrategy(v1.RolloutStrategy{
+			Type: v1.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &v1.RollingUpdateConfiguration{
+				MaxUnavailable: intstr.FromInt32(1),
+				Partition:      ptr.To[int32](0),
+			},
+		}).
+		WorkerTemplateSpec(wrappers.MakeWorkerPodSpec()).
+		Size(2).
+		RestartPolicy(v1.RecreateGroupOnPodRestart).Obj()
+	lws.Spec.GroupIdentity = v1.GroupIdentityHash
+	return lws
+}
+
+func TestValidateHashGroupIdentity(t *testing.T) {
+	webhook := &LeaderWorkerSetWebhook{}
+
+	valid := hashLws("valid")
+	if _, err := webhook.ValidateCreate(context.TODO(), valid); err != nil {
+		t.Errorf("valid hash lws rejected: %v", err)
+	}
+
+	subGroup := hashLws("subgroup")
+	subGroup.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{SubGroupSize: ptr.To[int32](2)}
+	if _, err := webhook.ValidateCreate(context.TODO(), subGroup); err == nil {
+		t.Error("expected subGroupPolicy to be rejected with groupIdentity Hash")
+	}
+
+	partitioned := hashLws("partitioned")
+	partitioned.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition = ptr.To[int32](1)
+	if _, err := webhook.ValidateCreate(context.TODO(), partitioned); err == nil {
+		t.Error("expected non-zero partition to be rejected with groupIdentity Hash")
+	}
+
+	uniqueSubdomain := hashLws("subdomain")
+	policy := v1.SubdomainUniquePerReplica
+	uniqueSubdomain.Spec.NetworkConfig = &v1.NetworkConfig{SubdomainPolicy: &policy}
+	if _, err := webhook.ValidateCreate(context.TODO(), uniqueSubdomain); err == nil {
+		t.Error("expected UniquePerReplica subdomain policy to be rejected with groupIdentity Hash")
+	}
+}
+
+func TestGroupIdentityImmutable(t *testing.T) {
+	webhook := &LeaderWorkerSetWebhook{}
+
+	oldLws := hashLws("immutable")
+	newLws := oldLws.DeepCopy()
+	newLws.Spec.GroupIdentity = v1.GroupIdentityOrdinal
+	if _, err := webhook.ValidateUpdate(context.TODO(), oldLws, newLws); err == nil {
+		t.Error("expected groupIdentity change Hash -> Ordinal to be rejected")
+	}
+
+	// Empty and Ordinal are the same identity scheme; changing between them is allowed.
+	oldDefault := hashLws("default")
+	oldDefault.Spec.GroupIdentity = ""
+	newDefault := oldDefault.DeepCopy()
+	newDefault.Spec.GroupIdentity = v1.GroupIdentityOrdinal
+	if _, err := webhook.ValidateUpdate(context.TODO(), oldDefault, newDefault); err != nil {
+		t.Errorf("empty -> Ordinal should be allowed, got: %v", err)
+	}
+}

--- a/pkg/webhooks/leaderworkerset_webhook_hash_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_hash_test.go
@@ -54,8 +54,8 @@ func TestValidateHashGroupIdentity(t *testing.T) {
 
 	subGroup := hashLws("subgroup")
 	subGroup.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{SubGroupSize: ptr.To[int32](2)}
-	if _, err := webhook.ValidateCreate(context.TODO(), subGroup); err == nil {
-		t.Error("expected subGroupPolicy to be rejected with groupIdentity Hash")
+	if _, err := webhook.ValidateCreate(context.TODO(), subGroup); err != nil {
+		t.Errorf("expected subGroupPolicy to be accepted with groupIdentity Hash: %v", err)
 	}
 
 	partitioned := hashLws("partitioned")
@@ -67,8 +67,8 @@ func TestValidateHashGroupIdentity(t *testing.T) {
 	uniqueSubdomain := hashLws("subdomain")
 	policy := v1.SubdomainUniquePerReplica
 	uniqueSubdomain.Spec.NetworkConfig = &v1.NetworkConfig{SubdomainPolicy: &policy}
-	if _, err := webhook.ValidateCreate(context.TODO(), uniqueSubdomain); err == nil {
-		t.Error("expected UniquePerReplica subdomain policy to be rejected with groupIdentity Hash")
+	if _, err := webhook.ValidateCreate(context.TODO(), uniqueSubdomain); err != nil {
+		t.Errorf("expected UniquePerReplica subdomain policy to be accepted with groupIdentity Hash: %v", err)
 	}
 }
 

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -99,6 +100,28 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 	}
 	// adding labels for pods
 	if podutils.LeaderPod(*pod) {
+		if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
+			// Hash-identity leaders are created through a Deployment: the pod name is
+			// not known at admission (generateName), so the group identity is a fresh
+			// random key rather than a name-derived ordinal.
+			var groupUniqueKey string
+			if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
+				groupUniqueKey = genGroupUniqueKey(pod.Namespace, utilrand.String(16))
+				pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
+			} else {
+				groupUniqueKey = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+			}
+			if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
+				pod.Labels[leaderworkerset.GroupIndexLabelKey] = groupUniqueKey
+			}
+			if epKey, foundEpKey := pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; foundEpKey {
+				SetExclusiveAffinities(pod, groupUniqueKey, epKey, leaderworkerset.GroupUniqueHashLabelKey)
+			}
+			if err := podutils.AddLWSVariables(pod); err != nil {
+				return err
+			}
+			return nil
+		}
 		// add group index label to group pods
 		if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
 			_, groupIndex := statefulsetutils.GetParentNameAndOrdinal(pod.Name)

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -117,6 +117,35 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 			if epKey, foundEpKey := pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; foundEpKey {
 				SetExclusiveAffinities(pod, groupUniqueKey, epKey, leaderworkerset.GroupUniqueHashLabelKey)
 			}
+			// The group key also provides the leader's DNS identity: hostname is a
+			// prefix of the key and subdomain is the headless service the record
+			// lives under. Both fields are immutable, so admission is the only
+			// chance to set them.
+			hostPrefix := hashDNSPrefix(groupUniqueKey)
+			if pod.Spec.Hostname == "" {
+				pod.Spec.Hostname = hostPrefix
+			}
+			if pod.Spec.Subdomain == "" {
+				subdomain := pod.Labels[leaderworkerset.SetNameLabelKey]
+				if sp, foundSP := pod.Annotations[leaderworkerset.SubdomainPolicyAnnotationKey]; foundSP && sp == string(leaderworkerset.SubdomainUniquePerReplica) {
+					// Service names must begin with a letter, so the per-replica
+					// service cannot be named the raw key.
+					subdomain = fmt.Sprintf("%s-%s", subdomain, hostPrefix)
+				}
+				pod.Spec.Subdomain = subdomain
+			}
+			_, foundSubGroupSize := pod.Annotations[leaderworkerset.SubGroupSizeAnnotationKey]
+			subGroupPolicyType := pod.Annotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey]
+			if foundSubGroupSize && pod.Labels[leaderworkerset.SubGroupIndexLabelKey] == "" && (subGroupPolicyType != string(leaderworkerset.SubGroupPolicyTypeLeaderExcluded)) {
+				// The leader pod always lands on SubGroup 0. The subgroup hash
+				// derives from the group key instead of the leader pod name.
+				pod.Labels[leaderworkerset.SubGroupIndexLabelKey] = "0"
+				subGroupUniqueKey := genGroupUniqueKey(groupUniqueKey, "0")
+				pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] = subGroupUniqueKey
+				if subEpKey, foundSubEpKey := pod.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]; foundSubEpKey {
+					SetExclusiveAffinities(pod, subGroupUniqueKey, subEpKey, leaderworkerset.SubGroupUniqueHashLabelKey)
+				}
+			}
 			if err := podutils.AddLWSVariables(pod); err != nil {
 				return err
 			}
@@ -168,10 +197,15 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 			if err != nil {
 				return err
 			}
-			leaderName := pod.Annotations[leaderworkerset.LeaderPodNameAnnotationKey]
+			// In hash mode the subgroup hash derives from the group key, matching
+			// what the leader computed at its own admission when it had no name.
+			subGroupKeyInput := pod.Annotations[leaderworkerset.LeaderPodNameAnnotationKey]
+			if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
+				subGroupKeyInput = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+			}
 			subGroupIndexKey := getSubGroupIndex(podCount, subGroupSizeInt, workerIndex)
 			pod.Labels[leaderworkerset.SubGroupIndexLabelKey] = subGroupIndexKey
-			subGroupUniqueKey := genGroupUniqueKey(leaderName, subGroupIndexKey)
+			subGroupUniqueKey := genGroupUniqueKey(subGroupKeyInput, subGroupIndexKey)
 			pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] = subGroupUniqueKey
 			if subEpKey, foundSubEpKey := pod.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]; foundSubEpKey {
 				SetExclusiveAffinities(pod, subGroupUniqueKey, subEpKey, leaderworkerset.SubGroupUniqueHashLabelKey)
@@ -202,6 +236,19 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 
 func genGroupUniqueKey(ns string, podName string) string {
 	return utils.Sha1Hash(fmt.Sprintf("%s/%s", ns, podName))
+}
+
+// hashDNSPrefixLength is how much of the group key goes into DNS facing names
+// (leader hostname, per-replica service name). 8 hex characters is 32 bits, the
+// same width as the pod template hash Deployments already rely on, and keeps
+// the LeaderWorkerSet's share of the 63 character name budgets large.
+const hashDNSPrefixLength = 8
+
+func hashDNSPrefix(groupUniqueKey string) string {
+	if len(groupUniqueKey) < hashDNSPrefixLength {
+		return groupUniqueKey
+	}
+	return groupUniqueKey[:hashDNSPrefixLength]
 }
 
 // SetExclusiveAffinities set the pod affinity/anti-affinity

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -106,46 +106,30 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 			// Hash-identity leaders are created through a Deployment: the pod name is
 			// not known at admission (generateName), so the group identity is a fresh
 			// random key rather than a name-derived ordinal.
-			if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
-				groupUniqueKey = genGroupUniqueKey(pod.Namespace, utilrand.String(16))
-				pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
-			} else {
-				groupUniqueKey = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
-			}
-			if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
-				pod.Labels[leaderworkerset.GroupIndexLabelKey] = groupUniqueKey
-			}
-			// The group key also provides the leader's hostname, a prefix of the key.
-			// The field is immutable, so admission is the only chance to set it. The
-			// subdomain default comes from the pod template.
+			groupUniqueKey = genGroupUniqueKey(pod.Namespace, utilrand.String(16))
+			pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
+			pod.Labels[leaderworkerset.GroupIndexLabelKey] = groupUniqueKey
+			// The host name is immutable, so admission is the only chance to set it.
+			// The subdomain default comes from the pod template.
 			if pod.Spec.Hostname == "" {
-				pod.Spec.Hostname = hashDNSPrefix(groupUniqueKey)
+				pod.Spec.Hostname = hashLeaderHostname(pod.Labels[leaderworkerset.SetNameLabelKey], groupUniqueKey)
 			}
 		} else {
-			// add group index label to group pods
-			if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
-				_, groupIndex := statefulsetutils.GetParentNameAndOrdinal(pod.Name)
-				if groupIndex == -1 {
-					return fmt.Errorf("parsing pod ordinal for pod %s", pod.Name)
-				}
-				pod.Labels[leaderworkerset.GroupIndexLabelKey] = fmt.Sprint(groupIndex)
+			_, groupIndex := statefulsetutils.GetParentNameAndOrdinal(pod.Name)
+			if groupIndex == -1 {
+				return fmt.Errorf("parsing pod ordinal for pod %s", pod.Name)
 			}
-			// add group unique key label for exclusive placement, and use it to check whether the node affinity has been applied
-			if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
-				groupUniqueKey = genGroupUniqueKey(pod.Namespace, pod.Name)
-				pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
-			} else {
-				groupUniqueKey = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
-			}
+			pod.Labels[leaderworkerset.GroupIndexLabelKey] = fmt.Sprint(groupIndex)
+			groupUniqueKey = genGroupUniqueKey(pod.Namespace, pod.Name)
+			pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
 		}
 		subdomainPolicy, foundSubdomainPolicy := pod.Annotations[leaderworkerset.SubdomainPolicyAnnotationKey]
 		if foundSubdomainPolicy && subdomainPolicy == string(leaderworkerset.SubdomainUniquePerReplica) {
+			// The per replica service is named after the leader: the pod name in
+			// ordinal mode, the assigned host name in hash mode.
+			pod.Spec.Subdomain = pod.Name
 			if hashIdentity {
-				// Service names must begin with a letter, so the per-replica
-				// service cannot be named the raw key.
-				pod.Spec.Subdomain = fmt.Sprintf("%s-%s", pod.Labels[leaderworkerset.SetNameLabelKey], pod.Spec.Hostname)
-			} else {
-				pod.Spec.Subdomain = pod.Name
+				pod.Spec.Subdomain = pod.Spec.Hostname
 			}
 		}
 		if epKey, foundEpKey := pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; foundEpKey {
@@ -242,11 +226,14 @@ func genGroupUniqueKey(ns string, podName string) string {
 // the LeaderWorkerSet's share of the 63 character name budgets large.
 const hashDNSPrefixLength = 8
 
-func hashDNSPrefix(groupUniqueKey string) string {
-	if len(groupUniqueKey) < hashDNSPrefixLength {
-		return groupUniqueKey
+// hashLeaderHostname is the host name of a hash identity leader: the lws name
+// plus a prefix of the group key, the same shape as worker and ordinal names.
+func hashLeaderHostname(lwsName, groupUniqueKey string) string {
+	key := groupUniqueKey
+	if len(key) > hashDNSPrefixLength {
+		key = key[:hashDNSPrefixLength]
 	}
-	return groupUniqueKey[:hashDNSPrefixLength]
+	return fmt.Sprintf("%s-%s", lwsName, key)
 }
 
 // SetExclusiveAffinities set the pod affinity/anti-affinity

--- a/pkg/webhooks/pod_webhook.go
+++ b/pkg/webhooks/pod_webhook.go
@@ -100,11 +100,12 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 	}
 	// adding labels for pods
 	if podutils.LeaderPod(*pod) {
-		if pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash) {
+		hashIdentity := pod.Annotations[leaderworkerset.GroupIdentityAnnotationKey] == string(leaderworkerset.GroupIdentityHash)
+		var groupUniqueKey string
+		if hashIdentity {
 			// Hash-identity leaders are created through a Deployment: the pod name is
 			// not known at admission (generateName), so the group identity is a fresh
 			// random key rather than a name-derived ordinal.
-			var groupUniqueKey string
 			if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
 				groupUniqueKey = genGroupUniqueKey(pod.Namespace, utilrand.String(16))
 				pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
@@ -114,62 +115,38 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 			if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
 				pod.Labels[leaderworkerset.GroupIndexLabelKey] = groupUniqueKey
 			}
-			if epKey, foundEpKey := pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; foundEpKey {
-				SetExclusiveAffinities(pod, groupUniqueKey, epKey, leaderworkerset.GroupUniqueHashLabelKey)
-			}
-			// The group key also provides the leader's DNS identity: hostname is a
-			// prefix of the key and subdomain is the headless service the record
-			// lives under. Both fields are immutable, so admission is the only
-			// chance to set them.
-			hostPrefix := hashDNSPrefix(groupUniqueKey)
+			// The group key also provides the leader's hostname, a prefix of the key.
+			// The field is immutable, so admission is the only chance to set it. The
+			// subdomain default comes from the pod template.
 			if pod.Spec.Hostname == "" {
-				pod.Spec.Hostname = hostPrefix
+				pod.Spec.Hostname = hashDNSPrefix(groupUniqueKey)
 			}
-			if pod.Spec.Subdomain == "" {
-				subdomain := pod.Labels[leaderworkerset.SetNameLabelKey]
-				if sp, foundSP := pod.Annotations[leaderworkerset.SubdomainPolicyAnnotationKey]; foundSP && sp == string(leaderworkerset.SubdomainUniquePerReplica) {
-					// Service names must begin with a letter, so the per-replica
-					// service cannot be named the raw key.
-					subdomain = fmt.Sprintf("%s-%s", subdomain, hostPrefix)
+		} else {
+			// add group index label to group pods
+			if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
+				_, groupIndex := statefulsetutils.GetParentNameAndOrdinal(pod.Name)
+				if groupIndex == -1 {
+					return fmt.Errorf("parsing pod ordinal for pod %s", pod.Name)
 				}
-				pod.Spec.Subdomain = subdomain
+				pod.Labels[leaderworkerset.GroupIndexLabelKey] = fmt.Sprint(groupIndex)
 			}
-			_, foundSubGroupSize := pod.Annotations[leaderworkerset.SubGroupSizeAnnotationKey]
-			subGroupPolicyType := pod.Annotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey]
-			if foundSubGroupSize && pod.Labels[leaderworkerset.SubGroupIndexLabelKey] == "" && (subGroupPolicyType != string(leaderworkerset.SubGroupPolicyTypeLeaderExcluded)) {
-				// The leader pod always lands on SubGroup 0. The subgroup hash
-				// derives from the group key instead of the leader pod name.
-				pod.Labels[leaderworkerset.SubGroupIndexLabelKey] = "0"
-				subGroupUniqueKey := genGroupUniqueKey(groupUniqueKey, "0")
-				pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] = subGroupUniqueKey
-				if subEpKey, foundSubEpKey := pod.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]; foundSubEpKey {
-					SetExclusiveAffinities(pod, subGroupUniqueKey, subEpKey, leaderworkerset.SubGroupUniqueHashLabelKey)
-				}
+			// add group unique key label for exclusive placement, and use it to check whether the node affinity has been applied
+			if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
+				groupUniqueKey = genGroupUniqueKey(pod.Namespace, pod.Name)
+				pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
+			} else {
+				groupUniqueKey = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
 			}
-			if err := podutils.AddLWSVariables(pod); err != nil {
-				return err
-			}
-			return nil
-		}
-		// add group index label to group pods
-		if _, found := pod.Labels[leaderworkerset.GroupIndexLabelKey]; !found {
-			_, groupIndex := statefulsetutils.GetParentNameAndOrdinal(pod.Name)
-			if groupIndex == -1 {
-				return fmt.Errorf("parsing pod ordinal for pod %s", pod.Name)
-			}
-			pod.Labels[leaderworkerset.GroupIndexLabelKey] = fmt.Sprint(groupIndex)
 		}
 		subdomainPolicy, foundSubdomainPolicy := pod.Annotations[leaderworkerset.SubdomainPolicyAnnotationKey]
 		if foundSubdomainPolicy && subdomainPolicy == string(leaderworkerset.SubdomainUniquePerReplica) {
-			pod.Spec.Subdomain = pod.Name
-		}
-		// add group unique key label for exclusive placement, and use it to check whether the node affinity has been applied
-		var groupUniqueKey string
-		if _, foundGroupKey := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]; !foundGroupKey {
-			groupUniqueKey = genGroupUniqueKey(pod.Namespace, pod.Name)
-			pod.Labels[leaderworkerset.GroupUniqueHashLabelKey] = groupUniqueKey
-		} else {
-			groupUniqueKey = pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+			if hashIdentity {
+				// Service names must begin with a letter, so the per-replica
+				// service cannot be named the raw key.
+				pod.Spec.Subdomain = fmt.Sprintf("%s-%s", pod.Labels[leaderworkerset.SetNameLabelKey], pod.Spec.Hostname)
+			} else {
+				pod.Spec.Subdomain = pod.Name
+			}
 		}
 		if epKey, foundEpKey := pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]; foundEpKey {
 			SetExclusiveAffinities(pod, groupUniqueKey, epKey, leaderworkerset.GroupUniqueHashLabelKey)
@@ -177,9 +154,14 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 		_, foundSubGroupSize := pod.Annotations[leaderworkerset.SubGroupSizeAnnotationKey]
 		subGroupPolicyType := pod.Annotations[leaderworkerset.SubGroupPolicyTypeAnnotationKey]
 		if foundSubGroupSize && pod.Labels[leaderworkerset.SubGroupIndexLabelKey] == "" && (subGroupPolicyType != string(leaderworkerset.SubGroupPolicyTypeLeaderExcluded)) {
-			// The leader pod always lands on SubGroup 0.
+			// The leader pod always lands on SubGroup 0. In hash mode the subgroup
+			// hash derives from the group key instead of the leader pod name.
 			pod.Labels[leaderworkerset.SubGroupIndexLabelKey] = "0"
-			subGroupUniqueKey := genGroupUniqueKey(pod.Name, "0")
+			subGroupKeyInput := pod.Name
+			if hashIdentity {
+				subGroupKeyInput = groupUniqueKey
+			}
+			subGroupUniqueKey := genGroupUniqueKey(subGroupKeyInput, "0")
 			pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] = subGroupUniqueKey
 			if subEpKey, foundSubEpKey := pod.Annotations[leaderworkerset.SubGroupExclusiveKeyAnnotationKey]; foundSubEpKey {
 				SetExclusiveAffinities(pod, subGroupUniqueKey, subEpKey, leaderworkerset.SubGroupUniqueHashLabelKey)
@@ -227,7 +209,23 @@ func (p *PodWebhook) Default(ctx context.Context, pod *corev1.Pod) error {
 		}
 	}
 
-	if err := podutils.AddLWSVariables(pod); err != nil {
+	// Worker pods carry the leader's DNS address in an annotation stamped on the
+	// worker statefulset template by the pod controller. Leader pods derive it
+	// from their own DNS identity. Pods with neither carry an ordinal identity
+	// and their labels name the leader.
+	leaderAddress := pod.Annotations[leaderworkerset.LeaderAddressAnnotationKey]
+	if leaderAddress == "" {
+		groupIndex, foundGroupIndex := pod.Labels[leaderworkerset.GroupIndexLabelKey]
+		if !foundGroupIndex {
+			return fmt.Errorf("no group index label found for pod %s", pod.Name)
+		}
+		host := fmt.Sprintf("%s-%s", pod.Labels[leaderworkerset.SetNameLabelKey], groupIndex)
+		if podutils.LeaderPod(*pod) && pod.Spec.Hostname != "" {
+			host = pod.Spec.Hostname
+		}
+		leaderAddress = fmt.Sprintf("%s.%s.%s", host, pod.Spec.Subdomain, pod.Namespace)
+	}
+	if err := podutils.AddLWSVariables(pod, leaderAddress); err != nil {
 		return err
 	}
 

--- a/pkg/webhooks/pod_webhook_hash_test.go
+++ b/pkg/webhooks/pod_webhook_hash_test.go
@@ -63,8 +63,8 @@ func TestHashLeaderDNSDefaults(t *testing.T) {
 	if key == "" {
 		t.Fatal("expected a group key to be assigned")
 	}
-	if pod.Spec.Hostname != hashDNSPrefix(key) {
-		t.Errorf("expected hostname %q, got %q", hashDNSPrefix(key), pod.Spec.Hostname)
+	if want := hashLeaderHostname("hash-dns", key); pod.Spec.Hostname != want {
+		t.Errorf("expected hostname %q, got %q", want, pod.Spec.Hostname)
 	}
 	if pod.Spec.Subdomain != "hash-dns" {
 		t.Errorf("expected subdomain %q, got %q", "hash-dns", pod.Spec.Subdomain)
@@ -93,7 +93,10 @@ func TestHashLeaderUniquePerReplicaSubdomain(t *testing.T) {
 		t.Fatalf("defaulting hash leader: %v", err)
 	}
 	key := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
-	want := fmt.Sprintf("hash-upr-%s", hashDNSPrefix(key))
+	want := hashLeaderHostname("hash-upr", key)
+	if pod.Spec.Hostname != want {
+		t.Errorf("expected hostname %q, got %q", want, pod.Spec.Hostname)
+	}
 	if pod.Spec.Subdomain != want {
 		t.Errorf("expected per-replica subdomain %q, got %q", want, pod.Spec.Subdomain)
 	}

--- a/pkg/webhooks/pod_webhook_hash_test.go
+++ b/pkg/webhooks/pod_webhook_hash_test.go
@@ -44,7 +44,12 @@ func hashLeaderPod(lwsName string, extraAnnotations map[string]string) *corev1.P
 			},
 			Annotations: annotations,
 		},
-		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "leader"}}},
+		Spec: corev1.PodSpec{
+			// The leader Deployment's pod template carries the shared headless
+			// service as the subdomain default.
+			Subdomain:  lwsName,
+			Containers: []corev1.Container{{Name: "leader"}},
+		},
 	}
 }
 

--- a/pkg/webhooks/pod_webhook_hash_test.go
+++ b/pkg/webhooks/pod_webhook_hash_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+func hashLeaderPod(lwsName string, extraAnnotations map[string]string) *corev1.Pod {
+	annotations := map[string]string{
+		leaderworkerset.SizeAnnotationKey:          "2",
+		leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
+	}
+	for k, v := range extraAnnotations {
+		annotations[k] = v
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: lwsName + "-",
+			Namespace:    "default",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     lwsName,
+				leaderworkerset.WorkerIndexLabelKey: "0",
+			},
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "leader"}}},
+	}
+}
+
+func TestHashLeaderDNSDefaults(t *testing.T) {
+	webhook := &PodWebhook{}
+	pod := hashLeaderPod("hash-dns", nil)
+	if err := webhook.Default(context.TODO(), pod); err != nil {
+		t.Fatalf("defaulting hash leader: %v", err)
+	}
+	key := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+	if key == "" {
+		t.Fatal("expected a group key to be assigned")
+	}
+	if pod.Spec.Hostname != hashDNSPrefix(key) {
+		t.Errorf("expected hostname %q, got %q", hashDNSPrefix(key), pod.Spec.Hostname)
+	}
+	if pod.Spec.Subdomain != "hash-dns" {
+		t.Errorf("expected subdomain %q, got %q", "hash-dns", pod.Spec.Subdomain)
+	}
+	wantAddress := fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace)
+	found := false
+	for _, env := range pod.Spec.Containers[0].Env {
+		if env.Name == leaderworkerset.LwsLeaderAddress {
+			found = true
+			if env.Value != wantAddress {
+				t.Errorf("expected %s %q, got %q", leaderworkerset.LwsLeaderAddress, wantAddress, env.Value)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected %s env var on the leader", leaderworkerset.LwsLeaderAddress)
+	}
+}
+
+func TestHashLeaderUniquePerReplicaSubdomain(t *testing.T) {
+	webhook := &PodWebhook{}
+	pod := hashLeaderPod("hash-upr", map[string]string{
+		leaderworkerset.SubdomainPolicyAnnotationKey: string(leaderworkerset.SubdomainUniquePerReplica),
+	})
+	if err := webhook.Default(context.TODO(), pod); err != nil {
+		t.Fatalf("defaulting hash leader: %v", err)
+	}
+	key := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+	want := fmt.Sprintf("hash-upr-%s", hashDNSPrefix(key))
+	if pod.Spec.Subdomain != want {
+		t.Errorf("expected per-replica subdomain %q, got %q", want, pod.Spec.Subdomain)
+	}
+}
+
+func TestHashLeaderSubGroupLabels(t *testing.T) {
+	webhook := &PodWebhook{}
+	pod := hashLeaderPod("hash-sub", map[string]string{
+		leaderworkerset.SubGroupSizeAnnotationKey:         "2",
+		leaderworkerset.SubGroupExclusiveKeyAnnotationKey: "topo",
+	})
+	if err := webhook.Default(context.TODO(), pod); err != nil {
+		t.Fatalf("defaulting hash leader: %v", err)
+	}
+	key := pod.Labels[leaderworkerset.GroupUniqueHashLabelKey]
+	if got := pod.Labels[leaderworkerset.SubGroupIndexLabelKey]; got != "0" {
+		t.Errorf("expected leader subgroup index 0, got %q", got)
+	}
+	if got, want := pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey], genGroupUniqueKey(key, "0"); got != want {
+		t.Errorf("expected subgroup hash derived from the group key %q, got %q", want, got)
+	}
+	if !exclusiveAffinityApplied(*pod, "topo") {
+		t.Error("expected subgroup exclusive placement affinity to be applied")
+	}
+}
+
+func TestHashWorkerSubGroupKeyFromGroupKey(t *testing.T) {
+	webhook := &PodWebhook{}
+	groupKey := genGroupUniqueKey("default", "some-random-input")
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hash-sub-x2kkp-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:         "hash-sub",
+				leaderworkerset.GroupIndexLabelKey:      groupKey,
+				leaderworkerset.GroupUniqueHashLabelKey: groupKey,
+			},
+			Annotations: map[string]string{
+				leaderworkerset.SizeAnnotationKey:          "4",
+				leaderworkerset.SubGroupSizeAnnotationKey:  "2",
+				leaderworkerset.GroupIdentityAnnotationKey: string(leaderworkerset.GroupIdentityHash),
+				leaderworkerset.LeaderPodNameAnnotationKey: "hash-sub-x2kkp",
+				leaderworkerset.LeaderAddressAnnotationKey: "host.hash-sub.default",
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "worker"}}},
+	}
+	if err := webhook.Default(context.TODO(), pod); err != nil {
+		t.Fatalf("defaulting hash worker: %v", err)
+	}
+	subGroupIndex := pod.Labels[leaderworkerset.SubGroupIndexLabelKey]
+	if got, want := pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey], genGroupUniqueKey(groupKey, subGroupIndex); got != want {
+		t.Errorf("expected worker subgroup hash derived from the group key %q, got %q", want, got)
+	}
+	if unwanted := genGroupUniqueKey("hash-sub-x2kkp", subGroupIndex); pod.Labels[leaderworkerset.SubGroupUniqueHashLabelKey] == unwanted {
+		t.Error("worker subgroup hash still derived from the leader pod name")
+	}
+}

--- a/site/content/en/docs/reference/leaderworkerset.v1.md
+++ b/site/content/en/docs/reference/leaderworkerset.v1.md
@@ -50,6 +50,20 @@ description: Generated API reference documentation for leaderworkerset.x-k8s.io/
 </tbody>
 </table>
 
+## `GroupIdentityType`     {#leaderworkerset-x-k8s-io-v1-GroupIdentityType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [LeaderWorkerSetSpec](#leaderworkerset-x-k8s-io-v1-LeaderWorkerSetSpec)
+
+
+<p>GroupIdentityType defines how group identities are assigned.</p>
+
+
+
+
 ## `LeaderWorkerSetSpec`     {#leaderworkerset-x-k8s-io-v1-LeaderWorkerSetSpec}
     
 
@@ -114,6 +128,19 @@ when a revision is made to the leaderWorkerTemplate.</p>
 </td>
 <td>
    <p>networkConfig defines the network configuration of the group</p>
+</td>
+</tr>
+<tr><td><code>groupIdentity</code><br/>
+<a href="#leaderworkerset-x-k8s-io-v1-GroupIdentityType"><code>GroupIdentityType</code></a>
+</td>
+<td>
+   <p>groupIdentity determines how group identities are assigned.
+Ordinal (default) manages leaders through a StatefulSet: groups are named
+<!-- raw HTML omitted -->-0..<!-- raw HTML omitted -->-N-1 and scale down always removes the highest ordinal.
+Hash manages leaders through a Deployment: group names are hash-suffixed,
+scale down prefers unscheduled and not-ready groups over healthy ones, and
+rollouts are paced by a group readiness gate on the leader pods.
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>

--- a/test/integration/webhooks/disaggregatedset_test.go
+++ b/test/integration/webhooks/disaggregatedset_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	disaggregatedset "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -146,5 +147,52 @@ var _ = ginkgo.Describe("disaggregatedset placement policy validation", func() {
 		err := k8sClient.Update(ctx, &fetched)
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(leaderworkerset.ExclusiveKeyAnnotationKey))
+	})
+})
+
+var _ = ginkgo.Describe("disaggregatedset group identity", func() {
+
+	var ns *corev1.Namespace
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-ns-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	buildDisaggregatedSet := func(name string) *wrappers.DisaggregatedSetWrapper {
+		disagg := wrappers.BuildDisaggregatedSet(name, ns.Name).
+			WithRole("prefill", 1, "nginx:1.14.2").
+			WithRole("decode", 1, "nginx:1.14.2")
+		for i := range disagg.Spec.Roles {
+			disagg.Spec.Roles[i].Spec.RolloutStrategy.Type = leaderworkerset.RollingUpdateStrategyType
+			disagg.Spec.Roles[i].Spec.StartupPolicy = leaderworkerset.LeaderCreatedStartupPolicy
+		}
+		return disagg
+	}
+
+	ginkgo.It("persists a Hash groupIdentity role through the CRD schema", func() {
+		disagg := buildDisaggregatedSet("gi-hash").Obj()
+		disagg.Spec.Roles[0].Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+		gomega.Expect(k8sClient.Create(ctx, disagg)).To(gomega.Succeed())
+
+		fetched := &disaggregatedset.DisaggregatedSet{}
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: disagg.Name, Namespace: ns.Name}, fetched)).To(gomega.Succeed())
+		gomega.Expect(fetched.Spec.Roles[0].Spec.GroupIdentity).To(gomega.Equal(leaderworkerset.GroupIdentityHash))
+		// The role without an explicit value gets the CRD default.
+		gomega.Expect(fetched.Spec.Roles[1].Spec.GroupIdentity).To(gomega.Equal(leaderworkerset.GroupIdentityOrdinal))
+	})
+
+	ginkgo.It("rejects a Hash role with subGroupPolicy at admission", func() {
+		disagg := buildDisaggregatedSet("gi-hash-subgroup").Obj()
+		disagg.Spec.Roles[0].Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
+		disagg.Spec.Roles[0].Spec.LeaderWorkerTemplate.SubGroupPolicy = &leaderworkerset.SubGroupPolicy{
+			SubGroupSize: ptr.To(int32(1)),
+		}
+		err := k8sClient.Create(ctx, disagg)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("subGroupPolicy is not supported with groupIdentity Hash"))
 	})
 })

--- a/test/integration/webhooks/disaggregatedset_test.go
+++ b/test/integration/webhooks/disaggregatedset_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	disaggregatedset "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -185,14 +184,14 @@ var _ = ginkgo.Describe("disaggregatedset group identity", func() {
 		gomega.Expect(fetched.Spec.Roles[1].Spec.GroupIdentity).To(gomega.Equal(leaderworkerset.GroupIdentityOrdinal))
 	})
 
-	ginkgo.It("rejects a Hash role with subGroupPolicy at admission", func() {
-		disagg := buildDisaggregatedSet("gi-hash-subgroup").Obj()
+	ginkgo.It("rejects a Hash role with volumeClaimTemplates at admission", func() {
+		disagg := buildDisaggregatedSet("gi-hash-vct").Obj()
 		disagg.Spec.Roles[0].Spec.GroupIdentity = leaderworkerset.GroupIdentityHash
-		disagg.Spec.Roles[0].Spec.LeaderWorkerTemplate.SubGroupPolicy = &leaderworkerset.SubGroupPolicy{
-			SubGroupSize: ptr.To(int32(1)),
-		}
+		disagg.Spec.Roles[0].Spec.LeaderWorkerTemplate.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}}
 		err := k8sClient.Create(ctx, disagg)
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		gomega.Expect(err.Error()).To(gomega.ContainSubstring("subGroupPolicy is not supported with groupIdentity Hash"))
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("volumeClaimTemplates are not supported with groupIdentity Hash"))
 	})
 })

--- a/test/testutils/util.go
+++ b/test/testutils/util.go
@@ -198,6 +198,14 @@ func makeLeaderPod(leaderSts appsv1.StatefulSet, lws *leaderworkerset.LeaderWork
 		},
 		Spec: podTemplateSpec.Spec,
 	}
+	// The statefulset controller assigns the DNS identity of its pods and the
+	// pod webhook overrides the subdomain per replica. This suite runs neither,
+	// so mimic both here.
+	pod.Spec.Hostname = pod.Name
+	pod.Spec.Subdomain = leaderSts.Spec.ServiceName
+	if lws.Spec.NetworkConfig != nil && *lws.Spec.NetworkConfig.SubdomainPolicy == leaderworkerset.SubdomainUniquePerReplica {
+		pod.Spec.Subdomain = pod.Name
+	}
 	if lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "" {
 		pod.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] = lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey]
 	}

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -249,6 +249,7 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 		},
 	}
 	lws.Spec.StartupPolicy = leaderworkerset.LeaderCreatedStartupPolicy
+	lws.Spec.GroupIdentity = leaderworkerset.GroupIdentityOrdinal
 	subdomainPolicy := leaderworkerset.SubdomainShared
 	lws.Spec.NetworkConfig = &leaderworkerset.NetworkConfig{
 		SubdomainPolicy: &subdomainPolicy,


### PR DESCRIPTION
<!--
/kind feature
/kind api-change
-->
### Summary
Implements hash group identity from KEP-898 (PR: #986, Issue: #898). Adds `spec.groupIdentity` with values `Ordinal` (default, unchanged behavior) and `Hash`. In hash mode the controller manages leader pods through a Deployment instead of a StatefulSet:
  - scale down removes unscheduled and not-ready groups before healthy ones (ReplicaSet victim ranking)
  - a `group-ready` readiness gate on leader pods paces rollouts and availability by whole groups
  - groups are identified by random 40 character keys in the group-index and group-key labels
  - workers reach their leader by pod IP through `LWS_LEADER_ADDRESS`

DisaggregatedSet roles opt in through their inline LWS spec, and changing a role from Ordinal to Hash rolls out like normal.

Notes for the reviewer
  - `groupIdentity` is immutable on a LeaderWorkerSet. Validation rejects hash mode combined with volumeClaimTemplates and non-zero rolling update partition. `subGroupPolicy` and `subdomainPolicy: UniquePerReplica` are supported, with their identity derived from the group key instead of the leader pod name.
  - The revision normalization treats an empty value and the CRD default Ordinal identically. Without it, the new CRD default would change every existing DisaggregatedSet revision on upgrade and trigger a mass rollout. Covered by tests.

Testing: unit tests; integration specs for webhook behavior in both APIs. Benchmarking: node failure victim selection in both modes, DisaggregatedSet scale down under load, Ordinal to Hash migration.

Which issue(s) this PR fixes: Fixes #898

### Release Note
```release-note
LeaderWorkerSet supports `groupIdentity: Hash`, which manages leader pods with a Deployment so scale down removes unhealthy groups before healthy ones.
```
