### PR TITLE
Fix DisaggregatedSet StatefulSet name validation budget (#972)

### DIFF
--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -126,26 +126,43 @@ func (w *DisaggregatedSetWebhook) validateGeneratedNames(obj *disaggv1.Disaggreg
 	sliceDigits := len(strconv.Itoa(int(maxSliceIndex)))
 
 	const (
-		dns1035MaxLen    = 63
-		revisionLen      = 8 // hex characters in the revision hash
-		serviceSuffixLen = 4 // len("-prv")
-		separators       = 3 // three "-" between dsName, slice, revision, roleName
+		dns1035MaxLen                     = 63
+		revisionLen                       = 8 // hex characters in the revision hash
+		serviceSuffixLen                  = 4 // len("-prv")
+		separators                        = 3 // three "-" between dsName, slice, revision, roleName
+		statefulSetRevisionLabelSuffixLen = 11 // len("-<10-char-hash>")
 	)
 
 	rolesPath := field.NewPath("spec", "roles")
 	for i, role := range obj.Spec.Roles {
 		lwsNameLen := len(obj.Name) + separators + sliceDigits + revisionLen + len(role.Name)
-		svcNameLen := lwsNameLen + serviceSuffixLen
+		
+		groupIndexDigits := 1
+		if role.Spec.Replicas != nil && *role.Spec.Replicas > 0 {
+			groupIndexDigits = len(strconv.Itoa(int(*role.Spec.Replicas - 1)))
+		}
 
-		if svcNameLen > dns1035MaxLen {
-			combinedLimit := dns1035MaxLen - separators - sliceDigits - revisionLen - serviceSuffixLen
+		// The worker StatefulSet pods get a label "controller-revision-hash" with value:
+		// <lwsName>-<groupIndex>-<hash>
+		// Which translates to: lwsNameLen + 1 (dash) + groupIndexDigits + statefulSetRevisionLabelSuffixLen
+		workerRevisionLabelSuffixLen := 1 + groupIndexDigits + statefulSetRevisionLabelSuffixLen
+
+		maxSuffixLen := serviceSuffixLen
+		if workerRevisionLabelSuffixLen > maxSuffixLen {
+			maxSuffixLen = workerRevisionLabelSuffixLen
+		}
+
+		maxNameLen := lwsNameLen + maxSuffixLen
+
+		if maxNameLen > dns1035MaxLen {
+			combinedLimit := dns1035MaxLen - separators - sliceDigits - revisionLen - maxSuffixLen
 			allErrs = append(allErrs, field.Invalid(
 				rolesPath.Index(i).Child("name"),
 				role.Name,
 				fmt.Sprintf(
-					"the generated service name (%d chars) would exceed the DNS-1035 limit of %d characters; "+
+					"the generated names (%d chars) would exceed the DNS-1035 limit of %d characters (accounting for service name and StatefulSet revision hash labels); "+
 						"reduce the DisaggregatedSet name and/or role name (combined limit: %d characters)",
-					svcNameLen, dns1035MaxLen, combinedLimit,
+					maxNameLen, dns1035MaxLen, combinedLimit,
 				),
 			))
 		}

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -127,16 +127,16 @@ func (w *DisaggregatedSetWebhook) validateGeneratedNames(obj *disaggv1.Disaggreg
 
 	const (
 		dns1035MaxLen                     = 63
-		revisionLen                       = 8 // hex characters in the revision hash
-		serviceSuffixLen                  = 4 // len("-prv")
-		separators                        = 3 // three "-" between dsName, slice, revision, roleName
+		revisionLen                       = 8  // hex characters in the revision hash
+		serviceSuffixLen                  = 4  // len("-prv")
+		separators                        = 3  // three "-" between dsName, slice, revision, roleName
 		statefulSetRevisionLabelSuffixLen = 11 // len("-<10-char-hash>")
 	)
 
 	rolesPath := field.NewPath("spec", "roles")
 	for i, role := range obj.Spec.Roles {
 		lwsNameLen := len(obj.Name) + separators + sliceDigits + revisionLen + len(role.Name)
-		
+
 		groupIndexDigits := 1
 		if role.Spec.Replicas != nil && *role.Spec.Replicas > 0 {
 			groupIndexDigits = len(strconv.Itoa(int(*role.Spec.Replicas - 1)))

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook_test.go
@@ -539,11 +539,11 @@ func TestValidateCreate(t *testing.T) {
 		},
 		// --- Generated name length validation tests ---
 		{
-			// With slices=1 (default), overhead = 3 separators + 1 slice digit + 8 revision + 4 "-prv" = 16.
-			// dsName(40) + roleName(7) + 16 = 63 → exactly at limit.
-			name: "generated service name at exact 63-char limit is accepted",
+			// With slices=1 (default), overhead = 3 separators + 1 slice digit + 8 revision + 13 max suffix (1 dash + 1 group index digit + 11 hash) = 25.
+			// dsName(31) + roleName(7) + 25 = 63 → exactly at limit.
+			name: "generated names at exact 63-char limit is accepted",
 			obj: &disaggv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 40), Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 31), Namespace: "default"},
 				Spec: disaggv1.DisaggregatedSetSpec{
 					Roles: []disaggv1.DisaggregatedRoleSpec{
 						{
@@ -564,10 +564,10 @@ func TestValidateCreate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			// dsName(40) + roleName(8) + 16 = 64 → 1 char over.
-			name: "generated service name 1 char over limit is rejected",
+			// dsName(31) + roleName(8) + 25 = 64 → 1 char over.
+			name: "generated names 1 char over limit is rejected",
 			obj: &disaggv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 40), Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 31), Namespace: "default"},
 				Spec: disaggv1.DisaggregatedSetSpec{
 					Roles: []disaggv1.DisaggregatedRoleSpec{
 						{
@@ -589,10 +589,10 @@ func TestValidateCreate(t *testing.T) {
 			errorMsg:    "would exceed the DNS-1035 limit",
 		},
 		{
-			// Long DS name (50 chars) with a short role (3 chars): 50+3+16=69 → rejected.
+			// Long DS name (40 chars) with a short role (3 chars): 40+3+25=68 → rejected.
 			name: "long DS name with short role name exceeds limit",
 			obj: &disaggv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("x", 50), Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("x", 40), Namespace: "default"},
 				Spec: disaggv1.DisaggregatedSetSpec{
 					Roles: []disaggv1.DisaggregatedRoleSpec{
 						{
@@ -614,11 +614,11 @@ func TestValidateCreate(t *testing.T) {
 			errorMsg:    "would exceed the DNS-1035 limit",
 		},
 		{
-			// slices=100 → max index 99 → 2 digits. Overhead = 3+2+8+4 = 17.
-			// dsName(40) + roleName(7) + 17 = 64 → rejected (would be accepted with slices=1).
+			// slices=100 → max index 99 → 2 digits. Overhead = 3+2+8+13 = 26.
+			// dsName(31) + roleName(7) + 26 = 64 → rejected (would be accepted with slices=1).
 			name: "multi-slice worst case pushes name over limit",
 			obj: &disaggv1.DisaggregatedSet{
-				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 40), Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 31), Namespace: "default"},
 				Spec: disaggv1.DisaggregatedSetSpec{
 					Slices: ptr.To(int32(100)),
 					Roles: []disaggv1.DisaggregatedRoleSpec{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it
This updates `validateGeneratedNames` in the DisaggregatedSet webhook to enforce a tighter downstream name budget. 

Previously, it only accounted for the `-prv` Service suffix. However, it needs to account for the StatefulSet controller revision hash labels, specifically for worker StatefulSets which use the format `<lws>-<groupIndex>-<hash>`. This ensures that the generated labels never exceed the Kubernetes 63-character limit for label values.

#### Which issue(s) this PR fixes
Fixes #972

#### Special notes for your reviewer
This introduces dynamic calculation of the required overhead per-role depending on the number of replicas (which determines the length of the group index digit), ensuring the tightest possible budget is used to validate the name length at admission time.

#### Does this PR introduce a user-facing change?
```release-note
Fixes a bug where DisaggregatedSet admission accepted names that were too long, causing the downstream StatefulSet to fail to create Pods due to controller-revision-hash label limits.
