### PR TITLE
fix: keep kind_load_image archive cleanup in a subshell

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -119,17 +119,18 @@ function deploy_gang_scheduler() {
 
 # Avoid kind's --all-platforms import path for multi-arch release images.
 function kind_load_image {
-    local image="$1"
-    local archive
-    archive="$(mktemp)"
-    docker save "$image" -o "$archive"
+    (
+        local image="$1"
+        local archive
+        archive="$(mktemp)"
+        trap 'rm -f "$archive"' EXIT
+        docker save "$image" -o "$archive"
 
-    while IFS= read -r node; do
-        docker exec -i "$node" ctr --namespace=k8s.io images import \
-            --digests --snapshotter=overlayfs - < "$archive"
-    done < <($KIND get nodes --name "$KIND_CLUSTER_NAME")
-
-    rm -f "$archive"
+        while IFS= read -r node; do
+            docker exec -i "$node" ctr --namespace=k8s.io images import \
+                --digests --snapshotter=overlayfs - < "$archive"
+        done < <($KIND get nodes --name "$KIND_CLUSTER_NAME")
+    )
 }
 
 function kind_load {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`pull-lws-test-e2e-upgrade-main` exits before the upgrade tests:

```text
hack/e2e-test.sh: line 136: archive: unbound variable
```

`kind_load_image` registered a `RETURN` trap against a function-local
`archive`. The trap outlives that local variable and aborts a later function
return when `nounset` is enabled.

This change runs the image export and import in a subshell and uses an `EXIT`
trap, keeping the cleanup handler and temporary archive in the same scope.

#### Which issue(s) this PR fixes

Fixes #992

#### Special notes for your reviewer

The original commit was replaced by a maintainer-authored, signed-off commit
because its EasyCLA check remained unresolved. Thanks to @AshSgDe29071999 for
opening the focused fix and documenting the failure.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
