### PR TITLE
fix: support budget-driven combined rollout and scale-up

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -321,6 +321,18 @@ const (
 
 // RollingUpdateConfiguration defines the parameters to be used for RollingUpdateStrategyType.
 type RollingUpdateConfiguration struct {
+	// updateOrder controls whether existing replicas are updated before scaling up
+	// when the pod template and replica count increase in the same update.
+	// ScaleFirst preserves the existing behavior of creating the additional replicas
+	// before updating existing replicas. RolloutFirst updates existing replicas before
+	// creating the additional replicas, allowing their old resources to be released.
+	// The default value is ScaleFirst.
+	//
+	// +optional
+	// +kubebuilder:default=ScaleFirst
+	// +kubebuilder:validation:Enum={ScaleFirst,RolloutFirst}
+	UpdateOrder UpdateOrderType `json:"updateOrder,omitempty"`
+
 	// partition indicates the ordinal at which the lws should be partitioned for updates.
 	// During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
 	// The groups from 0 to Partition-1 will not be updated.
@@ -366,6 +378,16 @@ type RollingUpdateConfiguration struct {
 	// +kubebuilder:default=0
 	MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
 }
+
+type UpdateOrderType string
+
+const (
+	// ScaleFirst increases the replica count before updating existing replicas.
+	ScaleFirstUpdateOrder UpdateOrderType = "ScaleFirst"
+
+	// RolloutFirst updates existing replicas before increasing the replica count.
+	RolloutFirstUpdateOrder UpdateOrderType = "RolloutFirst"
+)
 
 type RolloutStrategyType string
 

--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -321,18 +321,6 @@ const (
 
 // RollingUpdateConfiguration defines the parameters to be used for RollingUpdateStrategyType.
 type RollingUpdateConfiguration struct {
-	// updateOrder controls whether existing replicas are updated before scaling up
-	// when the pod template and replica count increase in the same update.
-	// ScaleFirst preserves the existing behavior of creating the additional replicas
-	// before updating existing replicas. RolloutFirst updates existing replicas before
-	// creating the additional replicas, allowing their old resources to be released.
-	// The default value is ScaleFirst.
-	//
-	// +optional
-	// +kubebuilder:default=ScaleFirst
-	// +kubebuilder:validation:Enum={ScaleFirst,RolloutFirst}
-	UpdateOrder UpdateOrderType `json:"updateOrder,omitempty"`
-
 	// partition indicates the ordinal at which the lws should be partitioned for updates.
 	// During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
 	// The groups from 0 to Partition-1 will not be updated.
@@ -348,7 +336,7 @@ type RollingUpdateConfiguration struct {
 	Partition *int32 `json:"partition,omitempty"`
 
 	// maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-	// Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+	// Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
 	// Absolute number is calculated from percentage by rounding down.
 	// This can not be 0 if MaxSurge is 0.
 	// By default, a fixed value of 1 is used.
@@ -357,6 +345,11 @@ type RollingUpdateConfiguration struct {
 	// can be scaled down further, followed by scaling up the new replicas, ensuring
 	// that at least 70% of original number of replicas are available at all times
 	// during the update.
+	// During combined template updates and scale-up, controller-authorized disruption
+	// uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+	// Whole Ready additional groups provide credit; Pending additions do not block
+	// affordable old-group replacement. This is not a guarantee against independent
+	// failures or a strict ordering policy. An unaffordable old suffix can block progress.
 	//
 	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:default=1
@@ -365,7 +358,7 @@ type RollingUpdateConfiguration struct {
 	// maxSurge is the maximum number of replicas that can be scheduled above the original number of
 	// replicas.
 	// Value can be an absolute number (ex: 5) or a percentage of total replicas at
-	// the start of the update (ex: 10%).
+	// desired spec.replicas (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
 	// By default, a value of 0 is used.
 	// Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -378,16 +371,6 @@ type RollingUpdateConfiguration struct {
 	// +kubebuilder:default=0
 	MaxSurge intstr.IntOrString `json:"maxSurge,omitempty"`
 }
-
-type UpdateOrderType string
-
-const (
-	// ScaleFirst increases the replica count before updating existing replicas.
-	ScaleFirstUpdateOrder UpdateOrderType = "ScaleFirst"
-
-	// RolloutFirst updates existing replicas before increasing the replica count.
-	RolloutFirstUpdateOrder UpdateOrderType = "RolloutFirst"
-)
 
 type RolloutStrategyType string
 

--- a/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -16868,6 +16868,19 @@ spec:
                                       The default value is 0.
                                     format: int32
                                     type: integer
+                                  updateOrder:
+                                    default: ScaleFirst
+                                    description: |-
+                                      updateOrder controls whether existing replicas are updated before scaling up
+                                      when the pod template and replica count increase in the same update.
+                                      ScaleFirst preserves the existing behavior of creating the additional replicas
+                                      before updating existing replicas. RolloutFirst updates existing replicas before
+                                      creating the additional replicas, allowing their old resources to be released.
+                                      The default value is ScaleFirst.
+                                    enum:
+                                      - ScaleFirst
+                                      - RolloutFirst
+                                    type: string
                                 type: object
                               type:
                                 default: RollingUpdate

--- a/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -16828,7 +16828,7 @@ spec:
                                       maxSurge is the maximum number of replicas that can be scheduled above the original number of
                                       replicas.
                                       Value can be an absolute number (ex: 5) or a percentage of total replicas at
-                                      the start of the update (ex: 10%).
+                                      desired spec.replicas (ex: 10%).
                                       Absolute number is calculated from percentage by rounding up.
                                       By default, a value of 0 is used.
                                       Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -16844,7 +16844,7 @@ spec:
                                     default: 1
                                     description: |-
                                       maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-                                      Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+                                      Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
                                       Absolute number is calculated from percentage by rounding down.
                                       This can not be 0 if MaxSurge is 0.
                                       By default, a fixed value of 1 is used.
@@ -16853,6 +16853,11 @@ spec:
                                       can be scaled down further, followed by scaling up the new replicas, ensuring
                                       that at least 70% of original number of replicas are available at all times
                                       during the update.
+                                      During combined template updates and scale-up, controller-authorized disruption
+                                      uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+                                      Whole Ready additional groups provide credit; Pending additions do not block
+                                      affordable old-group replacement. This is not a guarantee against independent
+                                      failures or a strict ordering policy. An unaffordable old suffix can block progress.
                                     x-kubernetes-int-or-string: true
                                   partition:
                                     default: 0
@@ -16868,19 +16873,6 @@ spec:
                                       The default value is 0.
                                     format: int32
                                     type: integer
-                                  updateOrder:
-                                    default: ScaleFirst
-                                    description: |-
-                                      updateOrder controls whether existing replicas are updated before scaling up
-                                      when the pod template and replica count increase in the same update.
-                                      ScaleFirst preserves the existing behavior of creating the additional replicas
-                                      before updating existing replicas. RolloutFirst updates existing replicas before
-                                      creating the additional replicas, allowing their old resources to be released.
-                                      The default value is ScaleFirst.
-                                    enum:
-                                      - ScaleFirst
-                                      - RolloutFirst
-                                    type: string
                                 type: object
                               type:
                                 default: RollingUpdate

--- a/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -16818,6 +16818,19 @@ spec:
                             The default value is 0.
                           format: int32
                           type: integer
+                        updateOrder:
+                          default: ScaleFirst
+                          description: |-
+                            updateOrder controls whether existing replicas are updated before scaling up
+                            when the pod template and replica count increase in the same update.
+                            ScaleFirst preserves the existing behavior of creating the additional replicas
+                            before updating existing replicas. RolloutFirst updates existing replicas before
+                            creating the additional replicas, allowing their old resources to be released.
+                            The default value is ScaleFirst.
+                          enum:
+                            - ScaleFirst
+                            - RolloutFirst
+                          type: string
                       type: object
                     type:
                       default: RollingUpdate

--- a/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -16778,7 +16778,7 @@ spec:
                             maxSurge is the maximum number of replicas that can be scheduled above the original number of
                             replicas.
                             Value can be an absolute number (ex: 5) or a percentage of total replicas at
-                            the start of the update (ex: 10%).
+                            desired spec.replicas (ex: 10%).
                             Absolute number is calculated from percentage by rounding up.
                             By default, a value of 0 is used.
                             Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -16794,7 +16794,7 @@ spec:
                           default: 1
                           description: |-
                             maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-                            Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+                            Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
                             Absolute number is calculated from percentage by rounding down.
                             This can not be 0 if MaxSurge is 0.
                             By default, a fixed value of 1 is used.
@@ -16803,6 +16803,11 @@ spec:
                             can be scaled down further, followed by scaling up the new replicas, ensuring
                             that at least 70% of original number of replicas are available at all times
                             during the update.
+                            During combined template updates and scale-up, controller-authorized disruption
+                            uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+                            Whole Ready additional groups provide credit; Pending additions do not block
+                            affordable old-group replacement. This is not a guarantee against independent
+                            failures or a strict ordering policy. An unaffordable old suffix can block progress.
                           x-kubernetes-int-or-string: true
                         partition:
                           default: 0
@@ -16818,19 +16823,6 @@ spec:
                             The default value is 0.
                           format: int32
                           type: integer
-                        updateOrder:
-                          default: ScaleFirst
-                          description: |-
-                            updateOrder controls whether existing replicas are updated before scaling up
-                            when the pod template and replica count increase in the same update.
-                            ScaleFirst preserves the existing behavior of creating the additional replicas
-                            before updating existing replicas. RolloutFirst updates existing replicas before
-                            creating the additional replicas, allowing their old resources to be released.
-                            The default value is ScaleFirst.
-                          enum:
-                            - ScaleFirst
-                            - RolloutFirst
-                          type: string
                       type: object
                     type:
                       default: RollingUpdate

--- a/client-go/applyconfiguration/leaderworkerset/v1/rollingupdateconfiguration.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/rollingupdateconfiguration.go
@@ -19,6 +19,7 @@ package v1
 
 import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
 // RollingUpdateConfigurationApplyConfiguration represents a declarative configuration of the RollingUpdateConfiguration type for use
@@ -26,6 +27,13 @@ import (
 //
 // RollingUpdateConfiguration defines the parameters to be used for RollingUpdateStrategyType.
 type RollingUpdateConfigurationApplyConfiguration struct {
+	// updateOrder controls whether existing replicas are updated before scaling up
+	// when the pod template and replica count increase in the same update.
+	// ScaleFirst preserves the existing behavior of creating the additional replicas
+	// before updating existing replicas. RolloutFirst updates existing replicas before
+	// creating the additional replicas, allowing their old resources to be released.
+	// The default value is ScaleFirst.
+	UpdateOrder *leaderworkersetv1.UpdateOrderType `json:"updateOrder,omitempty"`
 	// partition indicates the ordinal at which the lws should be partitioned for updates.
 	// During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
 	// The groups from 0 to Partition-1 will not be updated.
@@ -65,6 +73,14 @@ type RollingUpdateConfigurationApplyConfiguration struct {
 // apply.
 func RollingUpdateConfiguration() *RollingUpdateConfigurationApplyConfiguration {
 	return &RollingUpdateConfigurationApplyConfiguration{}
+}
+
+// WithUpdateOrder sets the UpdateOrder field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the UpdateOrder field is set to the value of the last call.
+func (b *RollingUpdateConfigurationApplyConfiguration) WithUpdateOrder(value leaderworkersetv1.UpdateOrderType) *RollingUpdateConfigurationApplyConfiguration {
+	b.UpdateOrder = &value
+	return b
 }
 
 // WithPartition sets the Partition field in the declarative configuration to the given value

--- a/client-go/applyconfiguration/leaderworkerset/v1/rollingupdateconfiguration.go
+++ b/client-go/applyconfiguration/leaderworkerset/v1/rollingupdateconfiguration.go
@@ -19,7 +19,6 @@ package v1
 
 import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
 // RollingUpdateConfigurationApplyConfiguration represents a declarative configuration of the RollingUpdateConfiguration type for use
@@ -27,13 +26,6 @@ import (
 //
 // RollingUpdateConfiguration defines the parameters to be used for RollingUpdateStrategyType.
 type RollingUpdateConfigurationApplyConfiguration struct {
-	// updateOrder controls whether existing replicas are updated before scaling up
-	// when the pod template and replica count increase in the same update.
-	// ScaleFirst preserves the existing behavior of creating the additional replicas
-	// before updating existing replicas. RolloutFirst updates existing replicas before
-	// creating the additional replicas, allowing their old resources to be released.
-	// The default value is ScaleFirst.
-	UpdateOrder *leaderworkersetv1.UpdateOrderType `json:"updateOrder,omitempty"`
 	// partition indicates the ordinal at which the lws should be partitioned for updates.
 	// During a rolling update, all the groups from ordinal Partition to Replicas-1 will be updated.
 	// The groups from 0 to Partition-1 will not be updated.
@@ -45,7 +37,7 @@ type RollingUpdateConfigurationApplyConfiguration struct {
 	// The default value is 0.
 	Partition *int32 `json:"partition,omitempty"`
 	// maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-	// Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+	// Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
 	// Absolute number is calculated from percentage by rounding down.
 	// This can not be 0 if MaxSurge is 0.
 	// By default, a fixed value of 1 is used.
@@ -54,11 +46,16 @@ type RollingUpdateConfigurationApplyConfiguration struct {
 	// can be scaled down further, followed by scaling up the new replicas, ensuring
 	// that at least 70% of original number of replicas are available at all times
 	// during the update.
+	// During combined template updates and scale-up, controller-authorized disruption
+	// uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+	// Whole Ready additional groups provide credit; Pending additions do not block
+	// affordable old-group replacement. This is not a guarantee against independent
+	// failures or a strict ordering policy. An unaffordable old suffix can block progress.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 	// maxSurge is the maximum number of replicas that can be scheduled above the original number of
 	// replicas.
 	// Value can be an absolute number (ex: 5) or a percentage of total replicas at
-	// the start of the update (ex: 10%).
+	// desired spec.replicas (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
 	// By default, a value of 0 is used.
 	// Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -73,14 +70,6 @@ type RollingUpdateConfigurationApplyConfiguration struct {
 // apply.
 func RollingUpdateConfiguration() *RollingUpdateConfigurationApplyConfiguration {
 	return &RollingUpdateConfigurationApplyConfiguration{}
-}
-
-// WithUpdateOrder sets the UpdateOrder field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the UpdateOrder field is set to the value of the last call.
-func (b *RollingUpdateConfigurationApplyConfiguration) WithUpdateOrder(value leaderworkersetv1.UpdateOrderType) *RollingUpdateConfigurationApplyConfiguration {
-	b.UpdateOrder = &value
-	return b
 }
 
 // WithPartition sets the Partition field in the declarative configuration to the given value

--- a/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -18343,6 +18343,19 @@ spec:
                                     The default value is 0.
                                   format: int32
                                   type: integer
+                                updateOrder:
+                                  default: ScaleFirst
+                                  description: |-
+                                    updateOrder controls whether existing replicas are updated before scaling up
+                                    when the pod template and replica count increase in the same update.
+                                    ScaleFirst preserves the existing behavior of creating the additional replicas
+                                    before updating existing replicas. RolloutFirst updates existing replicas before
+                                    creating the additional replicas, allowing their old resources to be released.
+                                    The default value is ScaleFirst.
+                                  enum:
+                                  - ScaleFirst
+                                  - RolloutFirst
+                                  type: string
                               type: object
                             type:
                               default: RollingUpdate

--- a/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+++ b/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
@@ -18303,7 +18303,7 @@ spec:
                                     maxSurge is the maximum number of replicas that can be scheduled above the original number of
                                     replicas.
                                     Value can be an absolute number (ex: 5) or a percentage of total replicas at
-                                    the start of the update (ex: 10%).
+                                    desired spec.replicas (ex: 10%).
                                     Absolute number is calculated from percentage by rounding up.
                                     By default, a value of 0 is used.
                                     Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -18319,7 +18319,7 @@ spec:
                                   default: 1
                                   description: |-
                                     maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-                                    Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+                                    Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
                                     Absolute number is calculated from percentage by rounding down.
                                     This can not be 0 if MaxSurge is 0.
                                     By default, a fixed value of 1 is used.
@@ -18328,6 +18328,11 @@ spec:
                                     can be scaled down further, followed by scaling up the new replicas, ensuring
                                     that at least 70% of original number of replicas are available at all times
                                     during the update.
+                                    During combined template updates and scale-up, controller-authorized disruption
+                                    uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+                                    Whole Ready additional groups provide credit; Pending additions do not block
+                                    affordable old-group replacement. This is not a guarantee against independent
+                                    failures or a strict ordering policy. An unaffordable old suffix can block progress.
                                   x-kubernetes-int-or-string: true
                                 partition:
                                   default: 0
@@ -18343,19 +18348,6 @@ spec:
                                     The default value is 0.
                                   format: int32
                                   type: integer
-                                updateOrder:
-                                  default: ScaleFirst
-                                  description: |-
-                                    updateOrder controls whether existing replicas are updated before scaling up
-                                    when the pod template and replica count increase in the same update.
-                                    ScaleFirst preserves the existing behavior of creating the additional replicas
-                                    before updating existing replicas. RolloutFirst updates existing replicas before
-                                    creating the additional replicas, allowing their old resources to be released.
-                                    The default value is ScaleFirst.
-                                  enum:
-                                  - ScaleFirst
-                                  - RolloutFirst
-                                  type: string
                               type: object
                             type:
                               default: RollingUpdate

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -17803,6 +17803,19 @@ spec:
                           The default value is 0.
                         format: int32
                         type: integer
+                      updateOrder:
+                        default: ScaleFirst
+                        description: |-
+                          updateOrder controls whether existing replicas are updated before scaling up
+                          when the pod template and replica count increase in the same update.
+                          ScaleFirst preserves the existing behavior of creating the additional replicas
+                          before updating existing replicas. RolloutFirst updates existing replicas before
+                          creating the additional replicas, allowing their old resources to be released.
+                          The default value is ScaleFirst.
+                        enum:
+                        - ScaleFirst
+                        - RolloutFirst
+                        type: string
                     type: object
                   type:
                     default: RollingUpdate

--- a/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+++ b/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
@@ -17763,7 +17763,7 @@ spec:
                           maxSurge is the maximum number of replicas that can be scheduled above the original number of
                           replicas.
                           Value can be an absolute number (ex: 5) or a percentage of total replicas at
-                          the start of the update (ex: 10%).
+                          desired spec.replicas (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
                           By default, a value of 0 is used.
                           Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -17779,7 +17779,7 @@ spec:
                         default: 1
                         description: |-
                           maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-                          Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+                          Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
                           Absolute number is calculated from percentage by rounding down.
                           This can not be 0 if MaxSurge is 0.
                           By default, a fixed value of 1 is used.
@@ -17788,6 +17788,11 @@ spec:
                           can be scaled down further, followed by scaling up the new replicas, ensuring
                           that at least 70% of original number of replicas are available at all times
                           during the update.
+                          During combined template updates and scale-up, controller-authorized disruption
+                          uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+                          Whole Ready additional groups provide credit; Pending additions do not block
+                          affordable old-group replacement. This is not a guarantee against independent
+                          failures or a strict ordering policy. An unaffordable old suffix can block progress.
                         x-kubernetes-int-or-string: true
                       partition:
                         default: 0
@@ -17803,19 +17808,6 @@ spec:
                           The default value is 0.
                         format: int32
                         type: integer
-                      updateOrder:
-                        default: ScaleFirst
-                        description: |-
-                          updateOrder controls whether existing replicas are updated before scaling up
-                          when the pod template and replica count increase in the same update.
-                          ScaleFirst preserves the existing behavior of creating the additional replicas
-                          before updating existing replicas. RolloutFirst updates existing replicas before
-                          creating the additional replicas, allowing their old resources to be released.
-                          The default value is ScaleFirst.
-                        enum:
-                        - ScaleFirst
-                        - RolloutFirst
-                        type: string
                     type: object
                   type:
                     default: RollingUpdate

--- a/docs/combined-rollout-investigation.md
+++ b/docs/combined-rollout-investigation.md
@@ -1,0 +1,278 @@
+# Combined rollout: local executable investigation
+
+Status: **bounded production implementation connected to `Reconcile`**. The
+branch's ordering enum is removed. Scoped native AKS validation is recorded
+below; this does not imply maintainer approval. This implements a narrower local #717 contract, not
+the separate #1018 proposal or universal neutral-repair liveness.
+
+## Implemented production scope
+
+The experiment helper was promoted into
+[combined_rollout.go](../pkg/controllers/combined_rollout.go), used by
+[combined_rollout_controller.go](../pkg/controllers/combined_rollout_controller.go).
+The retained tests exercise that same production planner. Its rules are:
+
+- Persist initial replica baseline `B`, latest desired `D`, active generation,
+  template revision, and outstanding ordinal/UID reservations in one JSON value.
+  It does not derive the baseline from Ready count or the overwritten replicas
+  annotation. Supersession retains `B`; explicit downscale uses `min(B,D)` for
+  the floor.
+- Resolve `U` by rounding down against `D`, and `S` by rounding up against `D`.
+  Preserve the nonzero-desired rejection of jointly zero resolved budgets.
+- Count complete Ready groups across revisions. Exclude terminating leaders,
+  terminating workers, mismatched controller UIDs/revisions, missing workers,
+  stale worker status and stale worker generations. Use each leader's stamped
+  size, not the latest LWS size, when evaluating an old group.
+- Exclude an authorized old group's credit immediately, even if a repeated
+  observation still sees its old leader Ready. Release its reservation only
+  when a different leader UID and its entire replacement group are Ready at the
+  reserved LWS and native revisions, or after an acknowledged freeze withdraws
+  an obsolete rollback/partition authorization. Retry deletion using the observed leader identity.
+- Permit paid replacements only above `max(0,min(B,D)-U)`. Unavailable old
+  groups can be repaired without spending another Ready group, provided the
+  partition suffix can be authorized.
+- Reserve every stale leader exposed by the partition, including those the
+  native controller could delete independently. Skip already-updated Pending
+  ordinals when selecting a lower explicit deletion.
+- Freeze before introducing or superseding a template, then wait for native
+  observedGeneration before publication. Wait again for observedGeneration and
+  updateRevision before planning. The planner's `templateFrozen` test input is
+  not itself an acknowledgement; production uses persisted phase barriers.
+- Create desired additions without automatically adding surge on top of a
+  scale-up. Keep operation state until desired partition-aware convergence and
+  observed surge cleanup. Ordinary rollout/scaling without active state stays
+  on the legacy path. Default U=1 can replace old groups before Pending additions
+  complete, changing the previous default combined scale-first behavior.
+- Bound reservations to 64 entries and state to 24 KiB. A full window blocks
+  additional suffix exposure until replacements recover. The floor bounds
+  controller-authorized disruption from observed health, not independent failures
+  or strict update ordering. Baseline is the pre-operation non-surge target.
+
+This is inspired by DaemonSet's distinction between unavailable old Pods that
+can be repaired and available old Pods whose deletion consumes budget. Unlike
+DaemonSet, an ordinal StatefulSet represents update eligibility with a suffix,
+not an arbitrary set of independent targets.
+
+## What the tests establish
+
+[combined_rollout_planner_test.go](../pkg/controllers/combined_rollout_planner_test.go)
+checks the 1-to-2 Pending-addition case, zero-budget waiting and Ready-addition
+credit, 4-to-8 concurrency, percentage rounding, repeated observations/restarts,
+initial unhealthy repair, whole-group readiness, supersession, downscale/zero,
+partition protection, malformed state, and all 256 readiness masks under each
+of four budgets for a 4-to-8 transition.
+
+The `B=2,D=3,U=1 -> 0 -> 1` case selects old ordinal 0 despite updated Pending
+ordinal 1 and Ready ordinal 2. A characterization of the native gate-disabled
+descending loop stops at ordinal 1. Thus explicit deletion, rather than merely
+lowering the partition, makes a real difference in the planner.
+
+[combined_rollout_api_test.go](../pkg/controllers/combined_rollout_api_test.go)
+uses an existing local envtest API server to establish that:
+
+1. SSA with `metadata.resourceVersion` atomically writes reservation and
+   partition, and rejects a stale second plan even with force ownership.
+2. Pod UID/resourceVersion preconditions reject stale deletion requests.
+3. An unconditioned by-name request can delete a replacement Pod. This is an
+   API fact, **not a reproduced StatefulSet race**: the native controller also
+   serializes per-set syncs and recreates Pods itself.
+4. `OnDelete` cannot retain `rollingUpdate.partition`: the API rejects that
+   combination, accepting the strategy change only after removing that field.
+
+Envtest here has no StatefulSet controller, scheduler, kubelet, or garbage
+collector. Pod replacement is simulated explicitly. The native-loop and
+creation-selection characterizations are not imported Kubernetes controller
+tests and must not be reported as older-cluster E2E validation.
+
+## Remaining neutral-repair limitation
+
+There is a distinct obstruction beyond the updated-Pending-middle case:
+
+| Ordinal | Revision | Whole group | Native leader readiness |
+| --- | --- | --- | --- |
+| 0 | old | Ready | Ready |
+| 1 | old | unavailable | not Ready |
+| 2 | old | Ready | Ready |
+| 3 | new | workers unavailable | Ready |
+
+For `B=3,D=4,U=1`, the floor is two and exactly two groups supply credit.
+Repairing group 1 at the new template would be availability-neutral. However:
+
+- Partition must be at most 1 for native recreation of ordinal 1 at the new
+  template.
+- That also exposes Ready old ordinal 2. The gate-disabled native controller
+  passes Ready leader 3 and deletes ordinal 2, leaving only one Ready group.
+  It does not know that group 3's workers are unavailable.
+- Keeping partition 3 allows direct repair of ordinal 1 only at the **current,
+  old template**. That can recover a transient failure, but cannot guarantee
+  progress when the old template itself must change.
+- Reserving ordinal 2 cannot invent the missing Ready credit. Requiring it to
+  become affordable preserves safety but can leave neutral repair blocked.
+
+`TestCombinedPlannerNeutralRepairBehindReadyOldSuffix` characterizes this
+limitation. The test **passes by asserting conservative blocking**, not by
+asserting the requested general neutral-repair liveness has been achieved.
+
+The production suffix planner explicitly adopts this narrower local contract
+and emits `CombinedRolloutBudgetBlocked`. It does not claim arbitrary
+DaemonSet-style neutral repair. DaemonSet's per-node pairs differ from LWS group
+identities; LWS retains mixed positive budgets and its existing rounding rules.
+
+## Alternative examined: OnDelete with protected-revision admission
+
+Plain OnDelete removes native rolling deletions and permits independent
+budget-authorized leader deletion. It does not preserve old-version recreation
+below the user's partition: native creation uses the updated template because
+the native partition field is absent. This is covered by the API test and the
+creation-selection characterization.
+
+An admission-assisted alternative could restore the protected revision during
+leader Pod **creation**, before existing Pod defaulting. This avoids racing an
+LWS-created Pod against native creation, but it is a substantially larger
+controller/admission protocol:
+
+1. Persist the protected revision selection and retain its ControllerRevision
+   before publishing the OnDelete strategy. A single latest-revision label is
+   insufficient across supersession and partition changes.
+2. Give the currently stateless `PodWebhook` an authenticated, uncached reader.
+   Validate actual leader StatefulSet owner UID and ordinal; do not trust only
+   caller-supplied LWS labels. Fail closed when required state/history is absent.
+3. Restore the complete revision-specific leader template, not just its image
+   or revision label. Preserve native Pod identity, ordinal PVC naming/bindings,
+   hostname/subdomain, owner reference and retention behavior. Then perform
+   existing LWS defaults, topology/TPU/PodGroup injection and environment setup
+   using the restored size and metadata. The current webhook only decorates the
+   template it receives; it cannot currently do this restoration.
+4. Reconcile creation admission with state-generation changes. A request must
+   not select a newer protected template from a stale state snapshot. Strategy
+   entry/exit and restoration of RollingUpdate need explicit handoff barriers.
+5. Keep protected history while it can be used by admission. In native OnDelete,
+   `completeRollingUpdate` does not promote `currentRevision`, so that field
+   alone is not an authoritative protected snapshot for later operations.
+6. Integrate worker recreation, revision-specific size, foreground leader/worker
+   cleanup, and stale UID handling. In the existing Pod controller, the early
+   size-one check uses the live LWS size, before revision restoration; that also
+   needs review for protected old groups with a different size.
+
+This could remove the suffix limitation, but it is not a safe local substitution
+of `OnDelete` for `RollingUpdate`. It needs creation-admission and native-controller
+tests, history lifecycle changes, and a specified protected-revision policy. No
+such admission-assisted production changes are included or required for this
+bounded implementation.
+
+## Implemented native handoff and remaining validation boundary
+
+Production checks live LWS UID/generation and StatefulSet UID/resourceVersion
+through the manager APIReader. Old-template freeze and new-template publication
+are separate acknowledged phases. Operational state/partition writes use
+optimistic-lock merge patches; template publication uses the complete intended
+declarative configuration with resourceVersion-fenced SSA. Neither operation
+claims unrelated observed fields. A later observation performs authorized direct
+deletion with Pod UID/RV preconditions, normal grace, and foreground worker GC.
+Every exposed stale leader is reserved, not merely the explicit deletion target.
+No temporary OnDelete or new native feature gate is required.
+
+Real Reconcile/envtest tests exercise phase persistence, acknowledgements, U=0
+whole-Ready credit, 1->2 and 4->8 Pending additions, restart/payment retention,
+stale LWS generations, supersession and malformed state. Native status and Pods
+are explicitly simulated: these tests do not reproduce native controller races.
+Separate native capacity-constrained AKS smoke tests are recorded below. They
+do not establish older-cluster or gate-disabled compatibility.
+
+The API enum, webhook restrictions, wrappers, generated client configuration,
+both CRD schemas/Helm copies and API reference are removed/regenerated. Existing
+unrelated line-ending changes are not reverted.
+
+## Final local validation - 2026-09-09
+
+- Full `make test`: **602 tests passed**.
+- Focused controller/webhook/revision/StatefulSet utility run: **168 test/subtest passes**.
+- Targeted rolling-update, scale, and surge integration: **23 passed, 0 failed**;
+  30 other specs were outside the selection. This is not a full integration-suite pass.
+- Go lint: **0 issues**.
+- `git diff --check`: **passed** after restoring LF endings in the two generated
+  API-reference pages. The DisaggregatedSet reference has no remaining diff.
+- Scoped native AKS 1.35.7 smoke validation: **passed**, as detailed below.
+  Earlier AKS validation of the ordering prototype is separate evidence and is
+  not counted as validation of this new controller path.
+
+Final regressions cover native-vs-LWS revision identity, worker native hashes,
+downscale before reserved deletion, rollback and partition changes across
+restarts, native revision promotion before cleanup, independent SSA metadata
+ownership, and revision reuse while waiting for freeze acknowledgement.
+Production now pins both native and LWS target revisions and uses optimistic
+operational patches rather than applying the entire observed StatefulSet.
+Earlier failed/timed-out runs below describe the investigation history, not
+the final results.
+
+## Native AKS validation - 2026-09-09
+
+The budget-driven implementation was built from the uncommitted working tree
+and deployed to a private AKS 1.35.7 cluster. Both controller replicas ran image
+digest `sha256:0178dc26f47c80eabbfd6d2fa42ebadbecdad6e4b922144216ba4abcb43b2702`.
+The 427-file source inventory was verified unchanged during validation; this
+subsequent documentation update does not change the tested controller code.
+
+Native scheduler, StatefulSet controller, kubelet and garbage collector were
+used, without simulated status, manual worker deletion or finalizer removal.
+Each fixture had size-two groups pinned through a node selector. Old Pods
+requested 300m CPU each and new Pods 175m each. A test-only filler left 750m
+available: the old 600m group and final 700m workload fit individually, but an
+old group plus one new Pod requires 775m and cannot fit.
+
+- **U1/S0, replicas 1 to 2:** a pre-mutation Pod watch captured the additional
+  leader Pending with `Insufficient cpu` before the original leader's
+  termination update. Native worker GC followed. The paid reservation remained
+  while the replacement leader was Ready but its worker was deliberately unready.
+- **U0/S1, replicas 1 to 2:** both original Pod UIDs remained Ready and unchanged
+  during bounded 15-second observations of Pending additions and, after releasing
+  the test filler, an additional Ready leader with an unready worker. Making the
+  additional worker Ready supplied whole-group credit and enabled replacement.
+- **Both finals:** four target-revision Ready Pods with correct ownership and
+  native worker revisions; native leader revision promotion, observed generation,
+  combined-state removal and retained RollingUpdate were verified. Both scenario
+  namespaces and their fillers were cleaned up.
+- **Admission:** server dry-run accepted U1/S0 and U0/S1, rejected jointly zero
+  budgets, and rejected removed `updateOrder` under strict validation.
+
+The completed smoke run passed 73 as-run assertions and 34 independent evidence
+checks. Raw Pod, StatefulSet, LWS and Event watches were established before
+mutation; timestamps, resource versions, UIDs and final snapshots were retained
+in local validation artifacts. An earlier attempt with broken watch setup is
+not counted as a passing transition test.
+
+**Extended restart/partition validation remains incomplete.** A B2/D3/U1/S0
+restart attempt successfully replaced both controller Pods, but the test harness
+asserted the new leader-election lease holder before lease handoff completed.
+Subsequent read-only observations verified new leadership, retained baseline and
+reservation, and protected old-group UIDs. These checks do not constitute a
+complete scenario: final convergence was not executed and the partition scenario
+was not run. Harness failures are not established controller defects. Full E2E,
+stock-controller A/B, and older gate-disabled native validation are not claimed.
+
+## Previous experiment validation (2026-09-09, not production validation)
+
+- Existing Ubuntu-22.04 Go 1.26.0; existing envtest assets Kubernetes 1.36.0.
+- Focused `TestCombined` run: PASS, including the real API precondition tests
+  and the two limitation characterizations; package time 11.592 seconds.
+- Existing controller, webhook, revision utility, and StatefulSet utility unit
+  packages: PASS in the regression run.
+- Full controller/webhook integration attempt with a four-minute Go timeout:
+  webhook package PASS (35.592 seconds); controller package did not complete
+  before the timeout (240.194 seconds). The captured stack was in the existing
+  `ExpectWorkerStatefulSetsNotCreated` assertion. This is **not a full integration
+  pass**, and no root cause or regression attribution is asserted.
+- The initial dependency download failed because WSL could not resolve the Go
+  proxy. The missing YAML module was downloaded through normal Windows HTTPS
+  into the existing Go download cache; Go then verified/used it successfully.
+  No checksum/TLS bypass, dependency-file change, or network configuration change
+  was made.
+
+## Pinned reference code
+
+- [DaemonSet rollout selection, Kubernetes v1.35.0](https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/daemon/update.go)
+- [DaemonSet surge KEP 1591](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1591-daemonset-surge)
+- [StatefulSet update loop and generation status](https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/statefulset/stateful_set_control.go)
+- [StatefulSet per-key serialized workqueue](https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/statefulset/stateful_set.go)
+- [Pod deletion request options](https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/statefulset/stateful_pod_control.go)
+- [Versioned Pod creation and revision promotion](https://github.com/kubernetes/kubernetes/blob/v1.35.0/pkg/controller/statefulset/stateful_set_utils.go)

--- a/pkg/controllers/combined_rollout.go
+++ b/pkg/controllers/combined_rollout.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	podutils "sigs.k8s.io/lws/pkg/utils/pod"
+)
+
+const (
+	combinedRolloutAnnotation = "leaderworkerset.sigs.k8s.io/combined-rollout"
+	// Bound persisted state independently of replica count. A full reservation
+	// window pauses further suffix exposure until existing replacements recover.
+	combinedReservationLimit = 64
+	combinedStateLimit       = 24 * 1024
+	combinedFreeze           = "freeze"
+	combinedPublish          = "publish"
+	combinedActive           = "active"
+)
+
+// These types retain the experiment's names so its exhaustive tests exercise
+// precisely the production planner, rather than a duplicate test-only model.
+type combinedModelReservation struct {
+	UID      types.UID `json:"uid"`
+	Revision string    `json:"revision"`
+}
+
+// Baseline is the initial non-surge target, never observed Ready capacity.
+// Phase barriers belong to the actuator; the planner cannot acknowledge them.
+type combinedModelState struct {
+	Version        int                                `json:"v"`
+	Baseline       int32                              `json:"b"`
+	Desired        int32                              `json:"d"`
+	Generation     int64                              `json:"g"`
+	Revision       string                             `json:"r"`
+	NativeRevision string                             `json:"native,omitempty"`
+	TargetTemplate string                             `json:"template,omitempty"`
+	Protected      int32                              `json:"protected,omitempty"`
+	Phase          string                             `json:"phase,omitempty"`
+	Reservations   map[int32]combinedModelReservation `json:"pending,omitempty"`
+}
+
+type combinedModelGroup struct {
+	leader  *corev1.Pod
+	workers *appsv1.StatefulSet
+	pods    []corev1.Pod
+}
+
+func combinedModelOwnedBy(obj metav1.Object, kind string, uid types.UID) bool {
+	owner := metav1.GetControllerOf(obj)
+	return uid != "" && owner != nil && owner.Kind == kind && owner.UID == uid
+}
+
+// A group's size is stamped on its leader, including protected old revisions.
+// Termination, stale owners and stale aggregate status never provide credit.
+func (g combinedModelGroup) ready(stsUID types.UID) bool {
+	p := g.leader
+	if p == nil || p.DeletionTimestamp != nil || !combinedModelOwnedBy(p, "StatefulSet", stsUID) || !podutils.PodRunningAndReady(*p) {
+		return false
+	}
+	size, err := strconv.Atoi(p.Annotations[leaderworkerset.SizeAnnotationKey])
+	if err != nil || size < 1 || p.Labels[leaderworkerset.RevisionKey] == "" {
+		return false
+	}
+	if size == 1 {
+		return true
+	}
+	w := g.workers
+	if w == nil || w.DeletionTimestamp != nil || !combinedModelOwnedBy(w, "Pod", p.UID) ||
+		w.Spec.Replicas == nil || int(*w.Spec.Replicas) != size-1 || w.Status.ObservedGeneration < w.Generation ||
+		w.Status.AvailableReplicas != *w.Spec.Replicas || w.Status.UpdateRevision == "" || w.Status.CurrentRevision != w.Status.UpdateRevision ||
+		w.Labels[leaderworkerset.RevisionKey] != p.Labels[leaderworkerset.RevisionKey] {
+		return false
+	}
+	seen := make(map[int]bool)
+	for _, worker := range g.pods {
+		i, err := strconv.Atoi(worker.Labels[leaderworkerset.WorkerIndexLabelKey])
+		if err != nil || i < 1 || i >= size || worker.Name != fmt.Sprintf("%s-%d", p.Name, i) ||
+			!combinedModelOwnedBy(&worker, "StatefulSet", w.UID) || worker.DeletionTimestamp != nil ||
+			worker.Labels[leaderworkerset.RevisionKey] != p.Labels[leaderworkerset.RevisionKey] ||
+			worker.Labels[appsv1.ControllerRevisionHashLabelKey] != w.Status.UpdateRevision || !podutils.PodRunningAndReady(worker) {
+			continue
+		}
+		seen[i] = true
+	}
+	return len(seen) == size-1
+}
+
+type combinedModelInput struct {
+	baseline, desired, replicas, partition, protected int32
+	generation                                        int64
+	revision                                          string
+	nativeRevision                                    string
+	stsUID                                            types.UID
+	unavailable, surge                                intstr.IntOrString
+	groups                                            []combinedModelGroup
+	state                                             string
+	// Set only after the actuator's freeze/publish generation barriers.
+	templateFrozen bool
+}
+
+type combinedModelPlan struct {
+	partition, replicas, floor, credited int32
+	state                                string
+	deletes                              []*corev1.Pod
+	freeze, done, blocked                bool
+}
+
+func combinedModelDecode(raw string) (combinedModelState, error) {
+	var s combinedModelState
+	if len(raw) > combinedStateLimit {
+		return s, fmt.Errorf("combined rollout state too large")
+	}
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		return s, err
+	}
+	if s.Version != 1 || s.Baseline < 0 || s.Desired < 0 || s.Protected < 0 || s.Generation < 1 || s.Revision == "" || len(s.Revision) > 128 || len(s.NativeRevision) > 253 || len(s.TargetTemplate) > 64 || len(s.Reservations) > combinedReservationLimit {
+		return s, fmt.Errorf("invalid combined rollout state")
+	}
+	if s.Phase != "" && s.Phase != combinedFreeze && s.Phase != combinedPublish && s.Phase != combinedActive {
+		return s, fmt.Errorf("invalid combined rollout phase")
+	}
+	for i, reservation := range s.Reservations {
+		if i < 0 || reservation.UID == "" || len(reservation.UID) > 128 || reservation.Revision == "" || len(reservation.Revision) > 128 {
+			return s, fmt.Errorf("invalid reservation at %d", i)
+		}
+	}
+	if s.Reservations == nil {
+		s.Reservations = make(map[int32]combinedModelReservation)
+	}
+	return s, nil
+}
+
+func combinedModelEncode(s combinedModelState) string {
+	b, _ := json.Marshal(s) // all fields are JSON-supported types
+	return string(b)
+}
+
+func combinedLeaderAtTarget(p *corev1.Pod, revision, nativeRevision string) bool {
+	return p != nil && nativeRevision != "" && p.Labels[leaderworkerset.RevisionKey] == revision &&
+		p.Labels[appsv1.ControllerRevisionHashLabelKey] == nativeRevision
+}
+
+// Reserve ALL stale leaders in the exposed suffix, not only direct-delete
+// targets: the native controller may act independently. This is a bound on
+// controller-authorized disruption using observed health, not on failures.
+func combinedModelPlanUpdate(in combinedModelInput) (combinedModelPlan, error) {
+	p := combinedModelPlan{partition: max(in.partition, in.protected), replicas: in.replicas}
+	if in.baseline < 0 || in.desired < 0 || in.replicas < 0 || in.protected < 0 || in.generation < 1 || in.revision == "" || in.nativeRevision == "" || in.stsUID == "" {
+		return p, fmt.Errorf("invalid rollout input")
+	}
+	u, err := intstr.GetScaledValueFromIntOrPercent(&in.unavailable, int(in.desired), false)
+	if err != nil || u < 0 {
+		return p, fmt.Errorf("invalid maxUnavailable")
+	}
+	surge, err := intstr.GetScaledValueFromIntOrPercent(&in.surge, int(in.desired), true)
+	if err != nil || surge < 0 || (in.desired > 0 && u == 0 && surge == 0) {
+		return p, fmt.Errorf("invalid maxSurge or zero resolved budgets")
+	}
+	s := combinedModelState{Version: 1, Baseline: in.baseline, Desired: in.desired, Generation: in.generation, Revision: in.revision, NativeRevision: in.nativeRevision, Reservations: make(map[int32]combinedModelReservation)}
+	if in.state != "" {
+		s, err = combinedModelDecode(in.state)
+		if err != nil || s.Generation > in.generation {
+			return p, fmt.Errorf("invalid or newer persisted state; do not apply or delete")
+		}
+	}
+	p.floor = max(0, min(s.Baseline, in.desired)-int32(min(u, int(in.desired))))
+	if (s.Revision != in.revision || s.NativeRevision != in.nativeRevision) && !in.templateFrozen {
+		p.freeze, p.partition, p.state = true, max(in.replicas, in.protected), combinedModelEncode(s)
+		return p, nil
+	}
+	// Validate the OLD exposed suffix before retiring any condemned obligations.
+	// The replica reduction and reservation removal are then persisted atomically.
+	for i := in.partition; i < min(in.replicas, int32(len(in.groups))); i++ {
+		g := in.groups[i]
+		if g.leader != nil && !combinedLeaderAtTarget(g.leader, in.revision, in.nativeRevision) {
+			if _, ok := s.Reservations[i]; !ok && in.state != "" && !in.templateFrozen {
+				return combinedModelPlan{}, fmt.Errorf("unreserved stale leader exposed at %d", i)
+			}
+		}
+	}
+	p.replicas = in.desired
+	if in.desired >= s.Desired {
+		p.replicas = max(in.desired, min(in.replicas, in.desired+int32(min(surge, int(in.desired)))))
+	}
+	for i, reservation := range s.Reservations {
+		// Supersession changes the replacement obligation, not its payment.
+		// Keep the old UID until a whole group at the new target is Ready.
+		if s.Revision != in.revision {
+			reservation.Revision = in.revision
+			s.Reservations[i] = reservation
+		}
+		if i >= p.replicas {
+			delete(s.Reservations, i) // condemned Pods cannot supply credit below
+			continue
+		}
+		if i < int32(len(in.groups)) {
+			g := in.groups[i]
+			if g.ready(in.stsUID) && g.leader.UID != reservation.UID && combinedLeaderAtTarget(g.leader, reservation.Revision, in.nativeRevision) {
+				delete(s.Reservations, i)
+			}
+		}
+	}
+	s.Desired, s.Generation, s.Revision = in.desired, in.generation, in.revision
+	s.NativeRevision, s.Protected = in.nativeRevision, in.protected
+	converged := true
+	for i := int32(0); i < p.replicas; i++ {
+		if i >= int32(len(in.groups)) {
+			if i < in.desired {
+				converged = false
+			}
+			continue
+		}
+		g := in.groups[i]
+		_, reserved := s.Reservations[i]
+		if g.ready(in.stsUID) && !reserved {
+			p.credited++
+		}
+		if i < in.desired && (!g.ready(in.stsUID) || reserved || (i >= in.protected && !combinedLeaderAtTarget(g.leader, in.revision, in.nativeRevision))) {
+			converged = false
+		}
+	}
+	if converged && len(s.Reservations) == 0 {
+		p.done, p.partition, p.replicas = true, in.protected, in.desired
+		return p, nil
+	}
+	p.partition = max(p.replicas, in.protected)
+	for i := p.replicas - 1; i >= in.protected; i-- {
+		if i >= int32(len(in.groups)) || in.groups[i].leader == nil {
+			// Below the previous target a native sync could still create an old
+			// Pod. Reserve that zero-credit hole before exposing it. Fresh scale
+			// additions cannot have been created by a sync of the smaller set.
+			if i < in.replicas {
+				if _, ok := s.Reservations[i]; !ok {
+					if len(s.Reservations) == combinedReservationLimit {
+						p.blocked = true
+						break
+					}
+					s.Reservations[i] = combinedModelReservation{UID: "missing", Revision: in.revision}
+				}
+			}
+			p.partition = i
+			continue
+		}
+		g, leader := in.groups[i], in.groups[i].leader
+		if !combinedModelOwnedBy(leader, "StatefulSet", in.stsUID) || leader.UID == "" || leader.ResourceVersion == "" {
+			p.blocked = true
+			break
+		}
+		if combinedLeaderAtTarget(leader, in.revision, in.nativeRevision) {
+			p.partition = i
+			continue
+		}
+		_, reserved := s.Reservations[i]
+		if !reserved {
+			if len(s.Reservations) == combinedReservationLimit {
+				p.blocked = true
+				break
+			}
+			if g.ready(in.stsUID) {
+				if p.credited <= p.floor {
+					p.blocked = true
+					break
+				}
+				p.credited--
+			}
+		}
+		s.Reservations[i] = combinedModelReservation{UID: leader.UID, Revision: in.revision}
+		p.partition = i
+		if leader.DeletionTimestamp == nil {
+			p.deletes = append(p.deletes, leader.DeepCopy())
+		}
+	}
+	// Pending desired additions already offer additional credit. Only add surge
+	// when growth no longer offers it; do not reclaim counted surge until done.
+	if len(p.deletes) == 0 && in.desired <= s.Baseline && !converged {
+		p.replicas = in.desired + int32(min(surge, int(in.desired)))
+	}
+	p.state = combinedModelEncode(s)
+	return p, nil
+}

--- a/pkg/controllers/combined_rollout_api_test.go
+++ b/pkg/controllers/combined_rollout_api_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+)
+
+// This tests real API semantics, not fake-client emulation of SSA/deletion.
+// envtest has no StatefulSet controller, scheduler, kubelet or garbage collector.
+// Replacement creation/status below is explicitly simulated; this is NOT an
+// end-to-end reproduction of a native-controller race.
+func TestCombinedRolloutAPIPreconditions(t *testing.T) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("set KUBEBUILDER_ASSETS to existing local envtest binaries")
+	}
+	environment := &envtest.Environment{CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")}, ErrorIfCRDPathMissing: true}
+	config, err := environment.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := environment.Stop(); err != nil {
+			t.Errorf("stop envtest: %v", err)
+		}
+	})
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := leaderworkerset.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "combined-rollout-"}}
+	if err := c.Create(ctx, ns); err != nil {
+		t.Fatal(err)
+	}
+	t.Run("production Reconcile persisted phases and fences", func(t *testing.T) {
+		testCombinedReconcile(t, c, scheme, ns.Name)
+	})
+	t.Run("production regression fences and ownership", func(t *testing.T) {
+		testCombinedRegressions(t, c, scheme, ns.Name)
+	})
+
+	t.Run("SSA persists partition and reservations atomically and rejects stale plans", func(t *testing.T) {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: ns.Name},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: "example", Replicas: ptr.To[int32](2), PodManagementPolicy: appsv1.ParallelPodManagement,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "example"}},
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "example"}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "test.invalid/image"}}}},
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{Partition: ptr.To[int32](2)}},
+			},
+		}
+		if err := c.Create(ctx, sts); err != nil {
+			t.Fatal(err)
+		}
+		oldRV := sts.ResourceVersion
+		annotation := "leaderworkerset.sigs.k8s.io/combined-rollout-experiment"
+		apply := func(rv, state string, partition int64) error {
+			patch := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1", "kind": "StatefulSet",
+				"metadata": map[string]interface{}{"name": sts.Name, "namespace": ns.Name, "resourceVersion": rv,
+					"annotations": map[string]interface{}{annotation: state}},
+				"spec": map[string]interface{}{"updateStrategy": map[string]interface{}{"type": "RollingUpdate",
+					"rollingUpdate": map[string]interface{}{"partition": partition}}},
+			}}
+			return c.Patch(ctx, patch, client.Apply, client.FieldOwner("combined-rollout-experiment"), client.ForceOwnership) //nolint:staticcheck // exercises the existing controller's SSA path
+		}
+		if err := apply(oldRV, "reservation-one", 1); err != nil {
+			t.Fatal(err)
+		}
+		if err := apply(oldRV, "stale-second-payment", 0); !apierrors.IsConflict(err) {
+			t.Fatalf("stale SSA must conflict even with force ownership; got %v", err)
+		}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(sts), sts); err != nil {
+			t.Fatal(err)
+		}
+		if *sts.Spec.UpdateStrategy.RollingUpdate.Partition != 1 || sts.Annotations[annotation] != "reservation-one" {
+			t.Fatalf("stale write altered partition/reservation: %+v", sts)
+		}
+		t.Log("real apiserver: stale SSA conflicted; partition and reservation remained atomic")
+		sts.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+		if err := c.Update(ctx, sts); !apierrors.IsInvalid(err) {
+			t.Fatalf("OnDelete with rollingUpdate.partition must be rejected: %v", err)
+		}
+		sts.Spec.UpdateStrategy.RollingUpdate = nil
+		if err := c.Update(ctx, sts); err != nil {
+			t.Fatal(err)
+		}
+		t.Log("real apiserver: OnDelete rejected partition; accepted only after removing rollingUpdate")
+	})
+
+	t.Run("Pod UID and resourceVersion fences protect retries", func(t *testing.T) {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "example-0", Namespace: ns.Name},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "test.invalid/image"}}}}
+		if err := c.Create(ctx, pod); err != nil {
+			t.Fatal(err)
+		}
+		original := pod.DeepCopy()
+		deleteOriginal := func() error {
+			return c.Delete(ctx, original, &client.DeleteOptions{
+				GracePeriodSeconds: ptr.To[int64](0),
+				Preconditions:      &metav1.Preconditions{UID: &original.UID, ResourceVersion: &original.ResourceVersion},
+			})
+		}
+		pod.Labels = map[string]string{"observation": "changed"}
+		if err := c.Update(ctx, pod); err != nil {
+			t.Fatal(err)
+		}
+		if err := deleteOriginal(); !apierrors.IsConflict(err) {
+			t.Fatalf("changed resourceVersion must reject deletion: %v", err)
+		}
+		original = pod.DeepCopy()
+		if err := deleteOriginal(); err != nil {
+			t.Fatal(err)
+		}
+		replacement := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: ns.Name}, Spec: pod.Spec}
+		if err := c.Create(ctx, replacement); err != nil {
+			t.Fatal(err)
+		}
+		if replacement.UID == original.UID {
+			t.Fatal("expected a new UID")
+		}
+		if err := deleteOriginal(); !apierrors.IsConflict(err) {
+			t.Fatalf("replacement UID must reject stale LWS deletion: %v", err)
+		}
+		// v1.35's native object manager sends a delete by name without these
+		// preconditions. Demonstrate the API difference, not an interleaving:
+		// only a native-controller test can establish whether it issues such a
+		// stale request, given its per-key serialized creation/update loop.
+		if err := c.Delete(ctx, original, &client.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(replacement), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+			t.Fatalf("unconditioned by-name delete should remove the replacement: %v", err)
+		}
+		t.Log("real apiserver: RV/UID stale deletes conflicted; unconditioned by-name delete removed replacement")
+	})
+}

--- a/pkg/controllers/combined_rollout_controller.go
+++ b/pkg/controllers/combined_rollout_controller.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
+)
+
+func (r *LeaderWorkerSetReconciler) combinedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	// Direct-client tests and embedders without a manager may supply Client.
+	// The production manager always installs its uncached APIReader.
+	return r.Client
+}
+
+func combinedBaseline(sts *appsv1.StatefulSet) (int32, error) {
+	n, err := strconv.ParseInt(sts.Annotations[leaderworkerset.ReplicasAnnotationKey], 10, 32)
+	if err != nil || n < 0 || sts.Spec.Replicas == nil {
+		return 0, fmt.Errorf("missing/invalid pre-operation non-surge replica target")
+	}
+	return min(int32(n), *sts.Spec.Replicas), nil
+}
+
+func (r *LeaderWorkerSetReconciler) reconcileCombinedRollout(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, sts *appsv1.StatefulSet, revision string, templateChanged bool) (bool, ctrl.Result, error) {
+	wait := ctrl.Result{RequeueAfter: time.Second}
+	if sts == nil {
+		return false, ctrl.Result{}, nil
+	}
+	raw, active := sts.Annotations[combinedRolloutAnnotation]
+	baseline, baselineErr := combinedBaseline(sts)
+	rolling := sts.Spec.UpdateStrategy.RollingUpdate
+	protected := *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition
+	// LWS revisions omit supported top-level topology annotations. Fingerprint
+	// the constructed template as well, without conflating it with native hashes.
+	config, err := constructLeaderStatefulSetApplyConfiguration(lws, 0, *lws.Spec.Replicas, revision)
+	if err != nil {
+		return true, wait, err
+	}
+	templateJSON, err := json.Marshal(config.Spec.Template)
+	if err != nil {
+		return true, wait, err
+	}
+	templateKey := fmt.Sprintf("%x", sha256.Sum256(templateJSON))
+	if !active {
+		if baselineErr != nil {
+			return false, ctrl.Result{}, nil
+		}
+		inProgress := rolling != nil && rolling.Partition != nil && *rolling.Partition > *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition
+		inProgress = inProgress || sts.Status.CurrentRevision != sts.Status.UpdateRevision
+		// Compare the annotations copied outside the LWS revision, including removal.
+		for _, key := range []string{leaderworkerset.ExclusiveKeyAnnotationKey, leaderworkerset.SubGroupExclusiveKeyAnnotationKey} {
+			templateChanged = templateChanged || sts.Spec.Template.Annotations[key] != config.Spec.Template.Annotations[key]
+		}
+		if *lws.Spec.Replicas <= baseline || (!templateChanged && !inProgress) {
+			return false, ctrl.Result{}, nil
+		}
+	}
+	if rolling == nil || rolling.Partition == nil || sts.Spec.Replicas == nil || sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		return true, wait, fmt.Errorf("combined rollout requires native RollingUpdate partition")
+	}
+	// Never construct a write from a stale cached StatefulSet or LWS generation.
+	if err := r.combinedFence(ctx, lws, sts); err != nil {
+		return true, wait, err
+	}
+	var state combinedModelState
+	if active {
+		state, err = combinedModelDecode(raw)
+		if err != nil || state.Phase == "" || state.Generation > lws.Generation {
+			return true, wait, fmt.Errorf("invalid combined rollout state; no mutation or deletion: %v", err)
+		}
+	} else {
+		state = combinedModelState{Version: 1, Baseline: baseline, Desired: *lws.Spec.Replicas, Generation: lws.Generation, Revision: revision, Phase: combinedFreeze}
+	}
+	// Initial entry and supersession freeze the ACTUAL old template first.
+	// A native per-set sync must acknowledge that fence before publication.
+	if !active || state.Revision != revision || state.TargetTemplate != templateKey || protected > state.Protected {
+		for ordinal, reservation := range state.Reservations {
+			reservation.Revision = revision
+			state.Reservations[ordinal] = reservation
+		}
+		state.Phase, state.Revision, state.Generation = combinedFreeze, revision, lws.Generation
+		state.NativeRevision, state.TargetTemplate, state.Protected = "", templateKey, protected
+		frozen := sts.DeepCopy()
+		frozen.Spec.UpdateStrategy.RollingUpdate.Partition = ptr.To(max(*sts.Spec.Replicas, protected))
+		return true, wait, r.applyCombinedStatefulSet(ctx, lws, sts, frozen, combinedModelEncode(state))
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return true, wait, nil
+	}
+	if state.Phase == combinedFreeze {
+		if *rolling.Partition < *sts.Spec.Replicas {
+			return true, wait, fmt.Errorf("combined freeze fence was changed")
+		}
+		// Keep the old replica count until the new template is acknowledged.
+		state.Phase, state.Generation = combinedPublish, lws.Generation
+		return true, wait, r.publishCombinedStatefulSet(ctx, lws, sts, state)
+	}
+	if sts.Status.UpdateRevision == "" || revisionutils.GetRevisionKey(sts) != revision || sts.Spec.Template.Labels[leaderworkerset.RevisionKey] != revision {
+		return true, wait, fmt.Errorf("combined rollout template/revision fence changed")
+	}
+	if state.Phase == combinedPublish {
+		if *rolling.Partition < *sts.Spec.Replicas {
+			return true, wait, fmt.Errorf("combined publication fence was changed")
+		}
+		state.NativeRevision = sts.Status.UpdateRevision
+		// Only an acknowledged full fence may retire a surviving same-UID
+		// obligation. Readiness recovery alone must never refund authorization.
+		groups, err := r.observeCombinedGroups(ctx, lws, *sts.Spec.Replicas)
+		if err != nil {
+			return true, wait, err
+		}
+		for i := range state.Reservations {
+			if i < protected || (i < int32(len(groups)) && combinedLeaderAtTarget(groups[i].leader, revision, state.NativeRevision)) {
+				delete(state.Reservations, i)
+			}
+		}
+		state.Phase, state.Generation, state.Protected = combinedActive, lws.Generation, protected
+		return true, wait, r.applyCombinedStatefulSet(ctx, lws, sts, sts.DeepCopy(), combinedModelEncode(state))
+	}
+	if state.NativeRevision == "" || sts.Status.UpdateRevision != state.NativeRevision {
+		return true, wait, fmt.Errorf("combined rollout native target changed outside publication fence")
+	}
+	groups, err := r.observeCombinedGroups(ctx, lws, max(*sts.Spec.Replicas, *lws.Spec.Replicas))
+	if err != nil {
+		return true, wait, err
+	}
+	budgets := lws.Spec.RolloutStrategy.RollingUpdateConfiguration
+	plan, err := combinedModelPlanUpdate(combinedModelInput{
+		baseline: state.Baseline, desired: *lws.Spec.Replicas, replicas: *sts.Spec.Replicas,
+		partition: *rolling.Partition, protected: protected, generation: lws.Generation,
+		revision: revision, nativeRevision: state.NativeRevision, stsUID: sts.UID, unavailable: budgets.MaxUnavailable, surge: budgets.MaxSurge,
+		groups: groups, state: raw,
+	})
+	if err != nil {
+		return true, wait, err
+	}
+	next := sts.DeepCopy()
+	next.Spec.Replicas = ptr.To(plan.replicas)
+	next.Spec.UpdateStrategy.RollingUpdate.Partition = ptr.To(plan.partition)
+	next.Annotations[leaderworkerset.ReplicasAnnotationKey] = strconv.Itoa(int(*lws.Spec.Replicas))
+	if plan.done {
+		// Retain B until the scale-down is acknowledged and surplus leaders
+		// (including terminating leaders) are gone. Do not count cleanup twice.
+		clean := *sts.Spec.Replicas == plan.replicas && sts.Status.Replicas == plan.replicas
+		// Ready Pods can precede native promotion. Keep history until the native
+		// current template catches up; protected old groups intentionally differ.
+		clean = clean && (protected > 0 || sts.Status.CurrentRevision == state.NativeRevision)
+		for i := plan.replicas; i < int32(len(groups)); i++ {
+			clean = clean && groups[i].leader == nil
+		}
+		if !clean {
+			state.Desired, state.Generation = *lws.Spec.Replicas, lws.Generation
+			plan.state = combinedModelEncode(state)
+		}
+	}
+	changed := plan.state != raw || plan.partition != *rolling.Partition || plan.replicas != *sts.Spec.Replicas
+	if changed {
+		// Reservation and eligibility move atomically; never delete on this
+		// pass. Re-observe the applied generation before an explicit deletion.
+		return true, wait, r.applyCombinedStatefulSet(ctx, lws, sts, next, plan.state)
+	}
+	for _, pod := range plan.deletes {
+		if err := r.deleteCombinedLeader(ctx, lws, sts, pod); err != nil {
+			return true, wait, err
+		}
+	}
+	if plan.blocked && r.Record != nil {
+		r.Record.Eventf(lws, sts, corev1.EventTypeNormal, "CombinedRolloutBudgetBlocked", Update, "Waiting for whole-group credit or reservation capacity; cannot expose an unaffordable old suffix")
+	}
+	if err := r.reconcileHeadlessServices(ctx, lws); err != nil {
+		return true, wait, err
+	}
+	// Legacy status is informational only; it never clears this persisted
+	// protocol or truncates protected history during an active operation.
+	_, err = r.updateStatus(ctx, lws, revision)
+	return true, wait, err
+}
+
+func (r *LeaderWorkerSetReconciler) combinedFence(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, sts *appsv1.StatefulSet) error {
+	var liveLWS leaderworkerset.LeaderWorkerSet
+	var liveSTS appsv1.StatefulSet
+	if err := r.combinedReader().Get(ctx, client.ObjectKeyFromObject(lws), &liveLWS); err != nil {
+		return err
+	}
+	if err := r.combinedReader().Get(ctx, client.ObjectKeyFromObject(sts), &liveSTS); err != nil {
+		return err
+	}
+	if liveLWS.UID != lws.UID || liveLWS.Generation != lws.Generation || liveLWS.ResourceVersion != lws.ResourceVersion || liveLWS.DeletionTimestamp != nil ||
+		liveSTS.UID != sts.UID || liveSTS.ResourceVersion != sts.ResourceVersion || liveSTS.DeletionTimestamp != nil ||
+		!combinedModelOwnedBy(&liveSTS, "LeaderWorkerSet", liveLWS.UID) {
+		return apierrors.NewConflict(appsv1.Resource("statefulsets"), sts.Name, fmt.Errorf("combined rollout observation changed"))
+	}
+	return nil
+}
+
+// Operational deltas must not acquire ownership of merely observed fields.
+// Optimistic-lock merge patches atomically couple eligibility and reservations.
+func (r *LeaderWorkerSetReconciler) applyCombinedStatefulSet(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, old, next *appsv1.StatefulSet, state string) error {
+	if len(state) > combinedStateLimit {
+		return fmt.Errorf("combined rollout state exceeds bound")
+	}
+	if err := r.combinedFence(ctx, lws, old); err != nil {
+		return err
+	}
+	next.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = ptr.To(intstr.FromInt(1))
+	if next.Annotations == nil {
+		next.Annotations = make(map[string]string)
+	}
+	if state == "" {
+		delete(next.Annotations, combinedRolloutAnnotation)
+	} else {
+		next.Annotations[combinedRolloutAnnotation] = state
+	}
+	return r.Patch(ctx, next, client.MergeFromWithOptions(old, client.MergeFromWithOptimisticLock{}), client.FieldOwner(fieldManager))
+}
+
+// Publish the COMPLETE intended declarative configuration, never the live
+// object or a partial apply under the existing manager (which would prune its
+// other fields). Independent StatefulSet/template metadata remains unowned.
+func (r *LeaderWorkerSetReconciler) publishCombinedStatefulSet(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, sts *appsv1.StatefulSet, state combinedModelState) error {
+	if err := r.combinedFence(ctx, lws, sts); err != nil {
+		return err
+	}
+	config, err := constructLeaderStatefulSetApplyConfiguration(lws, max(*sts.Spec.Replicas, state.Protected), *sts.Spec.Replicas, state.Revision)
+	if err != nil {
+		return err
+	}
+	if err := setControllerReferenceWithStatefulSet(lws, config, r.Scheme); err != nil {
+		return err
+	}
+	raw := combinedModelEncode(state)
+	if len(raw) > combinedStateLimit {
+		return fmt.Errorf("combined rollout state exceeds bound")
+	}
+	config.WithResourceVersion(sts.ResourceVersion).WithAnnotations(map[string]string{
+		combinedRolloutAnnotation:             raw,
+		leaderworkerset.ReplicasAnnotationKey: sts.Annotations[leaderworkerset.ReplicasAnnotationKey],
+	})
+	config.Spec.UpdateStrategy.RollingUpdate.WithMaxUnavailable(intstr.FromInt(1))
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(config)
+	if err != nil {
+		return err
+	}
+	patch := &unstructured.Unstructured{Object: obj}
+	return r.Patch(ctx, patch, client.Apply, client.FieldOwner(fieldManager), client.ForceOwnership) //nolint:staticcheck // complete declarative SSA with RV fence
+}
+
+func (r *LeaderWorkerSetReconciler) deleteCombinedLeader(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, sts *appsv1.StatefulSet, pod *corev1.Pod) error {
+	if err := r.combinedFence(ctx, lws, sts); err != nil {
+		return err
+	}
+	s, err := combinedModelDecode(sts.Annotations[combinedRolloutAnnotation])
+	if err != nil {
+		return err
+	}
+	i, err := strconv.Atoi(pod.Labels[leaderworkerset.GroupIndexLabelKey])
+	if err != nil {
+		return err
+	}
+	reservation, ok := s.Reservations[int32(i)]
+	if !ok || s.Phase != combinedActive || s.Generation != lws.Generation || s.Revision != revisionutils.GetRevisionKey(sts) ||
+		sts.Status.ObservedGeneration < sts.Generation || s.NativeRevision == "" || sts.Status.UpdateRevision != s.NativeRevision ||
+		reservation.UID != pod.UID || reservation.Revision != s.Revision ||
+		int32(i) < *sts.Spec.UpdateStrategy.RollingUpdate.Partition || int32(i) < *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition ||
+		!combinedModelOwnedBy(pod, "StatefulSet", sts.UID) || pod.DeletionTimestamp != nil || combinedLeaderAtTarget(pod, s.Revision, s.NativeRevision) {
+		return fmt.Errorf("combined deletion is not covered by current reservation")
+	}
+	// Normal grace, UID/RV-preconditioned, foreground GC removes old workers.
+	err = r.Delete(ctx, pod, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &pod.UID, ResourceVersion: &pod.ResourceVersion}, PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)})
+	return client.IgnoreNotFound(err)
+}
+
+func (r *LeaderWorkerSetReconciler) observeCombinedGroups(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, count int32) ([]combinedModelGroup, error) {
+	var pods corev1.PodList
+	var sets appsv1.StatefulSetList
+	selector := client.MatchingLabels{leaderworkerset.SetNameLabelKey: lws.Name}
+	if err := r.combinedReader().List(ctx, &pods, client.InNamespace(lws.Namespace), selector); err != nil {
+		return nil, err
+	}
+	if err := r.combinedReader().List(ctx, &sets, client.InNamespace(lws.Namespace), selector); err != nil {
+		return nil, err
+	}
+	// Include condemned ordinals for cleanup checks, but the planner never
+	// counts them above its planned replica target.
+	for _, p := range pods.Items {
+		i, err := strconv.ParseInt(p.Labels[leaderworkerset.GroupIndexLabelKey], 10, 32)
+		if err == nil && i >= 0 && p.Name == fmt.Sprintf("%s-%d", lws.Name, i) {
+			count = max(count, int32(i)+1)
+		}
+	}
+	groups := make([]combinedModelGroup, count)
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		n, err := strconv.ParseInt(p.Labels[leaderworkerset.GroupIndexLabelKey], 10, 32)
+		if err != nil || n < 0 || n >= int64(count) {
+			continue
+		}
+		if p.Name == fmt.Sprintf("%s-%d", lws.Name, n) && p.Labels[leaderworkerset.WorkerIndexLabelKey] == "0" {
+			groups[n].leader = p
+		} else {
+			groups[n].pods = append(groups[n].pods, *p)
+		}
+	}
+	for i := range sets.Items {
+		w := &sets.Items[i]
+		n, err := strconv.ParseInt(w.Labels[leaderworkerset.GroupIndexLabelKey], 10, 32)
+		if err == nil && n >= 0 && n < int64(count) && w.Name == fmt.Sprintf("%s-%d", lws.Name, n) {
+			groups[n].workers = w
+		}
+	}
+	return groups, nil
+}

--- a/pkg/controllers/combined_rollout_controller_test.go
+++ b/pkg/controllers/combined_rollout_controller_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+// Runs actual Reconcile and real SSA on envtest. Native acknowledgement and
+// Pod health are simulated explicitly; this is not native-controller E2E.
+func testCombinedReconcile(t *testing.T, c client.Client, scheme *runtime.Scheme, namespace string) {
+	for _, tc := range []struct {
+		b, d int32
+		u    int
+	}{{1, 2, 1}, {1, 2, 0}, {4, 8, 1}} {
+		t.Run(fmt.Sprintf("%d-to-%d-u%d", tc.b, tc.d, tc.u), func(t *testing.T) {
+			ctx := context.Background()
+			lws := wrappers.BuildLeaderWorkerSet(namespace).Replica(int(tc.b)).Size(1).Obj()
+			lws.Name = fmt.Sprintf("combined-%d-%d", tc.b, tc.u)
+			lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt(tc.u)
+			if tc.u == 0 {
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt(1)
+			}
+			if err := c.Create(ctx, lws); err != nil {
+				t.Fatal(err)
+			}
+			r := NewLeaderWorkerSetReconciler(c, scheme, fakeEventRecorder{})
+			r.APIReader = c
+			key := client.ObjectKeyFromObject(lws)
+			reconcile := func() {
+				t.Helper()
+				if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			getSTS := func() *appsv1.StatefulSet {
+				t.Helper()
+				s := &appsv1.StatefulSet{}
+				if err := c.Get(ctx, key, s); err != nil {
+					t.Fatal(err)
+				}
+				return s
+			}
+			ack := func() {
+				t.Helper()
+				s := getSTS()
+				s.Status.ObservedGeneration = s.Generation
+				s.Status.CurrentRevision = "native-old"
+				s.Status.UpdateRevision = "native-" + s.Spec.Template.Labels[leaderworkerset.RevisionKey]
+				s.Status.Replicas = *s.Spec.Replicas
+				if err := c.Status().Update(ctx, s); err != nil {
+					t.Fatal(err)
+				}
+			}
+			state := func() combinedModelState {
+				t.Helper()
+				s, err := combinedModelDecode(getSTS().Annotations[combinedRolloutAnnotation])
+				if err != nil {
+					t.Fatal(err)
+				}
+				return s
+			}
+			makePod := func(i int32, ready bool) *corev1.Pod {
+				t.Helper()
+				s := getSTS()
+				p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%d", lws.Name, i), Namespace: namespace,
+					Labels:          map[string]string{leaderworkerset.SetNameLabelKey: lws.Name, leaderworkerset.GroupIndexLabelKey: strconv.Itoa(int(i)), leaderworkerset.WorkerIndexLabelKey: "0", leaderworkerset.RevisionKey: s.Spec.Template.Labels[leaderworkerset.RevisionKey], appsv1.ControllerRevisionHashLabelKey: s.Status.UpdateRevision},
+					Annotations:     map[string]string{leaderworkerset.SizeAnnotationKey: "1"},
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: s.Name, UID: s.UID, Controller: ptr.To(true)}}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "test.invalid/image"}}}}
+				if err := c.Create(ctx, p); err != nil {
+					t.Fatal(err)
+				}
+				if ready {
+					p.Status.Phase = corev1.PodRunning
+					p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+					if err := c.Status().Update(ctx, p); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return p
+			}
+			reconcile()
+			ack()
+			for i := int32(0); i < tc.b; i++ {
+				makePod(i, true)
+			}
+			oldTemplate := getSTS().Spec.Template.Spec.Containers[0].Image
+			if err := c.Get(ctx, key, lws); err != nil {
+				t.Fatal(err)
+			}
+			lws.Spec.Replicas = ptr.To(tc.d)
+			lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image = "test.invalid/new"
+			if err := c.Update(ctx, lws); err != nil {
+				t.Fatal(err)
+			}
+			reconcile()
+			if state().Phase != combinedFreeze || state().Baseline != tc.b || getSTS().Spec.Template.Spec.Containers[0].Image != oldTemplate {
+				t.Fatal("entry did not freeze old template/baseline")
+			}
+			revisionCount := func() int {
+				t.Helper()
+				var revisions appsv1.ControllerRevisionList
+				if err := c.List(ctx, &revisions, client.InNamespace(namespace), client.MatchingLabels{leaderworkerset.SetNameLabelKey: lws.Name}); err != nil {
+					t.Fatal(err)
+				}
+				return len(revisions.Items)
+			}
+			count := revisionCount()
+			for i := 0; i < 5; i++ {
+				r = NewLeaderWorkerSetReconciler(c, scheme, fakeEventRecorder{})
+				r.APIReader = c
+				reconcile()
+			}
+			if revisionCount() != count || count != 2 {
+				t.Fatalf("unchanged freeze created duplicate revisions: %d -> %d", count, revisionCount())
+			}
+			if state().Phase != combinedFreeze {
+				t.Fatal("advanced before native freeze acknowledgement")
+			}
+			ack()
+			reconcile()
+			if state().Phase != combinedPublish || *getSTS().Spec.Replicas != tc.b || *getSTS().Spec.UpdateStrategy.RollingUpdate.Partition < tc.b {
+				t.Fatal("publication was not frozen")
+			}
+			reconcile()
+			if state().Phase != combinedPublish {
+				t.Fatal("advanced before native publication acknowledgement")
+			}
+			ack()
+			reconcile()
+			reconcile()
+			if state().Phase != combinedActive || *getSTS().Spec.Replicas != tc.d {
+				t.Fatal("active planner did not create desired additions")
+			}
+			if len(state().Reservations) != tc.u {
+				t.Fatalf("reservations=%v, want %d", state().Reservations, tc.u)
+			}
+			ack()
+			for i := tc.b; i < tc.d; i++ {
+				makePod(i, false)
+			}
+			if tc.u == 0 {
+				reconcile()
+				if len(state().Reservations) != 0 {
+					t.Fatal("Pending addition supplied credit")
+				}
+				p := &corev1.Pod{}
+				if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: lws.Name + "-1"}, p); err != nil {
+					t.Fatal(err)
+				}
+				p.Status.Phase = corev1.PodRunning
+				p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+				if err := c.Status().Update(ctx, p); err != nil {
+					t.Fatal(err)
+				}
+				reconcile()
+				ack()
+				if len(state().Reservations) != 1 {
+					t.Fatal("Ready addition failed to finance replacement")
+				}
+			}
+			// A restart observes the same persisted payment. A stale LWS
+			// generation cannot use it to delete, even with a fresh Pod UID.
+			stale := lws.DeepCopy()
+			if err := c.Get(ctx, key, lws); err != nil {
+				t.Fatal(err)
+			}
+			stale.Generation = lws.Generation - 1
+			pod := &corev1.Pod{}
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: fmt.Sprintf("%s-%d", lws.Name, tc.b-1)}, pod); err != nil {
+				t.Fatal(err)
+			}
+			if err := r.deleteCombinedLeader(ctx, stale, getSTS(), pod); err == nil {
+				t.Fatal("stale LWS generation deleted a leader")
+			}
+			r = NewLeaderWorkerSetReconciler(c, scheme, fakeEventRecorder{})
+			r.APIReader = c
+			reconcile()
+			if err := c.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+				t.Fatal(err)
+			}
+			if pod.DeletionTimestamp == nil {
+				t.Fatal("authorized old leader not deleted behind Pending addition")
+			}
+			if len(state().Reservations) != 1 {
+				t.Fatal("deletion dropped persisted payment")
+			}
+			// Supersession and HPA retain B and freeze before any new template.
+			if err := c.Get(ctx, key, lws); err != nil {
+				t.Fatal(err)
+			}
+			lws.Spec.Replicas = ptr.To(tc.d + 1)
+			lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image = "test.invalid/newer"
+			if err := c.Update(ctx, lws); err != nil {
+				t.Fatal(err)
+			}
+			before := getSTS().Spec.Template.Spec.Containers[0].Image
+			reconcile()
+			if state().Baseline != tc.b || state().Phase != combinedFreeze || getSTS().Spec.Template.Spec.Containers[0].Image != before {
+				t.Fatal("supersession rebaselined or skipped freeze")
+			}
+			// Corrupt state must fail closed in the actual Reconcile path.
+			s := getSTS()
+			s.Annotations[combinedRolloutAnnotation] = "{"
+			if err := c.Update(ctx, s); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err == nil {
+				t.Fatal("malformed state accepted")
+			}
+		})
+	}
+}

--- a/pkg/controllers/combined_rollout_model_test.go
+++ b/pkg/controllers/combined_rollout_model_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import "testing"
+
+// The original helper is now production code in combined_rollout.go. These
+// additional regressions exercise the bounded production reservation window.
+func TestCombinedPlannerBoundedReservations(t *testing.T) {
+	in := combinedTestInput(100, 101, 100)
+	p := combinedTestPlan(t, in)
+	s, err := combinedModelDecode(p.state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Reservations) != combinedReservationLimit || !p.blocked || len(p.state) > combinedStateLimit {
+		t.Fatalf("unbounded reservation window: %d, %+v", len(s.Reservations), p)
+	}
+	in.state, in.partition = p.state, p.partition
+	again := combinedTestPlan(t, in)
+	if p.state != again.state || p.partition != again.partition {
+		t.Fatal("full window spent more credit on restart")
+	}
+}
+
+func TestCombinedPlannerHPAKeepsBaseline(t *testing.T) {
+	in := combinedTestInput(4, 8, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition = p.state, p.partition
+	in.baseline, in.desired, in.generation = 8, 12, 3
+	p = combinedTestPlan(t, in)
+	s, err := combinedModelDecode(p.state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Baseline != 4 || p.floor != 3 || len(p.deletes) != 1 {
+		t.Fatalf("HPA recaptured baseline: %+v", p)
+	}
+}

--- a/pkg/controllers/combined_rollout_planner_test.go
+++ b/pkg/controllers/combined_rollout_planner_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	podutils "sigs.k8s.io/lws/pkg/utils/pod"
+)
+
+func combinedTestGroup(index int, revision string, ready bool) combinedModelGroup {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("example-%d", index), Namespace: "default",
+			UID: types.UID(fmt.Sprintf("%s-%d", revision, index)), ResourceVersion: "10",
+			Labels:          map[string]string{leaderworkerset.RevisionKey: revision, appsv1.ControllerRevisionHashLabelKey: "native-" + revision},
+			Annotations:     map[string]string{leaderworkerset.SizeAnnotationKey: "1"},
+			OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "example", UID: "leader-sts", Controller: ptr.To(true)}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	return combinedModelGroup{leader: pod}
+}
+
+func combinedTestInput(baseline, desired int32, unavailable int) combinedModelInput {
+	in := combinedModelInput{
+		baseline: baseline, desired: desired, replicas: desired, partition: baseline,
+		generation: 2, revision: "new", nativeRevision: "native-new", stsUID: "leader-sts",
+		unavailable: intstr.FromInt(unavailable), surge: intstr.FromInt(0),
+	}
+	for i := int32(0); i < desired; i++ {
+		revision, ready := "old", true
+		if i >= baseline {
+			revision, ready = "new", false
+		}
+		in.groups = append(in.groups, combinedTestGroup(int(i), revision, ready))
+	}
+	return in
+}
+
+func combinedTestPlan(t *testing.T, in combinedModelInput) combinedModelPlan {
+	t.Helper()
+	p, err := combinedModelPlanUpdate(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func combinedDeleteNames(p combinedModelPlan) []string {
+	names := []string{}
+	for _, pod := range p.deletes {
+		names = append(names, pod.Name)
+	}
+	return names
+}
+
+func TestCombinedPlannerBudgets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   combinedModelInput
+		want []string
+	}{
+		{"one to two pending addition permits old replacement", combinedTestInput(1, 2, 1), []string{"example-0"}},
+		{"four to eight default permits one paid replacement", combinedTestInput(4, 8, 1), []string{"example-3"}},
+		{"four to eight budget two permits two replacements", combinedTestInput(4, 8, 2), []string{"example-3", "example-2"}},
+	}
+	zero := combinedTestInput(1, 2, 0)
+	zero.surge = intstr.FromInt(1)
+	tests = append(tests, struct {
+		name string
+		in   combinedModelInput
+		want []string
+	}{"zero budget waits for additional capacity", zero, []string{}})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := combinedTestPlan(t, tc.in)
+			if got := combinedDeleteNames(p); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("deletes = %v, want %v", got, tc.want)
+			}
+			if p.credited < p.floor {
+				t.Fatalf("credited %d below floor %d", p.credited, p.floor)
+			}
+		})
+	}
+	zero.groups[1] = combinedTestGroup(1, "new", true)
+	if p := combinedTestPlan(t, zero); len(p.deletes) != 1 || p.floor != 1 {
+		t.Fatalf("Ready addition should finance old replacement: %+v", p)
+	}
+	percent := combinedTestInput(4, 8, 1)
+	percent.unavailable = intstr.FromString("25%")
+	if p := combinedTestPlan(t, percent); p.floor != 2 || len(p.deletes) != 2 {
+		t.Fatalf("percentages must resolve against desired replicas: %+v", p)
+	}
+	percent = combinedTestInput(1, 2, 1)
+	percent.unavailable = intstr.FromString("49%")
+	percent.surge = intstr.FromString("1%")
+	if p := combinedTestPlan(t, percent); p.floor != 1 || len(p.deletes) != 0 {
+		t.Fatalf("floor U and ceil S rounding changed: %+v", p)
+	}
+}
+
+func TestCombinedPlannerReservationsAndRestart(t *testing.T) {
+	in := combinedTestInput(4, 8, 1)
+	first := combinedTestPlan(t, in)
+	in.state, in.partition = first.state, first.partition
+	// The same old leader is still Ready in the observation; its already-paid
+	// deletion must be retried, not used to finance deleting ordinal 2 as well.
+	second := combinedTestPlan(t, in)
+	if !reflect.DeepEqual(combinedDeleteNames(first), combinedDeleteNames(second)) || first.state != second.state {
+		t.Fatalf("restarted/repeated planning spent the reservation twice: %+v", second)
+	}
+	in.groups[3] = combinedTestGroup(3, "new", false)
+	if p := combinedTestPlan(t, in); len(p.deletes) != 0 {
+		t.Fatalf("replacement Pending must retain the payment: %+v", p)
+	}
+	in.groups[3] = combinedTestGroup(3, "new", true)
+	if p := combinedTestPlan(t, in); !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-2"}) {
+		t.Fatalf("whole replacement Ready must release the reservation: %+v", p)
+	}
+}
+
+func TestCombinedPlannerNeutralRepairDoesNotSerializePaidReplacement(t *testing.T) {
+	in := combinedTestInput(3, 4, 2)
+	in.groups[2] = combinedTestGroup(2, "old", false)
+	p := combinedTestPlan(t, in)
+	if !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-2", "example-1"}) {
+		t.Fatalf("unavailable high group must not block a paid lower replacement: %+v", p)
+	}
+	in = combinedTestInput(3, 4, 1)
+	in.groups[2] = combinedTestGroup(2, "old", false)
+	p = combinedTestPlan(t, in)
+	if !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-2"}) {
+		t.Fatalf("initial unavailability consumes the paid budget: %+v", p)
+	}
+	// All initially unhealthy groups can be repaired without pretending that the
+	// initial replica baseline has shrunk to zero.
+	for i := 0; i < 3; i++ {
+		in.groups[i] = combinedTestGroup(i, "old", false)
+	}
+	p = combinedTestPlan(t, in)
+	if len(p.deletes) != 3 || p.floor != 2 {
+		t.Fatalf("neutral repair should work while already below the floor: %+v", p)
+	}
+}
+
+func TestCombinedPlannerUnavailableTogglePendingMiddle(t *testing.T) {
+	in := combinedTestInput(2, 3, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition = p.state, p.partition
+	in.groups[1] = combinedTestGroup(1, "new", false)
+	in.groups[2] = combinedTestGroup(2, "new", true)
+	in.generation++ // replicas/budget generation is independent of template revision
+	in.unavailable, in.surge = intstr.FromInt(0), intstr.FromInt(1)
+	p = combinedTestPlan(t, in)
+	if len(p.deletes) != 0 || p.floor != 2 {
+		t.Fatalf("U=0 should preserve two Ready groups: %+v", p)
+	}
+	in.state, in.partition = p.state, p.partition
+	in.generation++
+	in.unavailable = intstr.FromInt(1)
+	p = combinedTestPlan(t, in)
+	if p.partition != 0 || !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-0"}) {
+		t.Fatalf("U=1 must select lower old ordinal despite updated Pending ordinal 1: %+v", p)
+	}
+	// A model of the gate-disabled native descending loop stops at ordinal 1.
+	// This is the actual distinction from merely lowering the partition.
+	if target := combinedNativeGateOffTarget(in.groups, p.partition, "new"); target != -1 {
+		t.Fatalf("native loop should be blocked, selected %d", target)
+	}
+}
+
+// Only the destructive-update loop is modeled here. Native creation, cache
+// propagation, status updates, and per-key workqueue serialization are NOT.
+func combinedNativeGateOffTarget(groups []combinedModelGroup, partition int32, revision string) int {
+	for i := len(groups) - 1; i >= int(partition); i-- {
+		pod := groups[i].leader
+		if pod == nil {
+			return -1
+		}
+		if pod.Labels[appsv1.ControllerRevisionHashLabelKey] != "native-"+revision && pod.DeletionTimestamp == nil {
+			return i
+		}
+		// Native StatefulSet sees leader readiness, not the LWS worker group.
+		if pod.DeletionTimestamp != nil || !podutils.PodRunningAndReady(*pod) {
+			return -1
+		}
+	}
+	return -1
+}
+
+func TestCombinedPlannerNeutralRepairBehindReadyOldSuffix(t *testing.T) {
+	in := combinedTestInput(3, 4, 1)
+	in.groups[1] = combinedTestGroup(1, "old", false)
+	// New leader 3 is Ready, but its workers are missing. It supplies no LWS
+	// credit and does not block the native leader-only update loop.
+	in.groups[3] = combinedTestGroup(3, "new", true)
+	in.groups[3].leader.Annotations[leaderworkerset.SizeAnnotationKey] = "2"
+	p := combinedTestPlan(t, in)
+	if p.floor != 2 || p.credited != 2 || len(p.deletes) != 0 || p.partition != 3 {
+		t.Fatalf("must preserve two Ready groups, not expose old ordinal 2: %+v", p)
+	}
+	// To recreate unavailable old ordinal 1 with the update template requires
+	// partition <=1, exposing Ready old ordinal 2. A DaemonSet can select just
+	// ordinal 1; StatefulSet's partition cannot represent that selection.
+	if target := combinedNativeGateOffTarget(in.groups, 1, "new"); target != 2 {
+		t.Fatalf("native loop should delete unreserved Ready ordinal 2; got %d", target)
+	}
+	if p.credited-1 >= p.floor {
+		t.Fatal("counterexample must violate the availability floor")
+	}
+	// Deleting 1 while keeping partition 3 repairs at CURRENT revision. This
+	// can fix transient failures, but not a failure fixed only by the update.
+	if revision := combinedNativeCreationRevision(appsv1.RollingUpdateStatefulSetStrategyType, p.partition, 1); revision != "old" {
+		t.Fatalf("partition-protected creation should use old template, got %q", revision)
+	}
+	t.Log("neutral repair to new template blocked behind a Ready stale higher ordinal at the floor")
+}
+
+// Characterization of newVersionedStatefulSetPod for explicit partitions and
+// start ordinal zero in Kubernetes v1.35.0; does not run the native helper.
+// With OnDelete, API validation requires rollingUpdate to be absent, so native
+// creation chooses the update template; an LWS-only partition is invisible.
+func combinedNativeCreationRevision(strategy appsv1.StatefulSetUpdateStrategyType, partition, ordinal int32) string {
+	if strategy == appsv1.RollingUpdateStatefulSetStrategyType && ordinal < partition {
+		return "old"
+	}
+	return "new"
+}
+
+func TestCombinedPlannerOnDeleteAlternativeLosesProtectedRecreation(t *testing.T) {
+	const protected = int32(2)
+	for ordinal := int32(0); ordinal < 4; ordinal++ {
+		rolling := combinedNativeCreationRevision(appsv1.RollingUpdateStatefulSetStrategyType, protected, ordinal)
+		onDelete := combinedNativeCreationRevision(appsv1.OnDeleteStatefulSetStrategyType, protected, ordinal)
+		if ordinal < protected && (rolling != "old" || onDelete != "new") {
+			t.Fatalf("protected ordinal %d: RollingUpdate=%s OnDelete=%s", ordinal, rolling, onDelete)
+		}
+		if ordinal >= protected && (rolling != "new" || onDelete != "new") {
+			t.Fatalf("eligible ordinal %d should use updated template", ordinal)
+		}
+	}
+}
+
+func TestCombinedPlannerSupersessionAndDownscale(t *testing.T) {
+	in := combinedTestInput(4, 8, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition = p.state, p.partition
+	in.baseline = 8 // a newly observed target is NOT a new baseline
+	in.generation++
+	in.revision = "newer"
+	in.nativeRevision = "native-newer"
+	p = combinedTestPlan(t, in)
+	if !p.freeze || p.partition != 8 || len(p.deletes) != 0 {
+		t.Fatalf("supersession must freeze before changing the template: %+v", p)
+	}
+	s, err := combinedModelDecode(p.state)
+	if err != nil || s.Baseline != 4 || s.Revision != "new" || len(s.Reservations) != 1 {
+		t.Fatalf("freeze lost baseline/revision/obligation: %+v, %v", s, err)
+	}
+	in.templateFrozen = true
+	p = combinedTestPlan(t, in)
+	s, err = combinedModelDecode(p.state)
+	if err != nil || s.Baseline != 4 || s.Generation != in.generation || s.Revision != "newer" {
+		t.Fatalf("supersession changed the baseline or lost the active generation: %+v, %v", s, err)
+	}
+	in.state, in.partition = p.state, p.partition
+	in.desired, in.generation = 2, in.generation+1
+	p = combinedTestPlan(t, in)
+	if p.replicas != 2 || p.floor != 1 {
+		t.Fatalf("explicit downscale must cap the baseline, excluding condemned credit: %+v", p)
+	}
+	in.state, in.partition = p.state, p.partition
+	in.desired, in.generation = 0, in.generation+1
+	p = combinedTestPlan(t, in)
+	if !p.done || p.replicas != 0 || p.floor != 0 || len(p.deletes) != 0 {
+		t.Fatalf("scale to zero should leave scale-down to StatefulSet: %+v", p)
+	}
+	fromZero := combinedTestInput(0, 3, 1)
+	if p := combinedTestPlan(t, fromZero); p.replicas != 3 || len(p.deletes) != 0 {
+		t.Fatalf("from zero has no initial old groups to delete: %+v", p)
+	}
+}
+
+func TestCombinedPlannerPartitionAndMalformedState(t *testing.T) {
+	in := combinedTestInput(3, 4, 3)
+	in.protected = 2
+	p := combinedTestPlan(t, in)
+	if p.partition < 2 || !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-2"}) {
+		t.Fatalf("user partition was violated: %+v", p)
+	}
+	for _, raw := range []string{"{", "null", `{}`, `{"v":2,"b":3,"d":4,"g":2,"r":"new"}`, `{"v":1,"b":-1,"d":4,"g":2,"r":"new"}`, `{"v":1,"b":3,"d":4,"g":2,"r":"new","pending":{"2":{"uid":"","revision":"new"}}}`} {
+		in.state = raw
+		if p, err := combinedModelPlanUpdate(in); err == nil || len(p.deletes) != 0 {
+			t.Fatalf("malformed state %q was not rejected", raw)
+		}
+	}
+	in = combinedTestInput(3, 4, 1)
+	in.state = combinedModelEncode(combinedModelState{Version: 1, Baseline: 3, Desired: 4, Generation: 2, Revision: "new", NativeRevision: "native-new"})
+	in.partition = 1 // previous actor exposed two old leaders without reserving
+	if _, err := combinedModelPlanUpdate(in); err == nil {
+		t.Fatal("must not silently repair an unreserved native suffix")
+	}
+}
+
+func TestCombinedPlannerSnapshotInvariantExhaustive(t *testing.T) {
+	// Exercise every readiness mask for a 4 -> 8 transition with budgets 1..4.
+	// This checks decision accounting, not a real controller's concurrent writes.
+	for u := 1; u <= 4; u++ {
+		for mask := 0; mask < 256; mask++ {
+			in := combinedTestInput(4, 8, u)
+			ready := int32(0)
+			for i := range in.groups {
+				rev := in.groups[i].leader.Labels[leaderworkerset.RevisionKey]
+				in.groups[i] = combinedTestGroup(i, rev, mask&(1<<i) != 0)
+				if in.groups[i].ready(in.stsUID) {
+					ready++
+				}
+			}
+			p := combinedTestPlan(t, in)
+			if p.credited < min(ready, p.floor) {
+				t.Fatalf("u=%d mask=%08b: paid delete below attainable floor: %+v", u, mask, p)
+			}
+			state, err := combinedModelDecode(p.state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := p.partition; i < 4; i++ {
+				if _, ok := state.Reservations[i]; !ok {
+					t.Fatalf("u=%d mask=%08b: native suffix ordinal %d not reserved", u, mask, i)
+				}
+			}
+		}
+	}
+}
+
+func TestCombinedPlannerWholeGroupReadiness(t *testing.T) {
+	makeGroup := func() combinedModelGroup {
+		g := combinedTestGroup(0, "old", true)
+		g.leader.Annotations[leaderworkerset.SizeAnnotationKey] = "2"
+		g.workers = &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: g.leader.Name, UID: "workers", Generation: 2,
+				Labels:          map[string]string{leaderworkerset.RevisionKey: "old"},
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Pod", UID: g.leader.UID, Controller: ptr.To(true)}}},
+			Spec:   appsv1.StatefulSetSpec{Replicas: ptr.To[int32](1)},
+			Status: appsv1.StatefulSetStatus{ObservedGeneration: 2, AvailableReplicas: 1, CurrentRevision: "worker-rev", UpdateRevision: "worker-rev"},
+		}
+		worker := combinedTestGroup(0, "old", true).leader
+		worker.Name = "example-0-1"
+		worker.Labels[leaderworkerset.WorkerIndexLabelKey] = "1"
+		worker.Labels[appsv1.ControllerRevisionHashLabelKey] = "worker-rev"
+		worker.OwnerReferences[0].UID = g.workers.UID
+		g.pods = []corev1.Pod{*worker}
+		return g
+	}
+	if !makeGroup().ready("leader-sts") {
+		t.Fatal("valid old-revision group must supply Ready credit")
+	}
+	tests := map[string]func(*combinedModelGroup){
+		"leader terminating":                         func(g *combinedModelGroup) { now := metav1.Now(); g.leader.DeletionTimestamp = &now },
+		"foreign leader owner":                       func(g *combinedModelGroup) { g.leader.OwnerReferences[0].UID = "foreign" },
+		"workers terminating":                        func(g *combinedModelGroup) { now := metav1.Now(); g.workers.DeletionTimestamp = &now },
+		"previous leader UID":                        func(g *combinedModelGroup) { g.workers.OwnerReferences[0].UID = "previous" },
+		"previous worker revision":                   func(g *combinedModelGroup) { g.workers.Labels[leaderworkerset.RevisionKey] = "previous" },
+		"worker terminating despite Ready aggregate": func(g *combinedModelGroup) { now := metav1.Now(); g.pods[0].DeletionTimestamp = &now },
+		"stale worker UID":                           func(g *combinedModelGroup) { g.pods[0].OwnerReferences[0].UID = "previous-workers" },
+		"stale worker revision":                      func(g *combinedModelGroup) { g.pods[0].Labels[leaderworkerset.RevisionKey] = "previous" },
+		"same LWS label stale worker native hash": func(g *combinedModelGroup) {
+			g.pods[0].Labels[appsv1.ControllerRevisionHashLabelKey] = "previous-native"
+		},
+		"missing worker native target": func(g *combinedModelGroup) {
+			g.workers.Status.CurrentRevision = ""
+			g.workers.Status.UpdateRevision = ""
+		},
+		"worker missing":               func(g *combinedModelGroup) { g.pods = nil },
+		"worker Pending":               func(g *combinedModelGroup) { g.pods[0].Status.Conditions = nil },
+		"unobserved worker generation": func(g *combinedModelGroup) { g.workers.Status.ObservedGeneration = 1 },
+		"invalid revision size":        func(g *combinedModelGroup) { g.leader.Annotations[leaderworkerset.SizeAnnotationKey] = "garbage" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := makeGroup()
+			mutate(&g)
+			if g.ready("leader-sts") {
+				t.Fatal("invalid/incomplete group supplied Ready credit")
+			}
+		})
+	}
+	// A replacement leader alone does not release a reservation; old worker
+	// ownership/status cannot make a new group look ready.
+	in := combinedTestInput(2, 3, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition = p.state, p.partition
+	in.groups[1] = makeGroup()
+	in.groups[1].leader.Name, in.groups[1].leader.UID = "example-1", "new-1"
+	in.groups[1].leader.Labels[leaderworkerset.RevisionKey] = "new"
+	in.groups[1].leader.Labels[appsv1.ControllerRevisionHashLabelKey] = "native-new"
+	if p := combinedTestPlan(t, in); len(p.deletes) != 0 {
+		t.Fatalf("stale workers released the paid reservation: %+v", p)
+	}
+}
+
+func TestCombinedPlannerSameLWSRevisionDifferentNative(t *testing.T) {
+	in := combinedTestInput(2, 3, 0)
+	in.surge = intstr.FromInt(1)
+	for i := 0; i < 2; i++ {
+		in.groups[i].leader.Labels[leaderworkerset.RevisionKey] = "new"
+	}
+	// A Ready added leader with missing workers cannot pay for either native
+	// replacement, even though all leaders carry the desired LWS label.
+	in.groups[2] = combinedTestGroup(2, "new", true)
+	in.groups[2].leader.Annotations[leaderworkerset.SizeAnnotationKey] = "2"
+	p := combinedTestPlan(t, in)
+	if p.partition != 2 || len(p.deletes) != 0 || p.credited != p.floor {
+		t.Fatalf("same LWS label exposed unpaid native replacements: %+v", p)
+	}
+	in.groups[2].leader.Annotations[leaderworkerset.SizeAnnotationKey] = "1"
+	in.state, in.partition = p.state, p.partition
+	p = combinedTestPlan(t, in)
+	if !reflect.DeepEqual(combinedDeleteNames(p), []string{"example-1"}) {
+		t.Fatalf("native-stale leader must be reserved and selected: %+v", p)
+	}
+	in.state, in.partition = p.state, p.partition
+	in.groups[1].leader.UID = "replacement-but-native-stale"
+	p = combinedTestPlan(t, in)
+	s, err := combinedModelDecode(p.state)
+	if err != nil || len(s.Reservations) != 1 || len(p.deletes) != 1 {
+		t.Fatalf("wrong native replacement discharged obligation: %+v, %v", p, err)
+	}
+}
+
+func TestCombinedPlannerDownscaleBeforeReservedDeletion(t *testing.T) {
+	in := combinedTestInput(4, 8, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition, in.desired = p.state, p.partition, 2
+	in.generation++
+	// Production active input, NOT the synthetic supersession bypass.
+	in.templateFrozen = false
+	p = combinedTestPlan(t, in)
+	s, err := combinedModelDecode(p.state)
+	if err != nil || p.replicas != 2 || p.floor != 1 {
+		t.Fatalf("downscale trapped by old reservation: %+v, %v", p, err)
+	}
+	if _, ok := s.Reservations[3]; ok {
+		t.Fatal("condemned reservation survived atomic downscale")
+	}
+	in.state, in.partition, in.replicas = p.state, p.partition, p.replicas
+	again := combinedTestPlan(t, in)
+	if again.state != p.state {
+		t.Fatal("downscale retry spent a second reservation")
+	}
+}
+
+func TestCombinedPlannerSameUIDRecoveryDoesNotRefund(t *testing.T) {
+	in := combinedTestInput(2, 3, 1)
+	p := combinedTestPlan(t, in)
+	in.state, in.partition = p.state, p.partition
+	in.groups[1].leader.Labels[leaderworkerset.RevisionKey] = in.revision
+	in.groups[1].leader.Labels[appsv1.ControllerRevisionHashLabelKey] = in.nativeRevision
+	p = combinedTestPlan(t, in)
+	s, err := combinedModelDecode(p.state)
+	if err != nil || len(s.Reservations) != 1 || len(p.deletes) != 0 {
+		t.Fatalf("same UID refunded without acknowledged withdrawal: %+v, %v", p, err)
+	}
+}

--- a/pkg/controllers/combined_rollout_regression_test.go
+++ b/pkg/controllers/combined_rollout_regression_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+// Real apiserver writes, with explicitly simulated native status and Pods.
+// There is no native StatefulSet controller in envtest.
+type combinedAPIFixture struct {
+	t      *testing.T
+	c      client.Client
+	scheme *runtime.Scheme
+	key    client.ObjectKey
+}
+
+func newCombinedAPIFixture(t *testing.T, c client.Client, scheme *runtime.Scheme, namespace, name string, b int) *combinedAPIFixture {
+	t.Helper()
+	lws := wrappers.BuildLeaderWorkerSet(namespace).Replica(b).Size(1).Obj()
+	lws.Name = name
+	lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt(1)
+	f := &combinedAPIFixture{t: t, c: c, scheme: scheme, key: client.ObjectKeyFromObject(lws)}
+	if err := c.Create(context.Background(), lws); err != nil {
+		t.Fatal(err)
+	}
+	f.reconcile()
+	f.ack(true)
+	for i := 0; i < b; i++ {
+		f.leader(i, true)
+	}
+	return f
+}
+
+func (f *combinedAPIFixture) reconciler() *LeaderWorkerSetReconciler {
+	r := NewLeaderWorkerSetReconciler(f.c, f.scheme, fakeEventRecorder{})
+	r.APIReader = f.c
+	return r
+}
+
+func (f *combinedAPIFixture) reconcile() {
+	f.t.Helper()
+	// Restart every pass, so no test depends on in-memory phase state.
+	if _, err := f.reconciler().Reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *combinedAPIFixture) sts() *appsv1.StatefulSet {
+	f.t.Helper()
+	s := &appsv1.StatefulSet{}
+	if err := f.c.Get(context.Background(), f.key, s); err != nil {
+		f.t.Fatal(err)
+	}
+	return s
+}
+
+func (f *combinedAPIFixture) lws() *leaderworkerset.LeaderWorkerSet {
+	f.t.Helper()
+	lws := &leaderworkerset.LeaderWorkerSet{}
+	if err := f.c.Get(context.Background(), f.key, lws); err != nil {
+		f.t.Fatal(err)
+	}
+	return lws
+}
+
+func (f *combinedAPIFixture) change(mutate func(*leaderworkerset.LeaderWorkerSet)) {
+	f.t.Helper()
+	lws := f.lws()
+	mutate(lws)
+	if err := f.c.Update(context.Background(), lws); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *combinedAPIFixture) state() combinedModelState {
+	f.t.Helper()
+	s, err := combinedModelDecode(f.sts().Annotations[combinedRolloutAnnotation])
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return s
+}
+
+func (f *combinedAPIFixture) ack(promote bool) {
+	f.t.Helper()
+	s := f.sts()
+	b, err := json.Marshal(s.Spec.Template)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	s.Status.UpdateRevision = fmt.Sprintf("native-%x", sha256.Sum256(b))[:40]
+	if promote {
+		s.Status.CurrentRevision = s.Status.UpdateRevision
+	}
+	s.Status.ObservedGeneration, s.Status.Replicas = s.Generation, *s.Spec.Replicas
+	if err := f.c.Status().Update(context.Background(), s); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *combinedAPIFixture) leader(i int, ready bool) *corev1.Pod {
+	f.t.Helper()
+	s := f.sts()
+	p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%d", f.key.Name, i), Namespace: f.key.Namespace,
+		Labels:          map[string]string{leaderworkerset.SetNameLabelKey: f.key.Name, leaderworkerset.GroupIndexLabelKey: strconv.Itoa(i), leaderworkerset.WorkerIndexLabelKey: "0", leaderworkerset.RevisionKey: s.Spec.Template.Labels[leaderworkerset.RevisionKey], appsv1.ControllerRevisionHashLabelKey: s.Status.UpdateRevision},
+		Annotations:     map[string]string{leaderworkerset.SizeAnnotationKey: "1"},
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: s.Name, UID: s.UID, Controller: ptr.To(true)}}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "test.invalid/image"}}}}
+	if err := f.c.Create(context.Background(), p); err != nil {
+		f.t.Fatal(err)
+	}
+	if ready {
+		p.Status.Phase = corev1.PodRunning
+		p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+		if err := f.c.Status().Update(context.Background(), p); err != nil {
+			f.t.Fatal(err)
+		}
+	}
+	return p
+}
+
+func (f *combinedAPIFixture) activate() {
+	f.t.Helper()
+	f.reconcile() // freeze
+	f.ack(false)
+	f.reconcile() // publish
+	f.ack(false)
+	f.reconcile() // pin native target
+	if f.state().NativeRevision != f.sts().Status.UpdateRevision {
+		f.t.Fatal("native target not persisted")
+	}
+}
+
+func (f *combinedAPIFixture) grow(d int32) {
+	f.change(func(lws *leaderworkerset.LeaderWorkerSet) {
+		lws.Spec.Replicas = ptr.To(d)
+		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image = "test.invalid/new"
+	})
+	f.activate()
+	f.reconcile() // persist reservation, without deleting
+	f.ack(false)
+}
+
+func testCombinedRegressions(t *testing.T, c client.Client, scheme *runtime.Scheme, namespace string) {
+	for _, rollback := range []bool{true, false} {
+		name := "partition-raise"
+		if rollback {
+			name = "rollback"
+		}
+		t.Run(name+" retires only after acknowledged fence across restart", func(t *testing.T) {
+			f := newCombinedAPIFixture(t, c, scheme, namespace, name, 2)
+			oldImage := f.lws().Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image
+			f.grow(3)
+			reservation, ok := f.state().Reservations[1]
+			if !ok {
+				t.Fatal("expected ordinal 1 authorization")
+			}
+			f.change(func(lws *leaderworkerset.LeaderWorkerSet) {
+				if rollback {
+					lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image = oldImage
+				} else {
+					lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition = ptr.To[int32](2)
+				}
+			})
+			f.reconcile()
+			f.reconcile() // no native acknowledgement
+			if f.state().Phase != combinedFreeze || f.state().Reservations[1].UID != reservation.UID {
+				t.Fatal("retired surviving obligation before fence acknowledgement")
+			}
+			f.ack(false)
+			f.reconcile()
+			f.ack(false)
+			f.reconcile()
+			if len(f.state().Reservations) != 0 {
+				t.Fatal("impossible same-UID/protected obligation survived fence")
+			}
+			p := &corev1.Pod{}
+			if err := c.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: name + "-1"}, p); err != nil {
+				t.Fatal(err)
+			}
+			if p.UID != reservation.UID || p.DeletionTimestamp != nil {
+				t.Fatal("fenced obligation deleted original leader")
+			}
+			f.leader(2, true)
+			if rollback {
+				f.ack(true)
+			}
+			f.reconcile()
+			if f.sts().Annotations[combinedRolloutAnnotation] != "" {
+				t.Fatal("ready rollback/protected groups did not complete")
+			}
+			if !rollback && f.sts().Status.CurrentRevision == f.sts().Status.UpdateRevision {
+				t.Fatal("test must exercise protected old native revision")
+			}
+		})
+	}
+
+	t.Run("completion waits for native promotion and retains history", func(t *testing.T) {
+		f := newCombinedAPIFixture(t, c, scheme, namespace, "promotion", 1)
+		f.grow(2)
+		old := &corev1.Pod{}
+		if err := c.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: "promotion-0"}, old); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Delete(context.Background(), old, client.GracePeriodSeconds(0)); err != nil {
+			t.Fatal(err)
+		}
+		f.leader(0, true)
+		f.leader(1, true)
+		for i := 0; i < 3; i++ {
+			f.ack(false)
+			f.reconcile()
+		}
+		if f.state().Phase != combinedActive {
+			t.Fatal("cleared state before native promotion")
+		}
+		var revisions appsv1.ControllerRevisionList
+		if err := c.List(context.Background(), &revisions, client.InNamespace(namespace), client.MatchingLabels{leaderworkerset.SetNameLabelKey: f.key.Name}); err != nil {
+			t.Fatal(err)
+		}
+		if len(revisions.Items) != 2 {
+			t.Fatalf("lost protected history: %d", len(revisions.Items))
+		}
+		f.ack(true)
+		f.reconcile()
+		if f.sts().Annotations[combinedRolloutAnnotation] != "" {
+			t.Fatal("did not complete after native promotion")
+		}
+		f.change(func(lws *leaderworkerset.LeaderWorkerSet) {
+			lws.Spec.Replicas = ptr.To[int32](3)
+			lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.Containers[0].Image = "test.invalid/newer"
+		})
+		f.reconcile()
+		if f.state().Phase != combinedFreeze || f.state().Baseline != 2 || f.sts().Status.CurrentRevision != f.sts().Status.UpdateRevision {
+			t.Fatal("next update did not start from promoted baseline")
+		}
+	})
+
+	t.Run("same LWS revision annotation update freezes before publication", func(t *testing.T) {
+		f := newCombinedAPIFixture(t, c, scheme, namespace, "annotation", 2)
+		f.change(func(lws *leaderworkerset.LeaderWorkerSet) {
+			lws.Spec.Replicas = ptr.To[int32](3)
+			lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt(0)
+			lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt(1)
+			lws.Annotations = map[string]string{leaderworkerset.ExclusiveKeyAnnotationKey: "topology.example/a"}
+		})
+		lwsRevision := f.sts().Labels[leaderworkerset.RevisionKey]
+		oldNative := f.sts().Status.UpdateRevision
+		f.activate()
+		if f.state().Revision != lwsRevision || f.state().NativeRevision == oldNative {
+			t.Fatal("test did not produce identical LWS/different native identities")
+		}
+		f.reconcile()
+		f.ack(false)
+		p := f.leader(2, true)
+		p.Annotations[leaderworkerset.SizeAnnotationKey] = "2" // workers absent
+		if err := c.Update(context.Background(), p); err != nil {
+			t.Fatal(err)
+		}
+		f.reconcile()
+		if *f.sts().Spec.UpdateStrategy.RollingUpdate.Partition != 2 || len(f.state().Reservations) != 0 {
+			t.Fatal("Ready leader with missing workers financed native replacement")
+		}
+		f.change(func(lws *leaderworkerset.LeaderWorkerSet) {
+			lws.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] = "topology.example/b"
+		})
+		f.reconcile()
+		if f.state().Phase != combinedFreeze || f.sts().Spec.Template.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "topology.example/a" {
+			t.Fatal("metadata-only supersession published without freeze")
+		}
+		f.ack(false)
+		f.reconcile()
+		f.ack(false)
+		f.reconcile()
+		if f.state().Revision != lwsRevision || f.sts().Spec.Template.Annotations[leaderworkerset.ExclusiveKeyAnnotationKey] != "topology.example/b" {
+			t.Fatal("annotation-only target was not safely republished")
+		}
+	})
+
+	t.Run("operational patches preserve foreign SSA ownership and reject stale RV", func(t *testing.T) {
+		f := newCombinedAPIFixture(t, c, scheme, namespace, "ownership", 1)
+		foreign := func(value string) {
+			t.Helper()
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "apps/v1", "kind": "StatefulSet", "metadata": map[string]interface{}{"name": f.key.Name, "namespace": namespace, "annotations": map[string]interface{}{"independent.example/note": value}}, "spec": map[string]interface{}{"template": map[string]interface{}{"metadata": map[string]interface{}{"annotations": map[string]interface{}{"independent.example/template": "unchanged"}}}}}}
+			if err := c.Patch(context.Background(), obj, client.Apply, client.FieldOwner("independent")); err != nil {
+				t.Fatal(err)
+			} //nolint:staticcheck // real SSA ownership regression
+		}
+		foreign("before")
+		f.ack(true)
+		f.grow(2)
+		foreign("after-publication") // no force: copied ownership would conflict
+		if f.sts().Spec.Template.Annotations["independent.example/template"] != "unchanged" {
+			t.Fatal("publication pruned foreign template metadata")
+		}
+		r := f.reconciler()
+		old := f.sts()
+		next := old.DeepCopy()
+		next.Annotations["independent.example/note"] = "stale-write"
+		foreign("after-reservation")
+		if err := r.applyCombinedStatefulSet(context.Background(), f.lws(), old, next, old.Annotations[combinedRolloutAnnotation]); !apierrors.IsConflict(err) {
+			t.Fatalf("stale operational patch accepted: %v", err)
+		}
+		// Exercise cleanup through the same operational writer without relying
+		// on a native controller that is not present in this API test.
+		old = f.sts()
+		if err := r.applyCombinedStatefulSet(context.Background(), f.lws(), old, old.DeepCopy(), ""); err != nil {
+			t.Fatal(err)
+		}
+		foreign("after-cleanup")
+		if f.sts().Annotations[combinedRolloutAnnotation] != "" {
+			t.Fatal("cleanup did not remove protocol annotation")
+		}
+	})
+}
+
+func TestCombinedMixedSizeRestartUsesLeaderStamp(t *testing.T) {
+	for _, workerRestart := range []bool{false, true} {
+		t.Run(fmt.Sprintf("worker=%t", workerRestart), func(t *testing.T) {
+			lws := wrappers.BuildLeaderWorkerSet("default").Replica(1).Size(1).Obj()
+			lws.Spec.LeaderWorkerTemplate.RestartPolicy = leaderworkerset.RecreateGroupAfterStart
+			leader := combinedTestGroup(0, "old", true).leader
+			leader.Annotations[leaderworkerset.SizeAnnotationKey] = "2"
+			leader.Labels[leaderworkerset.WorkerIndexLabelKey] = "0"
+			leader.Labels[leaderworkerset.SetNameLabelKey] = lws.Name
+			leader.Labels[leaderworkerset.GroupIndexLabelKey] = "0"
+			worker := leader.DeepCopy()
+			worker.Name, worker.UID = leader.Name+"-1", "worker"
+			worker.Labels[leaderworkerset.WorkerIndexLabelKey] = "1"
+			worker.OwnerReferences = []metav1.OwnerReference{{Kind: "Pod", Name: leader.Name, UID: leader.UID, Controller: ptr.To(true)}}
+			restarting := leader
+			if workerRestart {
+				restarting = worker
+			}
+			restarting.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "test", RestartCount: 1}}
+			c := fake.NewClientBuilder().WithObjects(leader, worker).Build()
+			r := NewPodReconciler(c, c.Scheme(), fakeEventRecorder{}, nil)
+			deleted, err := r.handleRestartPolicy(context.Background(), *restarting, *lws)
+			if err != nil || !deleted {
+				t.Fatalf("old size-two group suppressed under live size-one: deleted=%t err=%v", deleted, err)
+			}
+		})
+	}
+}

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -348,6 +348,10 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 		// Processing scaling up/down first prior to rolling update.
 		partition := min(lwsReplicas, stsReplicas)
 		if stsReplicas < lwsReplicas {
+			if lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == leaderworkerset.RolloutFirstUpdateOrder && stsReplicas > 0 {
+				partition = max(*lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition, stsReplicas-int32(maxUnavailable))
+				return partition, stsReplicas, nil
+			}
 			return partition, lwsReplicas, nil
 		}
 		return partition, wantReplicas(lwsReplicas), nil
@@ -360,14 +364,30 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 	if rollingUpdateCompleted {
 		return 0, lwsReplicas, nil
 	}
-	if stsReplicas < lwsReplicas {
+	if stsReplicas < lwsReplicas && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder != leaderworkerset.RolloutFirstUpdateOrder {
 		return partition, lwsReplicas, nil
 	}
-
 	states, err := r.getReplicaStates(ctx, lws, stsReplicas, revisionKey)
 	if err != nil {
 		return 0, 0, err
 	}
+	if stsReplicas < lwsReplicas {
+		rolloutPartition := *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition
+		rolloutComplete := true
+		for idx := rolloutPartition; idx < stsReplicas; idx++ {
+			if !states[idx].ready || !states[idx].updated {
+				rolloutComplete = false
+				break
+			}
+		}
+		if rolloutComplete {
+			return partition, lwsReplicas, nil
+		}
+
+		partition = rollingUpdatePartition(states, stsReplicas, int32(maxUnavailable), partition)
+		return partition, stsReplicas, nil
+	}
+
 	lwsUnreadyReplicas := calculateLWSUnreadyReplicas(states, lwsReplicas)
 
 	originalLwsReplicas, err := strconv.Atoi(sts.Annotations[leaderworkerset.ReplicasAnnotationKey])

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -53,8 +53,11 @@ import (
 // LeaderWorkerSetReconciler reconciles a LeaderWorkerSet object
 type LeaderWorkerSetReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Record events.EventRecorder
+	// APIReader fences combined-rollout decisions against uncached identities.
+	// SetupWithManager supplies it without changing existing constructors.
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Record    events.EventRecorder
 
 	revisionEqualityCache *lru.Cache
 }
@@ -116,6 +119,9 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, lws); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	// Typed direct clients may omit TypeMeta; revision owner references require
+	// the known GVK independently of whether this read came from a cache.
+	lws.SetGroupVersionKind(leaderworkerset.GroupVersion.WithKind("LeaderWorkerSet"))
 
 	if lws.DeletionTimestamp != nil {
 		return ctrl.Result{}, nil
@@ -163,12 +169,19 @@ func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	lwsUpdated := updatedRevision != nil
 	if lwsUpdated {
-		revision, err = revisionutils.CreateRevision(ctx, r.Client, updatedRevision)
+		// Freeze deliberately leaves the StatefulSet's old label in place.
+		// Reuse an equivalent target (also on rollback/restart), rather than
+		// allocating a new numbered revision on every acknowledgement wait.
+		revision, err = r.reuseOrCreateRevision(ctx, lws, updatedRevision)
 		if err != nil {
 			log.Error(err, "Creating revision for updated LWS")
 			return ctrl.Result{}, err
 		}
 		r.Record.Eventf(lws, revision, corev1.EventTypeNormal, CreatingRevision, Create, fmt.Sprintf("Creating revision with key %s for updated LWS", revisionutils.GetRevisionKey(revision)))
+	}
+
+	if handled, result, err := r.reconcileCombinedRollout(ctx, lws, leaderSts, revisionutils.GetRevisionKey(revision), lwsUpdated); handled {
+		return result, err
 	}
 
 	partition, replicas, err := r.rollingUpdateParameters(ctx, lws, leaderSts, revisionutils.GetRevisionKey(revision), lwsUpdated)
@@ -237,11 +250,13 @@ func (r *LeaderWorkerSetReconciler) reconcileHeadlessServices(ctx context.Contex
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LeaderWorkerSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&leaderworkerset.LeaderWorkerSet{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(enqueueLWSRequests)).
 		Watches(&appsv1.StatefulSet{},
 			handler.EnqueueRequestsFromMapFunc(enqueueLWSRequests)).
 		Complete(r)
@@ -348,10 +363,6 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 		// Processing scaling up/down first prior to rolling update.
 		partition := min(lwsReplicas, stsReplicas)
 		if stsReplicas < lwsReplicas {
-			if lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == leaderworkerset.RolloutFirstUpdateOrder && stsReplicas > 0 {
-				partition = max(*lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition, stsReplicas-int32(maxUnavailable))
-				return partition, stsReplicas, nil
-			}
 			return partition, lwsReplicas, nil
 		}
 		return partition, wantReplicas(lwsReplicas), nil
@@ -364,28 +375,12 @@ func (r *LeaderWorkerSetReconciler) rollingUpdateParameters(ctx context.Context,
 	if rollingUpdateCompleted {
 		return 0, lwsReplicas, nil
 	}
-	if stsReplicas < lwsReplicas && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder != leaderworkerset.RolloutFirstUpdateOrder {
+	if stsReplicas < lwsReplicas {
 		return partition, lwsReplicas, nil
 	}
 	states, err := r.getReplicaStates(ctx, lws, stsReplicas, revisionKey)
 	if err != nil {
 		return 0, 0, err
-	}
-	if stsReplicas < lwsReplicas {
-		rolloutPartition := *lws.Spec.RolloutStrategy.RollingUpdateConfiguration.Partition
-		rolloutComplete := true
-		for idx := rolloutPartition; idx < stsReplicas; idx++ {
-			if !states[idx].ready || !states[idx].updated {
-				rolloutComplete = false
-				break
-			}
-		}
-		if rolloutComplete {
-			return partition, lwsReplicas, nil
-		}
-
-		partition = rollingUpdatePartition(states, stsReplicas, int32(maxUnavailable), partition)
-		return partition, stsReplicas, nil
 	}
 
 	lwsUnreadyReplicas := calculateLWSUnreadyReplicas(states, lwsReplicas)
@@ -806,6 +801,22 @@ func (r *LeaderWorkerSetReconciler) getUpdatedRevision(ctx context.Context, lws 
 	}
 
 	return nil, nil
+}
+
+func (r *LeaderWorkerSetReconciler) reuseOrCreateRevision(ctx context.Context, lws *leaderworkerset.LeaderWorkerSet, proposed *appsv1.ControllerRevision) (*appsv1.ControllerRevision, error) {
+	var revisions appsv1.ControllerRevisionList
+	// A cached list can lag our last create across repeated reconciles.
+	if err := r.combinedReader().List(ctx, &revisions, client.InNamespace(lws.Namespace), client.MatchingLabels{leaderworkerset.SetNameLabelKey: lws.Name}); err != nil {
+		return nil, err
+	}
+	for i := range revisions.Items {
+		existing := &revisions.Items[i]
+		if combinedModelOwnedBy(existing, "LeaderWorkerSet", lws.UID) &&
+			(revisionutils.EqualRevision(proposed, existing) || revisionutils.SetMatchesRevision(lws, proposed, existing, r.revisionEqualityCache)) {
+			return existing, nil
+		}
+	}
+	return revisionutils.CreateRevision(ctx, r.Client, proposed)
 }
 
 // buildLeaderPodTemplateApplyConfiguration constructs the leader pod template

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -1034,6 +1034,167 @@ func TestRollingUpdateParametersScaleUpWithTemplateUpdateDoesNotCreateExtraSurge
 	}
 }
 
+func TestRollingUpdateParametersRolloutFirstHoldsReplicasDuringTemplateUpdate(t *testing.T) {
+	reconciler := &LeaderWorkerSetReconciler{Record: fakeEventRecorder{}}
+	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+		Replica(3).
+		Size(1).
+		RolloutStrategy(leaderworkerset.RolloutStrategy{
+			Type: leaderworkerset.RollingUpdateStrategyType,
+			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+				UpdateOrder:    leaderworkerset.RolloutFirstUpdateOrder,
+				Partition:      ptr.To[int32](0),
+				MaxUnavailable: intstr.FromInt32(1),
+				MaxSurge:       intstr.FromInt32(0),
+			},
+		}).Obj()
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        lws.Name,
+			Namespace:   lws.Namespace,
+			Annotations: map[string]string{leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(2)},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr.To[int32](2),
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					Partition: ptr.To[int32](0),
+				},
+			},
+		},
+	}
+
+	partition, replicas, err := reconciler.rollingUpdateParameters(context.Background(), lws, sts, "rev-new", true)
+	if err != nil {
+		t.Fatalf("rollingUpdateParameters() unexpected error: %v", err)
+	}
+	if partition != 1 {
+		t.Fatalf("rollingUpdateParameters() partition=%d, want 1", partition)
+	}
+	if replicas != 2 {
+		t.Fatalf("rollingUpdateParameters() replicas=%d, want 2", replicas)
+	}
+}
+
+func TestRollingUpdateParametersRolloutFirstProgression(t *testing.T) {
+	const (
+		oldRevision = "rev-old"
+		newRevision = "rev-new"
+	)
+
+	tests := []struct {
+		name          string
+		partition     int32
+		pods          []corev1.Pod
+		wantPartition int32
+		wantReplicas  int32
+	}{
+		{
+			name:      "holds replicas while the first replacement is unready",
+			partition: 1,
+			pods: []corev1.Pod{
+				makeRolloutFirstTestPod("test-sample-0", "0", oldRevision, true),
+				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, false),
+			},
+			wantPartition: 1,
+			wantReplicas:  2,
+		},
+		{
+			name:      "updates the next existing replica before scaling",
+			partition: 1,
+			pods: []corev1.Pod{
+				makeRolloutFirstTestPod("test-sample-0", "0", oldRevision, true),
+				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, true),
+			},
+			wantPartition: 0,
+			wantReplicas:  2,
+		},
+		{
+			name:      "scales after all existing replicas are updated and ready",
+			partition: 0,
+			pods: []corev1.Pod{
+				makeRolloutFirstTestPod("test-sample-0", "0", newRevision, true),
+				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, true),
+			},
+			wantPartition: 0,
+			wantReplicas:  3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := make([]runtime.Object, 0, len(tc.pods))
+			for idx := range tc.pods {
+				objects = append(objects, &tc.pods[idx])
+			}
+			reconciler := &LeaderWorkerSetReconciler{
+				Client: fake.NewClientBuilder().WithRuntimeObjects(objects...).Build(),
+				Record: fakeEventRecorder{},
+			}
+			lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
+				Replica(3).
+				Size(1).
+				RolloutStrategy(leaderworkerset.RolloutStrategy{
+					Type: leaderworkerset.RollingUpdateStrategyType,
+					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+						UpdateOrder:    leaderworkerset.RolloutFirstUpdateOrder,
+						Partition:      ptr.To[int32](0),
+						MaxUnavailable: intstr.FromInt32(1),
+						MaxSurge:       intstr.FromInt32(0),
+					},
+				}).Obj()
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        lws.Name,
+					Namespace:   lws.Namespace,
+					Annotations: map[string]string{leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(2)},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To[int32](2),
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+							Partition: ptr.To(tc.partition),
+						},
+					},
+				},
+			}
+
+			partition, replicas, err := reconciler.rollingUpdateParameters(context.Background(), lws, sts, newRevision, false)
+			if err != nil {
+				t.Fatalf("rollingUpdateParameters() unexpected error: %v", err)
+			}
+			if partition != tc.wantPartition {
+				t.Errorf("rollingUpdateParameters() partition=%d, want %d", partition, tc.wantPartition)
+			}
+			if replicas != tc.wantReplicas {
+				t.Errorf("rollingUpdateParameters() replicas=%d, want %d", replicas, tc.wantReplicas)
+			}
+		})
+	}
+}
+
+func makeRolloutFirstTestPod(name, groupIndex, revision string, ready bool) corev1.Pod {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     "test-sample",
+				leaderworkerset.WorkerIndexLabelKey: "0",
+				leaderworkerset.GroupIndexLabelKey:  groupIndex,
+				leaderworkerset.RevisionKey:         revision,
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	return pod
+}
+
 func TestRollingUpdateParametersTemplateUpdateReclaimsSurgeWhenAllowed(t *testing.T) {
 	reconciler := &LeaderWorkerSetReconciler{Record: fakeEventRecorder{}}
 	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -1034,7 +1034,7 @@ func TestRollingUpdateParametersScaleUpWithTemplateUpdateDoesNotCreateExtraSurge
 	}
 }
 
-func TestRollingUpdateParametersRolloutFirstHoldsReplicasDuringTemplateUpdate(t *testing.T) {
+func TestLegacyRollingParametersDoNotHoldGrowth(t *testing.T) {
 	reconciler := &LeaderWorkerSetReconciler{Record: fakeEventRecorder{}}
 	lws := wrappers.BuildBasicLeaderWorkerSet("test-sample", "default").
 		Replica(3).
@@ -1042,7 +1042,6 @@ func TestRollingUpdateParametersRolloutFirstHoldsReplicasDuringTemplateUpdate(t 
 		RolloutStrategy(leaderworkerset.RolloutStrategy{
 			Type: leaderworkerset.RollingUpdateStrategyType,
 			RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-				UpdateOrder:    leaderworkerset.RolloutFirstUpdateOrder,
 				Partition:      ptr.To[int32](0),
 				MaxUnavailable: intstr.FromInt32(1),
 				MaxSurge:       intstr.FromInt32(0),
@@ -1069,15 +1068,15 @@ func TestRollingUpdateParametersRolloutFirstHoldsReplicasDuringTemplateUpdate(t 
 	if err != nil {
 		t.Fatalf("rollingUpdateParameters() unexpected error: %v", err)
 	}
-	if partition != 1 {
-		t.Fatalf("rollingUpdateParameters() partition=%d, want 1", partition)
+	if partition != 2 {
+		t.Fatalf("rollingUpdateParameters() partition=%d, want 2", partition)
 	}
-	if replicas != 2 {
-		t.Fatalf("rollingUpdateParameters() replicas=%d, want 2", replicas)
+	if replicas != 3 {
+		t.Fatalf("rollingUpdateParameters() replicas=%d, want 3", replicas)
 	}
 }
 
-func TestRollingUpdateParametersRolloutFirstProgression(t *testing.T) {
+func TestLegacyRollingParametersGrowthWithoutActiveState(t *testing.T) {
 	const (
 		oldRevision = "rev-old"
 		newRevision = "rev-new"
@@ -1091,31 +1090,31 @@ func TestRollingUpdateParametersRolloutFirstProgression(t *testing.T) {
 		wantReplicas  int32
 	}{
 		{
-			name:      "holds replicas while the first replacement is unready",
+			name:      "legacy growth while replacement is unready",
 			partition: 1,
 			pods: []corev1.Pod{
-				makeRolloutFirstTestPod("test-sample-0", "0", oldRevision, true),
-				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, false),
+				makeGrowthTestPod("test-sample-0", "0", oldRevision, true),
+				makeGrowthTestPod("test-sample-1", "1", newRevision, false),
 			},
 			wantPartition: 1,
-			wantReplicas:  2,
+			wantReplicas:  3,
 		},
 		{
-			name:      "updates the next existing replica before scaling",
+			name:      "legacy growth does not select a lower replica",
 			partition: 1,
 			pods: []corev1.Pod{
-				makeRolloutFirstTestPod("test-sample-0", "0", oldRevision, true),
-				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, true),
+				makeGrowthTestPod("test-sample-0", "0", oldRevision, true),
+				makeGrowthTestPod("test-sample-1", "1", newRevision, true),
 			},
-			wantPartition: 0,
-			wantReplicas:  2,
+			wantPartition: 1,
+			wantReplicas:  3,
 		},
 		{
 			name:      "scales after all existing replicas are updated and ready",
 			partition: 0,
 			pods: []corev1.Pod{
-				makeRolloutFirstTestPod("test-sample-0", "0", newRevision, true),
-				makeRolloutFirstTestPod("test-sample-1", "1", newRevision, true),
+				makeGrowthTestPod("test-sample-0", "0", newRevision, true),
+				makeGrowthTestPod("test-sample-1", "1", newRevision, true),
 			},
 			wantPartition: 0,
 			wantReplicas:  3,
@@ -1138,7 +1137,6 @@ func TestRollingUpdateParametersRolloutFirstProgression(t *testing.T) {
 				RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
 					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-						UpdateOrder:    leaderworkerset.RolloutFirstUpdateOrder,
 						Partition:      ptr.To[int32](0),
 						MaxUnavailable: intstr.FromInt32(1),
 						MaxSurge:       intstr.FromInt32(0),
@@ -1175,7 +1173,7 @@ func TestRollingUpdateParametersRolloutFirstProgression(t *testing.T) {
 	}
 }
 
-func makeRolloutFirstTestPod(name, groupIndex, revision string, ready bool) corev1.Pod {
+func makeGrowthTestPod(name, groupIndex, revision string, ready bool) corev1.Pod {
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -169,8 +169,17 @@ func (r *PodReconciler) reconcilePod(ctx context.Context, req podReconcileReques
 		}
 	}
 
-	// Once size = 1, no need to create worker statefulSets.
-	if *leaderWorkerSet.Spec.LeaderWorkerTemplate.Size == 1 {
+	// A protected old leader may have a different size from the live LWS.
+	// Use its stamped revision size, not the latest template's size-one shortcut.
+	groupSize := *leaderWorkerSet.Spec.LeaderWorkerTemplate.Size
+	if stamped, ok := pod.Annotations[leaderworkerset.SizeAnnotationKey]; ok {
+		size, err := strconv.ParseInt(stamped, 10, 32)
+		if err != nil || size < 1 {
+			return ctrl.Result{}, fmt.Errorf("invalid leader group size %q", stamped)
+		}
+		groupSize = int32(size)
+	}
+	if groupSize == 1 {
 		return ctrl.Result{}, nil
 	}
 
@@ -313,18 +322,6 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 		return false, nil
 	}
 
-	pendingPods, err := r.pendingPodsInGroup(ctx, pod, int(*leaderWorkerSet.Spec.LeaderWorkerTemplate.Size))
-	if err != nil {
-		return false, err
-	}
-
-	_, hasRecreateGroupAfterStartAnnotation := leaderWorkerSet.Annotations[leaderworkerset.RecreateGroupAfterStartAnnotationKey]
-
-	if pendingPods && (policy == leaderworkerset.RecreateGroupAfterStart || hasRecreateGroupAfterStartAnnotation) {
-		log.V(2).Info(fmt.Sprintf("Skipping group recreation because there is a pod pending: %s", pod.Name))
-		return false, nil
-	}
-
 	var leader corev1.Pod
 	if !podutils.LeaderPod(pod) {
 		// Prefer the annotation over name parsing: with hash identity the leader
@@ -357,6 +354,25 @@ func (r *PodReconciler) handleRestartPolicy(ctx context.Context, pod corev1.Pod,
 		}
 	} else {
 		leader = pod
+	}
+	// A protected old group may have a different size from the live template.
+	// Resolve its leader first, also when the restarting Pod is a worker.
+	groupSize := int(*leaderWorkerSet.Spec.LeaderWorkerTemplate.Size)
+	if stamped, ok := leader.Annotations[leaderworkerset.SizeAnnotationKey]; ok {
+		size, err := strconv.ParseInt(stamped, 10, 32)
+		if err != nil || size < 1 {
+			return false, fmt.Errorf("invalid leader group size %q", stamped)
+		}
+		groupSize = int(size)
+	}
+	pendingPods, err := r.pendingPodsInGroup(ctx, pod, groupSize)
+	if err != nil {
+		return false, err
+	}
+	_, hasRecreateGroupAfterStartAnnotation := leaderWorkerSet.Annotations[leaderworkerset.RecreateGroupAfterStartAnnotationKey]
+	if pendingPods && (policy == leaderworkerset.RecreateGroupAfterStart || hasRecreateGroupAfterStartAnnotation) {
+		log.V(2).Info(fmt.Sprintf("Skipping group recreation because there is a pod pending: %s", pod.Name))
+		return false, nil
 	}
 	// if the leader pod is being deleted, we don't need to send deletion requests
 	if leader.DeletionTimestamp != nil {

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -72,14 +72,10 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, lws *v1.LeaderWork
 
 	if lws.Spec.RolloutStrategy.Type == v1.RollingUpdateStrategyType && lws.Spec.RolloutStrategy.RollingUpdateConfiguration == nil {
 		lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &v1.RollingUpdateConfiguration{
-			UpdateOrder:    v1.ScaleFirstUpdateOrder,
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt32(0),
 			Partition:      ptr.To[int32](0),
 		}
-	}
-	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == "" {
-		lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder = v1.ScaleFirstUpdateOrder
 	}
 
 	if lws.Spec.NetworkConfig == nil {
@@ -192,9 +188,6 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 			// Both MaxSurge and MaxUnavailable cannot be zero.
 			allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "must not be 0 when `maxSurge` is 0"))
 		}
-	}
-	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == v1.RolloutFirstUpdateOrder && maxUnavailableValue == 0 && *lws.Spec.Replicas != 0 {
-		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "must not be 0 when `updateOrder` is RolloutFirst"))
 	}
 
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {

--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -72,10 +72,14 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, lws *v1.LeaderWork
 
 	if lws.Spec.RolloutStrategy.Type == v1.RollingUpdateStrategyType && lws.Spec.RolloutStrategy.RollingUpdateConfiguration == nil {
 		lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &v1.RollingUpdateConfiguration{
+			UpdateOrder:    v1.ScaleFirstUpdateOrder,
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt32(0),
 			Partition:      ptr.To[int32](0),
 		}
+	}
+	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration != nil && lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == "" {
+		lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder = v1.ScaleFirstUpdateOrder
 	}
 
 	if lws.Spec.NetworkConfig == nil {
@@ -188,6 +192,9 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 			// Both MaxSurge and MaxUnavailable cannot be zero.
 			allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "must not be 0 when `maxSurge` is 0"))
 		}
+	}
+	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder == v1.RolloutFirstUpdateOrder && maxUnavailableValue == 0 && *lws.Spec.Replicas != 0 {
+		allErrs = append(allErrs, field.Invalid(maxUnavailablePath, maxUnavailable, "must not be 0 when `updateOrder` is RolloutFirst"))
 	}
 
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {

--- a/site/content/en/docs/concepts/leaderworkerset/rollout-strategy/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/rollout-strategy/_index.md
@@ -3,15 +3,16 @@ title: "Rollout Strategy"
 linkTitle: "Rollout Strategy"
 weight: 60
 description: >
-  Rolling update configurations, maxUnavailable, and maxSurge in LeaderWorkerSet.
+  Rolling update configurations, updateOrder, maxUnavailable, and maxSurge in LeaderWorkerSet.
 aliases:
 - /docs/concepts/rollout-strategy/
 ---
 
 Rolling update is vital to online services requiring high availability and zero downtime. For LLM inference services, this is particularly important to mitigate stockout and maintain serving capacity during updates.
 
-LeaderWorkerSet supports two primary parameters within `.spec.rolloutStrategy.rollingUpdateConfiguration`: `maxUnavailable` and `maxSurge`:
+LeaderWorkerSet supports three primary parameters within `.spec.rolloutStrategy.rollingUpdateConfiguration`: `updateOrder`, `maxUnavailable`, and `maxSurge`:
 
+- `updateOrder`: Controls simultaneous template updates and scale-ups. `ScaleFirst` creates the additional replicas before updating existing replicas and is the default. `RolloutFirst` updates existing replicas before creating additional replicas, which allows old resources to be released in clusters without spare capacity.
 - `maxUnavailable`: Indicates how many replicas (groups of pods) are allowed to be unavailable during the update, based on `spec.replicas`. Defaults to 1.
 - `maxSurge`: Indicates how many extra replicas can be deployed above `spec.replicas` during the update. Defaults to 0.
 
@@ -32,6 +33,7 @@ spec:
   rolloutStrategy:
     type: RollingUpdate
     rollingUpdateConfiguration:
+      updateOrder: ScaleFirst
       maxUnavailable: 2
       maxSurge: 2
   replicas: 4
@@ -64,6 +66,25 @@ Status indicators:
 | **Stage 7** | 0 | 4 | ⏳ | ⏳ | ✅ | ✅ | | | Scaled down to 4 replicas; surge replicas reclaimed |
 | **Stage 8** | 0 | 4 | ⏳ | ✅ | ✅ | ✅ | | | R-1 becomes ready |
 | **Stage 9** | 0 | 4 | ✅ | ✅ | ✅ | ✅ | | | R-0 becomes ready; rolling update complete |
+
+## Update Order
+
+`ScaleFirst` preserves availability during a simultaneous template update and scale-up by creating the additional replicas before updating existing replicas. It requires enough capacity for the old replicas and at least one additional replica to run at the same time.
+
+`RolloutFirst` is intended for capacity-constrained clusters. It holds the current replica count, updates existing replicas according to `maxUnavailable`, waits for them to become ready, and then scales to the desired replica count. For example, changing one replica that requests eight GPUs into two replicas that request four GPUs each requires `RolloutFirst` when only eight GPUs are available:
+
+```yaml
+spec:
+  replicas: 2
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdateConfiguration:
+      updateOrder: RolloutFirst
+      maxUnavailable: 1
+      maxSurge: 0
+```
+
+`RolloutFirst` requires `maxUnavailable` to be greater than zero. It can temporarily reduce availability while existing replicas are replaced.
 
 ## MaxUnavailable Feature Gate
 

--- a/site/content/en/docs/concepts/leaderworkerset/rollout-strategy/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/rollout-strategy/_index.md
@@ -3,16 +3,16 @@ title: "Rollout Strategy"
 linkTitle: "Rollout Strategy"
 weight: 60
 description: >
-  Rolling update configurations, updateOrder, maxUnavailable, and maxSurge in LeaderWorkerSet.
+  Rolling update budgets, partition, maxUnavailable, and maxSurge in LeaderWorkerSet.
 aliases:
 - /docs/concepts/rollout-strategy/
 ---
 
 Rolling update is vital to online services requiring high availability and zero downtime. For LLM inference services, this is particularly important to mitigate stockout and maintain serving capacity during updates.
 
-LeaderWorkerSet supports three primary parameters within `.spec.rolloutStrategy.rollingUpdateConfiguration`: `updateOrder`, `maxUnavailable`, and `maxSurge`:
+LeaderWorkerSet supports three primary parameters within `.spec.rolloutStrategy.rollingUpdateConfiguration`: `partition`, `maxUnavailable`, and `maxSurge`:
 
-- `updateOrder`: Controls simultaneous template updates and scale-ups. `ScaleFirst` creates the additional replicas before updating existing replicas and is the default. `RolloutFirst` updates existing replicas before creating additional replicas, which allows old resources to be released in clusters without spare capacity.
+- `partition`: Protects groups below the specified ordinal from template updates. Defaults to 0.
 - `maxUnavailable`: Indicates how many replicas (groups of pods) are allowed to be unavailable during the update, based on `spec.replicas`. Defaults to 1.
 - `maxSurge`: Indicates how many extra replicas can be deployed above `spec.replicas` during the update. Defaults to 0.
 
@@ -33,7 +33,6 @@ spec:
   rolloutStrategy:
     type: RollingUpdate
     rollingUpdateConfiguration:
-      updateOrder: ScaleFirst
       maxUnavailable: 2
       maxSurge: 2
   replicas: 4
@@ -67,11 +66,17 @@ Status indicators:
 | **Stage 8** | 0 | 4 | ⏳ | ✅ | ✅ | ✅ | | | R-1 becomes ready |
 | **Stage 9** | 0 | 4 | ✅ | ✅ | ✅ | ✅ | | | R-0 becomes ready; rolling update complete |
 
-## Update Order
+## Combined Template Update and Scale-Up
 
-`ScaleFirst` preserves availability during a simultaneous template update and scale-up by creating the additional replicas before updating existing replicas. It requires enough capacity for the old replicas and at least one additional replica to run at the same time.
+When a template update accompanies scale-up, or desired replicas grow during an
+ongoing rollout, the controller uses whole-group availability instead of waiting
+for a continuous Ready suffix. Ordinary scaling and rollouts retain their existing
+behavior when no combined operation is active.
 
-`RolloutFirst` is intended for capacity-constrained clusters. It holds the current replica count, updates existing replicas according to `maxUnavailable`, waits for them to become ready, and then scales to the desired replica count. For example, changing one replica that requests eight GPUs into two replicas that request four GPUs each requires `RolloutFirst` when only eight GPUs are available:
+This changes the default combined-update behavior: with `maxUnavailable: 1`, an
+old group can be replaced while additions remain Pending. One eight-GPU group can
+release resources while changing to two four-GPU groups on an eight-GPU cluster.
+No ordering opt-in is needed:
 
 ```yaml
 spec:
@@ -79,13 +84,33 @@ spec:
   rolloutStrategy:
     type: RollingUpdate
     rollingUpdateConfiguration:
-      updateOrder: RolloutFirst
       maxUnavailable: 1
       maxSurge: 0
 ```
 
-`RolloutFirst` requires `maxUnavailable` to be greater than zero. It can temporarily reduce availability while existing replicas are replaced.
+The controller persists initial non-surge replicas `B` through HPA changes and
+revision supersession. With desired replicas `D` and resolved unavailable budget
+`U`, the floor is `max(0,min(B,D)-U)`. Percentages resolve against `D`: unavailable
+rounds down and surge rounds up. Whole Ready additions provide credit; Pending
+additions do not. Leaders and revision-sized workers must be nonterminating and
+owned by the current group. Outstanding replacements cannot spend credit twice.
+
+With `U=0`, Ready old replacement waits for additional whole-group Ready capacity.
+Surge can provide capacity when desired growth no longer does. Both budgets can
+be positive. The bound concerns controller-authorized disruption based on observed
+health, not independent failures or a strict rollout-first/scale-first order.
+
+The native StatefulSet remains `RollingUpdate`. The controller reserves all stale
+leaders exposed by its partition and can directly delete an authorized lower old
+leader behind an updated Pending ordinal. It conservatively blocks when repairing
+a lower unavailable old group would expose an unaffordable Ready old higher group.
+There is no universal liveness or DaemonSet-style independent selection guarantee.
+Reservation storage is bounded; a full window waits for replacements to recover.
 
 ## MaxUnavailable Feature Gate
 
-`MaxUnavailable` for StatefulSets graduated to Beta in Kubernetes [1.35](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/#maxunavailable-for-statefulsets), meaning it is enabled by default in supported Kubernetes clusters.
+The combined controller does not require the native StatefulSet
+`MaxUnavailableStatefulSet` feature gate. It uses partition fencing and
+preconditioned leader deletion without increasing the supported-cluster requirement.
+Envtest does not run the native StatefulSet controller and is not older-cluster E2E
+validation.

--- a/site/content/en/docs/reference/leaderworkerset.v1.md
+++ b/site/content/en/docs/reference/leaderworkerset.v1.md
@@ -345,18 +345,6 @@ the headless service, defaults to shared</p>
 <tbody>
     
   
-<tr><td><code>updateOrder</code><br/>
-<a href="#leaderworkerset-x-k8s-io-v1-UpdateOrderType"><code>UpdateOrderType</code></a>
-</td>
-<td>
-   <p>updateOrder controls whether existing replicas are updated before scaling up
-when the pod template and replica count increase in the same update.
-ScaleFirst preserves the existing behavior of creating the additional replicas
-before updating existing replicas. RolloutFirst updates existing replicas before
-creating the additional replicas, allowing their old resources to be released.
-The default value is ScaleFirst.</p>
-</td>
-</tr>
 <tr><td><code>partition</code><br/>
 <code>int32</code>
 </td>
@@ -377,7 +365,7 @@ The default value is 0.</p>
 </td>
 <td>
    <p>maxUnavailable is the maximum number of replicas that can be unavailable during the update.
-Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of update (ex: 10%).
+Value can be an absolute number (ex: 5) or a percentage of desired spec.replicas (ex: 10%).
 Absolute number is calculated from percentage by rounding down.
 This can not be 0 if MaxSurge is 0.
 By default, a fixed value of 1 is used.
@@ -385,7 +373,12 @@ Example: when this is set to 30%, the old replicas can be scaled down by 30%
 immediately when the rolling update starts. Once new replicas are ready, old replicas
 can be scaled down further, followed by scaling up the new replicas, ensuring
 that at least 70% of original number of replicas are available at all times
-during the update.</p>
+during the update.
+During combined template updates and scale-up, controller-authorized disruption
+uses a floor of max(0, min(initial non-surge replicas, desired replicas)-maxUnavailable).
+Whole Ready additional groups provide credit; Pending additions do not block
+affordable old-group replacement. This is not a guarantee against independent
+failures or a strict ordering policy. An unaffordable old suffix can block progress.</p>
 </td>
 </tr>
 <tr><td><code>maxSurge</code> <B>[Required]</B><br/>
@@ -395,7 +388,7 @@ during the update.</p>
    <p>maxSurge is the maximum number of replicas that can be scheduled above the original number of
 replicas.
 Value can be an absolute number (ex: 5) or a percentage of total replicas at
-the start of the update (ex: 10%).
+desired spec.replicas (ex: 10%).
 Absolute number is calculated from percentage by rounding up.
 By default, a value of 0 is used.
 Example: when this is set to 30%, the new replicas can be scaled up by 30%
@@ -524,17 +517,6 @@ the extra pod, and will be part of the first subgroup.</p>
 **Appears in:**
 
 - [NetworkConfig](#leaderworkerset-x-k8s-io-v1-NetworkConfig)
-
-
-
-
-  ## `UpdateOrderType`     {#leaderworkerset-x-k8s-io-v1-UpdateOrderType}
-    
-(Alias of `string`)
-
-**Appears in:**
-
-- [RollingUpdateConfiguration](#leaderworkerset-x-k8s-io-v1-RollingUpdateConfiguration)
 
 
 

--- a/site/content/en/docs/reference/leaderworkerset.v1.md
+++ b/site/content/en/docs/reference/leaderworkerset.v1.md
@@ -345,6 +345,18 @@ the headless service, defaults to shared</p>
 <tbody>
     
   
+<tr><td><code>updateOrder</code><br/>
+<a href="#leaderworkerset-x-k8s-io-v1-UpdateOrderType"><code>UpdateOrderType</code></a>
+</td>
+<td>
+   <p>updateOrder controls whether existing replicas are updated before scaling up
+when the pod template and replica count increase in the same update.
+ScaleFirst preserves the existing behavior of creating the additional replicas
+before updating existing replicas. RolloutFirst updates existing replicas before
+creating the additional replicas, allowing their old resources to be released.
+The default value is ScaleFirst.</p>
+</td>
+</tr>
 <tr><td><code>partition</code><br/>
 <code>int32</code>
 </td>
@@ -512,6 +524,17 @@ the extra pod, and will be part of the first subgroup.</p>
 **Appears in:**
 
 - [NetworkConfig](#leaderworkerset-x-k8s-io-v1-NetworkConfig)
+
+
+
+
+  ## `UpdateOrderType`     {#leaderworkerset-x-k8s-io-v1-UpdateOrderType}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [RollingUpdateConfiguration](#leaderworkerset-x-k8s-io-v1-RollingUpdateConfiguration)
 
 
 

--- a/test/integration/controllers/combined_rollout_test.go
+++ b/test/integration/controllers/combined_rollout_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	testing "sigs.k8s.io/lws/test/testutils"
+)
+
+// These growth scenarios run the real asynchronous LWS controller, not
+// kube-controller-manager. Explicitly simulate native acknowledgement, Pod
+// creation, whole-group kubelet readiness and GC. Native failure modes also
+// have separate real-apiserver and exhaustive planner tests in pkg/controllers.
+func testCombinedScaleSurge(lws *leaderworkerset.LeaderWorkerSet, duringUpdate bool) {
+	const annotation = "leaderworkerset.sigs.k8s.io/combined-rollout"
+	key := client.ObjectKeyFromObject(lws)
+	baseline := *lws.Spec.Replicas
+	desired := baseline + 2
+	surge := int32(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge.IntValue())
+	downscale := duringUpdate && surge > 0
+	getSTS := func() *appsv1.StatefulSet {
+		var sts appsv1.StatefulSet
+		gomega.Expect(k8sClient.Get(ctx, key, &sts)).To(gomega.Succeed())
+		return &sts
+	}
+	// Bounded Eventually only acknowledges concrete observed spec generations;
+	// it never fabricates healthy Pods or silently completes a rollout.
+	advance := func(predicate func(*appsv1.StatefulSet) bool) {
+		gomega.Eventually(func() (bool, error) {
+			var sts appsv1.StatefulSet
+			if err := k8sClient.Get(ctx, key, &sts); err != nil {
+				return false, err
+			}
+			native := "native-" + sts.Spec.Template.Labels[leaderworkerset.RevisionKey]
+			if sts.Status.ObservedGeneration < sts.Generation || sts.Status.UpdateRevision != native || sts.Status.Replicas != *sts.Spec.Replicas {
+				sts.Status.ObservedGeneration, sts.Status.UpdateRevision, sts.Status.Replicas = sts.Generation, native, *sts.Spec.Replicas
+				if sts.Status.CurrentRevision == "" {
+					sts.Status.CurrentRevision = native
+				}
+				if err := k8sClient.Status().Update(ctx, &sts); err != nil {
+					return false, err
+				}
+			}
+			return predicate(&sts), nil
+		}, testing.Timeout, testing.Interval).Should(gomega.BeTrue())
+	}
+	change := func(mutate func(*leaderworkerset.LeaderWorkerSet)) {
+		gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var live leaderworkerset.LeaderWorkerSet
+			if err := k8sClient.Get(ctx, key, &live); err != nil {
+				return err
+			}
+			mutate(&live)
+			return k8sClient.Update(ctx, &live)
+		})).To(gomega.Succeed())
+	}
+	ready := func(i int32) {
+		podKey := client.ObjectKey{Namespace: key.Namespace, Name: fmt.Sprintf("%s-%d", key.Name, i)}
+		gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var pod corev1.Pod
+			if err := k8sClient.Get(ctx, podKey, &pod); err != nil {
+				return err
+			}
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+			return k8sClient.Status().Update(ctx, &pod)
+		})).To(gomega.Succeed())
+		if *lws.Spec.LeaderWorkerTemplate.Size > 1 {
+			var workers appsv1.StatefulSet
+			gomega.Eventually(func() error { return k8sClient.Get(ctx, podKey, &workers) }, testing.Timeout, testing.Interval).Should(gomega.Succeed())
+			native := "native-" + workers.Labels[leaderworkerset.RevisionKey]
+			for j := int32(1); j <= *workers.Spec.Replicas; j++ {
+				p := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%d", workers.Name, j), Namespace: key.Namespace,
+					Labels:          map[string]string{leaderworkerset.SetNameLabelKey: key.Name, leaderworkerset.GroupIndexLabelKey: strconv.Itoa(int(i)), leaderworkerset.WorkerIndexLabelKey: strconv.Itoa(int(j)), leaderworkerset.RevisionKey: workers.Labels[leaderworkerset.RevisionKey], appsv1.ControllerRevisionHashLabelKey: native},
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: workers.Name, UID: workers.UID, Controller: ptr.To(true)}}}, Spec: *workers.Spec.Template.Spec.DeepCopy()}
+				gomega.Expect(k8sClient.Create(ctx, p)).To(gomega.Succeed())
+				p.Status.Phase = corev1.PodRunning
+				p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+				gomega.Expect(k8sClient.Status().Update(ctx, p)).To(gomega.Succeed())
+			}
+			gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := k8sClient.Get(ctx, podKey, &workers); err != nil {
+					return err
+				}
+				workers.Status.ObservedGeneration = workers.Generation
+				workers.Status.Replicas, workers.Status.ReadyReplicas, workers.Status.AvailableReplicas = *workers.Spec.Replicas, *workers.Spec.Replicas, *workers.Spec.Replicas
+				workers.Status.CurrentRevision, workers.Status.UpdateRevision = native, native
+				return k8sClient.Status().Update(ctx, &workers)
+			})).To(gomega.Succeed())
+		}
+	}
+	create := func(i int32) {
+		sts := getSTS()
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%d", key.Name, i), Namespace: key.Namespace,
+			Labels:          map[string]string{leaderworkerset.SetNameLabelKey: key.Name, leaderworkerset.GroupIndexLabelKey: strconv.Itoa(int(i)), leaderworkerset.WorkerIndexLabelKey: "0", leaderworkerset.RevisionKey: sts.Spec.Template.Labels[leaderworkerset.RevisionKey], appsv1.ControllerRevisionHashLabelKey: "native-" + sts.Spec.Template.Labels[leaderworkerset.RevisionKey]},
+			Annotations:     map[string]string{leaderworkerset.SizeAnnotationKey: strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size))},
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: sts.Name, UID: sts.UID, Controller: ptr.To(true)}}},
+			Spec: *sts.Spec.Template.Spec.DeepCopy()}
+		gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
+	}
+	remove := func(i int32) {
+		podKey := client.ObjectKey{Namespace: key.Namespace, Name: fmt.Sprintf("%s-%d", key.Name, i)}
+		if *lws.Spec.LeaderWorkerTemplate.Size > 1 {
+			var workers appsv1.StatefulSet
+			err := k8sClient.Get(ctx, podKey, &workers)
+			gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
+			if err == nil {
+				gomega.Expect(k8sClient.Delete(ctx, &workers)).To(gomega.Succeed())
+			}
+			var pods corev1.PodList
+			gomega.Expect(k8sClient.List(ctx, &pods, client.InNamespace(key.Namespace), client.MatchingLabels{leaderworkerset.SetNameLabelKey: key.Name, leaderworkerset.GroupIndexLabelKey: strconv.Itoa(int(i))})).To(gomega.Succeed())
+			for j := range pods.Items {
+				if pods.Items[j].Name != podKey.Name {
+					gomega.Expect(k8sClient.Delete(ctx, &pods.Items[j], client.GracePeriodSeconds(0))).To(gomega.Succeed())
+				}
+			}
+		}
+		gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var pod corev1.Pod
+			if err := k8sClient.Get(ctx, podKey, &pod); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			// envtest lacks GC; release the controller's foreground finalizer.
+			if pod.DeletionTimestamp != nil && len(pod.Finalizers) > 0 {
+				pod.Finalizers = nil
+				if err := k8sClient.Update(ctx, &pod); err != nil {
+					return client.IgnoreNotFound(err)
+				}
+			}
+			return client.IgnoreNotFound(k8sClient.Delete(ctx, &pod, client.GracePeriodSeconds(0)))
+		})).To(gomega.Succeed())
+		gomega.Eventually(func() bool { return apierrors.IsNotFound(k8sClient.Get(ctx, podKey, &corev1.Pod{})) }, testing.Timeout, testing.Interval).Should(gomega.BeTrue())
+	}
+	oldRevision := getSTS().Labels[leaderworkerset.RevisionKey]
+	for i := int32(0); i < baseline; i++ {
+		podKey := client.ObjectKey{Namespace: key.Namespace, Name: fmt.Sprintf("%s-%d", key.Name, i)}
+		var pod corev1.Pod
+		gomega.Expect(k8sClient.Get(ctx, podKey, &pod)).To(gomega.Succeed())
+		pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "native-" + oldRevision
+		gomega.Expect(k8sClient.Update(ctx, &pod)).To(gomega.Succeed())
+		ready(i)
+	}
+	advance(func(*appsv1.StatefulSet) bool { return true })
+	ginkgo.By("publishing growth concurrently with a template update, or during an ordinary surge rollout")
+	change(func(live *leaderworkerset.LeaderWorkerSet) {
+		live.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Image = "test.invalid/combined-update"
+		if !duringUpdate {
+			live.Spec.Replicas = ptr.To(desired)
+		}
+	})
+	if duringUpdate {
+		advance(func(sts *appsv1.StatefulSet) bool {
+			return sts.Labels[leaderworkerset.RevisionKey] != oldRevision && *sts.Spec.Replicas == baseline+surge
+		})
+		for i := baseline; i < baseline+surge; i++ {
+			create(i)
+		}
+		change(func(live *leaderworkerset.LeaderWorkerSet) { live.Spec.Replicas = ptr.To(desired) })
+	}
+	advance(func(sts *appsv1.StatefulSet) bool {
+		var state struct {
+			Phase    string                     `json:"phase"`
+			Baseline int32                      `json:"b"`
+			Pending  map[string]json.RawMessage `json:"pending"`
+		}
+		if json.Unmarshal([]byte(sts.Annotations[annotation]), &state) != nil {
+			return false
+		}
+		return state.Phase == "active" && state.Baseline == baseline && len(state.Pending) == 1 && *sts.Spec.Replicas == desired && *sts.Spec.UpdateStrategy.RollingUpdate.Partition == baseline-1
+	})
+	// Desired additions, rather than an extra surge, supply growth capacity.
+	if !duringUpdate || surge == 0 {
+		for i := baseline; i < desired; i++ {
+			create(i)
+		}
+	}
+	gomega.Expect(*getSTS().Spec.Replicas).To(gomega.Equal(desired))
+	if downscale {
+		ginkgo.By("downscaling with an outstanding old-leader reservation")
+		change(func(live *leaderworkerset.LeaderWorkerSet) { live.Spec.Replicas = ptr.To[int32](2) })
+		advance(func(sts *appsv1.StatefulSet) bool { return *sts.Spec.Replicas == 2 })
+		for i := int32(2); i < desired; i++ {
+			remove(i)
+		}
+		desired = 2
+	} else {
+		for i := baseline; i < desired; i++ {
+			ready(i)
+		}
+	}
+	// Replace only leaders actually selected for deletion, using NEW UIDs.
+	for i := min(baseline, desired) - 1; i >= 0; i-- {
+		podKey := client.ObjectKey{Namespace: key.Namespace, Name: fmt.Sprintf("%s-%d", key.Name, i)}
+		advance(func(*appsv1.StatefulSet) bool {
+			var pod corev1.Pod
+			err := k8sClient.Get(ctx, podKey, &pod)
+			return apierrors.IsNotFound(err) || (err == nil && pod.DeletionTimestamp != nil)
+		})
+		remove(i)
+		create(i)
+		if downscale && i == desired-1 {
+			// Once growth is withdrawn, a Pending replacement can request the
+			// configured surge. Simulate those native additions too; missing
+			// surge Pods must not be mistaken for available capacity.
+			advance(func(sts *appsv1.StatefulSet) bool { return *sts.Spec.Replicas == desired+2 })
+			for extra := desired; extra < desired+2; extra++ {
+				create(extra)
+				ready(extra)
+			}
+		}
+		ready(i)
+	}
+	advance(func(sts *appsv1.StatefulSet) bool {
+		return *sts.Spec.Replicas == desired && *sts.Spec.UpdateStrategy.RollingUpdate.Partition == 0
+	})
+	if downscale {
+		for extra := desired; extra < desired+2; extra++ {
+			remove(extra)
+		}
+	}
+	gomega.Expect(getSTS().Annotations[annotation]).NotTo(gomega.BeEmpty(), "must wait for native currentRevision promotion")
+	gomega.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sts := getSTS()
+		sts.Status.CurrentRevision = sts.Status.UpdateRevision
+		return k8sClient.Status().Update(ctx, sts)
+	})).To(gomega.Succeed())
+	advance(func(sts *appsv1.StatefulSet) bool { return sts.Annotations[annotation] == "" })
+	testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, desired)
+	testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
+}

--- a/test/integration/controllers/combined_rollout_test.go
+++ b/test/integration/controllers/combined_rollout_test.go
@@ -124,6 +124,13 @@ func testCombinedScaleSurge(lws *leaderworkerset.LeaderWorkerSet, duringUpdate b
 			Annotations:     map[string]string{leaderworkerset.SizeAnnotationKey: strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size))},
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "StatefulSet", Name: sts.Name, UID: sts.UID, Controller: ptr.To(true)}}},
 			Spec: *sts.Spec.Template.Spec.DeepCopy()}
+		// envtest runs neither the native StatefulSet controller nor Pod
+		// admission. Supply the DNS identity they assign before workers start.
+		pod.Spec.Hostname = pod.Name
+		pod.Spec.Subdomain = sts.Spec.ServiceName
+		if lws.Spec.NetworkConfig != nil && ptr.Deref(lws.Spec.NetworkConfig.SubdomainPolicy, leaderworkerset.SubdomainShared) == leaderworkerset.SubdomainUniquePerReplica {
+			pod.Spec.Subdomain = pod.Name
+		}
 		gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
 	}
 	remove := func(i int32) {

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -2036,6 +2036,15 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 					// Update size to 4.
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
 						testing.UpdateSize(ctx, k8sClient, lws, 4)
+						// The readiness helper copies the revision from the leader
+						// StatefulSet. Wait for publication, not just the LWS write,
+						// or it can mark old-revision groups Ready and stall the test.
+						gomega.Eventually(func(g gomega.Gomega) {
+							var sts appsv1.StatefulSet
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), &sts)).To(gomega.Succeed())
+							g.Expect(sts.Spec.Template.Annotations[leaderworkerset.SizeAnnotationKey]).To(gomega.Equal("4"))
+							g.Expect(sts.Spec.Template.Labels[leaderworkerset.RevisionKey]).To(gomega.Equal(sts.Labels[leaderworkerset.RevisionKey]))
+						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
 						testing.SetSuperPodToReady(ctx, k8sClient, lws, 2)
 					},
 					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {

--- a/test/integration/controllers/leaderworkerset_test.go
+++ b/test/integration/controllers/leaderworkerset_test.go
@@ -857,153 +857,17 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
 				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
-			updates: []*update{
-				{
-					// Set lws to available condition.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 4)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
-					},
-				},
-				{
-					// Update the worker template and the replicas.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset)).To(gomega.Succeed())
-						leaderworkerset.Spec.Replicas = ptr.To[int32](6)
-						leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Name = "new-worker"
-						gomega.Expect(k8sClient.Update(ctx, &leaderworkerset)).To(gomega.Succeed())
-
-						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						// Manually create leader pods here because we have no statefulset controller.
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 4, 6)).To(gomega.Succeed())
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						// When scaling up the Replicas, Partition will not change, so the new created Pods will apply with the new template.
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 4)
-						// We haven't set the replica-4, replica-5 to ready, so the readyReplicas is 4, the updatedReplicas is 0.
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
-					},
-				},
-				{
-					// Set all groups to ready.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 6)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 6)
-					},
-				},
-			},
+			updates: []*update{{lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+				testCombinedScaleSurge(lws, false)
+			}}},
 		}),
 		ginkgo.Entry("replicas increases during rolling update", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
 				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4)
 			},
-			updates: []*update{
-				{
-					// Set lws to available condition.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 4)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
-					},
-				},
-				{
-					// Update the worker template.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.UpdateWorkerTemplate(ctx, k8sClient, lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
-					},
-				},
-				{
-					// Rolling update index-3 replica.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-3", lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 1)
-					},
-				},
-				{
-					// Update the replicas during rolling update.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						var leaderworkerset leaderworkerset.LeaderWorkerSet
-
-						gomega.Eventually(func() error {
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
-								return err
-							}
-							leaderworkerset.Spec.Replicas = ptr.To[int32](6)
-							return k8sClient.Update(ctx, &leaderworkerset)
-						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
-
-						var leaderSts appsv1.StatefulSet
-						gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: leaderworkerset.Name, Namespace: leaderworkerset.Namespace}, &leaderSts)).To(gomega.Succeed())
-						// Manually create leader pods here because we have no statefulset controller.
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 4, 6)).To(gomega.Succeed())
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-4", lws)
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-5", lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 3)
-					},
-				},
-				{
-					// Set all groups to ready.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 6)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 6)
-					},
-				},
-			},
+			updates: []*update{{lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+				testCombinedScaleSurge(lws, true)
+			}}},
 		}),
 		ginkgo.Entry("replicas decreases during rolling update", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
@@ -1403,69 +1267,12 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 		}),
 		ginkgo.Entry("rolling update with replicas scaled up and maxSurge set", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
-				return wrappers.BuildLeaderWorkerSet(nsName).MaxSurge(2)
+				return wrappers.BuildLeaderWorkerSet(nsName).Size(1).MaxSurge(2)
 			},
 			updates: []*update{
 				{
-					// Set lws to available condition.
 					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 2)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
-					},
-				},
-				{
-					// Update the worker template and replicas.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						gomega.Eventually(func() error {
-							var leaderworkerset leaderworkerset.LeaderWorkerSet
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
-								return err
-							}
-							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Name = "new-worker"
-							leaderworkerset.Spec.Replicas = ptr.To[int32](4)
-							return k8sClient.Update(ctx, &leaderworkerset)
-						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
-
-						var leaderSts appsv1.StatefulSet
-						testing.GetLeaderStatefulset(ctx, lws, k8sClient, &leaderSts)
-						// Create leader pod for maxSurge.
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 2, 6)).To(gomega.Succeed())
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 2)
-					},
-				},
-				{
-					// Set all groups to ready.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 6)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-					},
-				},
-				{
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.DeleteLeaderPods(ctx, k8sClient, lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
+						testCombinedScaleSurge(lws, false)
 					},
 				},
 			},
@@ -1608,160 +1415,11 @@ var _ = ginkgo.Describe("LeaderWorkerSet controller", func() {
 		}),
 		ginkgo.Entry("scale up and down during rolling update with maxSurge set", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {
-				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).MaxSurge(2)
+				return wrappers.BuildLeaderWorkerSet(nsName).Replica(4).Size(1).MaxSurge(2)
 			},
-			updates: []*update{
-				{
-					// Set lws to available condition.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetSuperPodToReady(ctx, k8sClient, lws, 4)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 4)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 4)
-					},
-				},
-				{
-					// Update the worker template.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						gomega.Eventually(func() error {
-							var leaderworkerset leaderworkerset.LeaderWorkerSet
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
-								return err
-							}
-							leaderworkerset.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.Containers[0].Name = "new-worker"
-							return k8sClient.Update(ctx, &leaderworkerset)
-						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
-
-						var leaderSts appsv1.StatefulSet
-						testing.GetLeaderStatefulset(ctx, lws, k8sClient, &leaderSts)
-						// Create leader pod for maxSurge.
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 4, 6)).To(gomega.Succeed())
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 6)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 0)
-					},
-				},
-				{
-					// Scale up during rolling update.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						gomega.Eventually(func() error {
-							var leaderworkerset leaderworkerset.LeaderWorkerSet
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
-								return err
-							}
-							leaderworkerset.Spec.Replicas = ptr.To[int32](6)
-							return k8sClient.Update(ctx, &leaderworkerset)
-						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
-
-						var leaderSts appsv1.StatefulSet
-						testing.GetLeaderStatefulset(ctx, lws, k8sClient, &leaderSts)
-						// Create leader pod for maxSurge.
-						gomega.Expect(testing.CreateLeaderPods(ctx, leaderSts, k8sClient, lws, 6, 8)).To(gomega.Succeed())
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 8)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						// The last 2 replicas are updated but not ready.
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 4, 2)
-					},
-				},
-				{
-					// Rolling update last two replica.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-7", lws)
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-6", lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 8)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 6, 2)
-					},
-				},
-				{
-					// Scale down during rolling update.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						gomega.Eventually(func() error {
-							var leaderworkerset leaderworkerset.LeaderWorkerSet
-							if err := k8sClient.Get(ctx, types.NamespacedName{Name: lws.Name, Namespace: lws.Namespace}, &leaderworkerset); err != nil {
-								return err
-							}
-							leaderworkerset.Spec.Replicas = ptr.To[int32](2)
-							return k8sClient.Update(ctx, &leaderworkerset)
-						}, testing.Timeout, testing.Interval).Should(gomega.Succeed())
-						testing.DeleteLeaderPod(ctx, k8sClient, lws, 4, 8)
-						// Reclaim the last replica.
-						testing.DeleteLeaderPod(ctx, k8sClient, lws, 3, 4)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 1)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 0)
-					},
-				},
-				{
-					// Rolling update index-2 replica.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-2", lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 3)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 3, 1)
-					},
-				},
-				{
-					// Rolling update index-1 replica.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-1", lws)
-						// Reclaim the last replica.
-						testing.DeleteLeaderPod(ctx, k8sClient, lws, 2, 3)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
-						testing.ExpectLeaderWorkerSetUnavailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 1)
-					},
-				},
-				{
-					// Rolling update index-0 replica.
-					lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.SetPodGroupToReady(ctx, k8sClient, lws.Name+"-0", lws)
-					},
-					checkLWSState: func(lws *leaderworkerset.LeaderWorkerSet) {
-						testing.ExpectValidLeaderStatefulSet(ctx, k8sClient, lws, 2)
-						testing.ExpectValidWorkerStatefulSets(ctx, lws, k8sClient, true)
-						testing.ExpectLeaderWorkerSetAvailable(ctx, k8sClient, lws, "All replicas are ready")
-						testing.ExpectLeaderWorkerSetNotProgressing(ctx, k8sClient, lws, "Replicas are progressing")
-						testing.ExpectLeaderWorkerSetNoUpgradeInProgress(ctx, k8sClient, lws, "Rolling Upgrade is in progress")
-						testing.ExpectStatefulsetPartitionEqualTo(ctx, k8sClient, lws, 0)
-						testing.ExpectLeaderWorkerSetStatusReplicas(ctx, k8sClient, lws, 2, 2)
-					},
-				},
-			},
+			updates: []*update{{lwsUpdateFn: func(lws *leaderworkerset.LeaderWorkerSet) {
+				testCombinedScaleSurge(lws, true)
+			}}},
 		}),
 		ginkgo.Entry("multiple rolling update with maxSurge set", &testCase{
 			makeLeaderWorkerSet: func(nsName string) *wrappers.LeaderWorkerSetWrapper {

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -150,6 +150,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return wrappers.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
 					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+						UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 						Partition:      ptr.To[int32](0),
 						MaxUnavailable: intstr.FromInt32(1),
 						MaxSurge:       intstr.FromInt32(0),
@@ -162,6 +163,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+							UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 							Partition:      ptr.To[int32](2),
 							MaxUnavailable: intstr.FromInt32(2),
 							MaxSurge:       intstr.FromInt32(1),
@@ -173,6 +175,7 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+							UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 							Partition:      ptr.To[int32](2),
 							MaxUnavailable: intstr.FromInt32(2),
 							MaxSurge:       intstr.FromInt32(1),
@@ -486,6 +489,16 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return lws
 			},
 			lwsCreationShouldFail: false,
+		}),
+		ginkgo.Entry("set RolloutFirst with maxUnavailable 0 should fail", &testValidationCase{
+			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
+				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder = leaderworkerset.RolloutFirstUpdateOrder
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt32(0)
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt32(1)
+				return lws
+			},
+			lwsCreationShouldFail: true,
 		}),
 		ginkgo.Entry("set replica to 0 no matter maxUnavailable or maxSurge is should be allowed", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {

--- a/test/integration/webhooks/leaderworkerset_test.go
+++ b/test/integration/webhooks/leaderworkerset_test.go
@@ -150,7 +150,6 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 				return wrappers.BuildLeaderWorkerSet(ns.Name).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).RolloutStrategy(leaderworkerset.RolloutStrategy{
 					Type: leaderworkerset.RollingUpdateStrategyType,
 					RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-						UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 						Partition:      ptr.To[int32](0),
 						MaxUnavailable: intstr.FromInt32(1),
 						MaxSurge:       intstr.FromInt32(0),
@@ -163,7 +162,6 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-							UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 							Partition:      ptr.To[int32](2),
 							MaxUnavailable: intstr.FromInt32(2),
 							MaxSurge:       intstr.FromInt32(1),
@@ -175,7 +173,6 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 					RolloutStrategy(leaderworkerset.RolloutStrategy{
 						Type: leaderworkerset.RollingUpdateStrategyType,
 						RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-							UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 							Partition:      ptr.To[int32](2),
 							MaxUnavailable: intstr.FromInt32(2),
 							MaxSurge:       intstr.FromInt32(1),
@@ -490,15 +487,15 @@ var _ = ginkgo.Describe("leaderworkerset defaulting, creation and update", func(
 			},
 			lwsCreationShouldFail: false,
 		}),
-		ginkgo.Entry("set RolloutFirst with maxUnavailable 0 should fail", &testValidationCase{
+		ginkgo.Entry("combined growth accepts zero unavailable with surge", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {
 				lws := wrappers.BuildLeaderWorkerSet(ns.Name)
-				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.UpdateOrder = leaderworkerset.RolloutFirstUpdateOrder
+				lws.Spec.Replicas = ptr.To[int32](3)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxUnavailable = intstr.FromInt32(0)
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge = intstr.FromInt32(1)
 				return lws
 			},
-			lwsCreationShouldFail: true,
+			lwsCreationShouldFail: false,
 		}),
 		ginkgo.Entry("set replica to 0 no matter maxUnavailable or maxSurge is should be allowed", &testValidationCase{
 			makeLeaderWorkerSet: func(ns *corev1.Namespace) *wrappers.LeaderWorkerSetWrapper {

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -243,6 +243,7 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws.Spec.RolloutStrategy = leaderworkerset.RolloutStrategy{
 		Type: leaderworkerset.RollingUpdateStrategyType,
 		RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
+			UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 			Partition:      ptr.To[int32](0),
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt(0),

--- a/test/wrappers/wrappers.go
+++ b/test/wrappers/wrappers.go
@@ -243,7 +243,6 @@ func BuildLeaderWorkerSet(nsName string) *LeaderWorkerSetWrapper {
 	lws.Spec.RolloutStrategy = leaderworkerset.RolloutStrategy{
 		Type: leaderworkerset.RollingUpdateStrategyType,
 		RollingUpdateConfiguration: &leaderworkerset.RollingUpdateConfiguration{
-			UpdateOrder:    leaderworkerset.ScaleFirstUpdateOrder,
 			Partition:      ptr.To[int32](0),
 			MaxUnavailable: intstr.FromInt32(1),
 			MaxSurge:       intstr.FromInt(0),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it

This fixes combined template updates and scale-up getting stuck when the cluster does not have enough spare capacity. For example, replacing one 8-GPU group with two 4-GPU groups fits the same cluster, but creating the additional group before replacing the old one needs extra capacity that may not exist.

The PR now uses the existing `maxUnavailable` and `maxSurge` settings. It removes the proposed `updateOrder` field; there is no new `ScaleFirst` or `RolloutFirst` option.

It follows the same idea as DaemonSet rolling updates: replace an old group when the availability budget allows it, even if an additional group is stuck Pending. For LWS, the leader and all its workers must be Ready before the group counts as available. It is not an exact copy of DaemonSet behavior: LWS keeps StatefulSet RollingUpdate and partition protection.

In practice:

- With `maxUnavailable: 1` and `maxSurge: 0`, an old group can be replaced to free capacity while an additional group is Pending.
- With `maxUnavailable: 0` and `maxSurge: 1`, a healthy old group is kept until enough whole groups are Ready to replace it without dropping below the availability floor. A Ready leader with an unready worker is not enough.
- The controller records replacement reservations before allowing disruption, so repeated reconciliations do not spend the same availability credit twice. Leader deletion uses UID/resourceVersion checks and normal worker garbage collection.

#### Which issue(s) this PR fixes

Fixes #717

Design discussion: #1018. DaemonSet reference: [KEP-1591](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1591-daemonset-surge).

#### Special notes for your reviewer

**This changes the default behavior for combined updates.** The existing default `maxUnavailable: 1` can now allow old-group replacement while additions are Pending. It is not an opt-in ordering setting, and it does not promise that every rollout happens in a fixed order. Ordinary scaling and rollouts outside the combined-update path keep their existing handling.

The availability floor is `max(0, min(initial non-surge replicas, desired replicas) - resolved maxUnavailable)`. The initial baseline is retained across superseding updates. Percentages use the desired replica count, with the existing LWS rounding rules. This bounds controller-authorized disruption, not independent Pod failures.

There is a known partition limitation: updating an unavailable lower ordinal may also expose a healthy higher ordinal to native replacement. If the budget cannot cover that, the controller waits and reports `CombinedRolloutBudgetBlocked`. This does not provide DaemonSet-style independent replacement of any group.

**Validation**

- On the rebased commit `692ab326`, CI unit and verification jobs passed. All eight E2E jobs passed: Kubernetes 1.33 through 1.36, cert-manager, gang scheduling, and both upgrade paths. These are the existing CI suites, not proof of every new combined-rollout edge case.
- On the follow-up commit `365b850`, **integration CI passed: 53 controller specs and 94 webhook specs, with no failures or skips** ([passing run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_lws/996/pull-lws-test-integration-main/2097961912057729024)). The three failures on the previous commit were fixed in the test simulator: supply the leader DNS identity normally assigned by Kubernetes, and wait for the resized template to be published before simulating readiness. No production code or availability assertions were changed. Unit and verification CI also passed on this commit; E2E reruns were still in progress when this note was updated.
- Before the rebase, native AKS 1.35.7 tests passed for constrained-capacity replacement, zero-unavailability protection, whole-group readiness credit, worker cleanup and final convergence. These used size-two groups with 300m CPU per old Pod and 175m per new Pod, constrained to 750m available capacity. They tested the budget-driven implementation, not the earlier ordering prototype.
- Before the rebase, local validation passed 602 unit tests, 23 selected integration tests and Go lint. Those are separate, earlier results; the current full integration result is listed above.
- The additional native restart/partition scenarios remain incomplete. The restart harness checked leadership before lease handoff completed; later observations confirmed reservation preservation, but final convergence and the partition scenario were not completed.

The description has been updated to replace the original ordering proposal. Earlier discussion and test results for that prototype are historical. #1018 remains open for maintainer agreement on the approach.

#### Does this PR introduce a user-facing change?

```release-note
Combined LeaderWorkerSet template updates and scale-up now use the existing maxUnavailable and maxSurge budgets to decide when old groups can be replaced. Pending additions no longer block an affordable replacement, and availability credit requires the leader and all workers to be Ready. With the default maxUnavailable of 1, this can replace old groups earlier than before. No updateOrder field is added; StatefulSet RollingUpdate and partition protection are retained.
```