### PR TITLE
Remove unnecessary pods create permission from controller RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,9 +18,7 @@ rules:
   - ""
   resources:
   - pods
-  - services
   verbs:
-  - create
   - delete
   - get
   - list
@@ -40,6 +38,18 @@ rules:
   verbs:
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -62,7 +62,7 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

Removes the `create` verb from the `pods` RBAC marker in `pkg/controllers/pod_controller.go` and regenerates `config/rbac/role.yaml`. LWS never creates Pods directly — the leader Pod's reconcile creates a worker **StatefulSet**, and Pods for both leader and workers are created by the built-in StatefulSet controller under its own RBAC. LWS only needs `get`, `list`, `watch`, `patch`, `update`, and `delete` on Pods.

Verified no code path creates Pods:
- `grep -rn "\.Create(" pkg/` — every production hit constructs a non-Pod object (StatefulSet, Service, ControllerRevision, PodGroup, DisaggregatedSetRoleScaler, LeaderWorkerSet)
- `grep -rn "&corev1.Pod{" pkg/` — the only non-test Pod construction is a transient in-memory object for a resource-sum calculation, never sent to the API server
- No `CreateOrUpdate`/`CreateOrPatch` usage
- The one production server-side-apply (`leaderworkerset_controller.go:407`) applies a StatefulSet

Background: this permission was already removed once in `a34330a` ("Remove pods create RBAC.", Jan 2025), but by hand-editing the generated YAML and Helm chart without updating the marker. A later `make manifests` in an unrelated PR regenerated `role.yaml` from the stale marker and silently reintroduced `create`. This PR fixes the marker — the source of truth — so regeneration stays correct. The Helm chart needs no change; `charts/lws/templates/rbac/clusterrole.yaml` still reflects the correct state

#### Which issue(s) this PR fixes

Fixes #994

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
