### PR TITLE
Fix RecreateGroupOnPodRestart deletion race

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -61,71 +61,29 @@ type PodReconciler struct {
 	SchedulerProvider schedulerprovider.SchedulerProvider
 }
 
-// podReconcileRequest keeps the identity of a deleted Pod in the workqueue.
-// A StatefulSet can create a replacement with the same namespace and name
-// before reconciliation starts, so a namespaced name alone is insufficient.
+// podReconcileRequest keeps the identity and snapshot of a deleted Pod in the
+// workqueue. A StatefulSet can create a replacement with the same namespace
+// and name before reconciliation starts, so a namespaced name alone is
+// insufficient.
 type podReconcileRequest struct {
 	types.NamespacedName
-	UID             types.UID
-	Deleted         bool
-	LWSName         string
-	WorkerIndex     string
-	GroupIndex      string
-	RevisionKey     string
-	OwnerAPIVersion string
-	OwnerKind       string
-	OwnerName       string
-	OwnerUID        types.UID
+	UID        types.UID
+	DeletedPod *corev1.Pod
 }
 
 func podReconcileRequestForPod(pod *corev1.Pod, deleted bool) podReconcileRequest {
 	request := podReconcileRequest{
 		NamespacedName: client.ObjectKeyFromObject(pod),
 		UID:            pod.UID,
-		Deleted:        deleted,
 	}
-	if !deleted {
-		return request
-	}
-
-	request.LWSName = pod.Labels[leaderworkerset.SetNameLabelKey]
-	request.WorkerIndex = pod.Labels[leaderworkerset.WorkerIndexLabelKey]
-	request.GroupIndex = pod.Labels[leaderworkerset.GroupIndexLabelKey]
-	request.RevisionKey = pod.Labels[leaderworkerset.RevisionKey]
-	if owner := metav1.GetControllerOf(pod); owner != nil {
-		request.OwnerAPIVersion = owner.APIVersion
-		request.OwnerKind = owner.Kind
-		request.OwnerName = owner.Name
-		request.OwnerUID = owner.UID
+	if deleted {
+		request.DeletedPod = pod.DeepCopy()
+		if request.DeletedPod.DeletionTimestamp == nil {
+			deletionTimestamp := metav1.Now()
+			request.DeletedPod.DeletionTimestamp = &deletionTimestamp
+		}
 	}
 	return request
-}
-
-func (r podReconcileRequest) deletedPod() corev1.Pod {
-	deletionTimestamp := metav1.Now()
-	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-		Name:              r.Name,
-		Namespace:         r.Namespace,
-		UID:               r.UID,
-		DeletionTimestamp: &deletionTimestamp,
-		Labels: map[string]string{
-			leaderworkerset.SetNameLabelKey:     r.LWSName,
-			leaderworkerset.WorkerIndexLabelKey: r.WorkerIndex,
-			leaderworkerset.GroupIndexLabelKey:  r.GroupIndex,
-			leaderworkerset.RevisionKey:         r.RevisionKey,
-		},
-	}}
-	if r.OwnerUID != "" {
-		controller := true
-		pod.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: r.OwnerAPIVersion,
-			Kind:       r.OwnerKind,
-			Name:       r.OwnerName,
-			UID:        r.OwnerUID,
-			Controller: &controller,
-		}}
-	}
-	return pod
 }
 
 func NewPodReconciler(client client.Client, schema *runtime.Scheme, record events.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
@@ -138,14 +96,10 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 
-func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.reconcilePod(ctx, podReconcileRequest{NamespacedName: req.NamespacedName})
-}
-
 func (r *PodReconciler) reconcilePod(ctx context.Context, req podReconcileRequest) (ctrl.Result, error) {
 	var pod corev1.Pod
-	if req.Deleted {
-		pod = req.deletedPod()
+	if req.DeletedPod != nil {
+		pod = *req.DeletedPod.DeepCopy()
 	} else if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -33,11 +33,16 @@ import (
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	"sigs.k8s.io/lws/pkg/schedulerprovider"
@@ -56,6 +61,73 @@ type PodReconciler struct {
 	SchedulerProvider schedulerprovider.SchedulerProvider
 }
 
+// podReconcileRequest keeps the identity of a deleted Pod in the workqueue.
+// A StatefulSet can create a replacement with the same namespace and name
+// before reconciliation starts, so a namespaced name alone is insufficient.
+type podReconcileRequest struct {
+	types.NamespacedName
+	UID             types.UID
+	Deleted         bool
+	LWSName         string
+	WorkerIndex     string
+	GroupIndex      string
+	RevisionKey     string
+	OwnerAPIVersion string
+	OwnerKind       string
+	OwnerName       string
+	OwnerUID        types.UID
+}
+
+func podReconcileRequestForPod(pod *corev1.Pod, deleted bool) podReconcileRequest {
+	request := podReconcileRequest{
+		NamespacedName: client.ObjectKeyFromObject(pod),
+		UID:            pod.UID,
+		Deleted:        deleted,
+	}
+	if !deleted {
+		return request
+	}
+
+	request.LWSName = pod.Labels[leaderworkerset.SetNameLabelKey]
+	request.WorkerIndex = pod.Labels[leaderworkerset.WorkerIndexLabelKey]
+	request.GroupIndex = pod.Labels[leaderworkerset.GroupIndexLabelKey]
+	request.RevisionKey = pod.Labels[leaderworkerset.RevisionKey]
+	if owner := metav1.GetControllerOf(pod); owner != nil {
+		request.OwnerAPIVersion = owner.APIVersion
+		request.OwnerKind = owner.Kind
+		request.OwnerName = owner.Name
+		request.OwnerUID = owner.UID
+	}
+	return request
+}
+
+func (r podReconcileRequest) deletedPod() corev1.Pod {
+	deletionTimestamp := metav1.Now()
+	pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:              r.Name,
+		Namespace:         r.Namespace,
+		UID:               r.UID,
+		DeletionTimestamp: &deletionTimestamp,
+		Labels: map[string]string{
+			leaderworkerset.SetNameLabelKey:     r.LWSName,
+			leaderworkerset.WorkerIndexLabelKey: r.WorkerIndex,
+			leaderworkerset.GroupIndexLabelKey:  r.GroupIndex,
+			leaderworkerset.RevisionKey:         r.RevisionKey,
+		},
+	}}
+	if r.OwnerUID != "" {
+		controller := true
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: r.OwnerAPIVersion,
+			Kind:       r.OwnerKind,
+			Name:       r.OwnerName,
+			UID:        r.OwnerUID,
+			Controller: &controller,
+		}}
+	}
+	return pod
+}
+
 func NewPodReconciler(client client.Client, schema *runtime.Scheme, record events.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
 	return &PodReconciler{Client: client, Scheme: schema, Record: record, SchedulerProvider: sp}
 }
@@ -67,8 +139,14 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.reconcilePod(ctx, podReconcileRequest{NamespacedName: req.NamespacedName})
+}
+
+func (r *PodReconciler) reconcilePod(ctx context.Context, req podReconcileRequest) (ctrl.Result, error) {
 	var pod corev1.Pod
-	if err := r.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, &pod); err != nil {
+	if req.Deleted {
+		pod = req.deletedPod()
+	} else if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&pod))
@@ -461,8 +539,10 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 }
 
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}).
+	return builder.TypedControllerManagedBy[podReconcileRequest](mgr).
+		Named("pod").
+		Watches(&corev1.Pod{}, podEventHandler()).
+		Watches(&appsv1.StatefulSet{}, statefulSetEventHandler()).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if pod, ok := object.(*corev1.Pod); ok {
 				_, exist := pod.Labels[leaderworkerset.SetNameLabelKey]
@@ -473,5 +553,47 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return exist
 			}
 			return false
-		})).Owns(&appsv1.StatefulSet{}).Complete(r)
+		})).
+		Complete(reconcile.TypedFunc[podReconcileRequest](r.reconcilePod))
+}
+
+func podEventHandler() handler.TypedEventHandler[client.Object, podReconcileRequest] {
+	enqueue := func(object client.Object, deleted bool, queue workqueue.TypedRateLimitingInterface[podReconcileRequest]) {
+		pod, ok := object.(*corev1.Pod)
+		if !ok || pod == nil {
+			return
+		}
+		queue.Add(podReconcileRequestForPod(pod, deleted))
+	}
+	return handler.TypedFuncs[client.Object, podReconcileRequest]{
+		CreateFunc: func(_ context.Context, event event.TypedCreateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[podReconcileRequest]) {
+			enqueue(event.Object, false, queue)
+		},
+		UpdateFunc: func(_ context.Context, event event.TypedUpdateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[podReconcileRequest]) {
+			enqueue(event.ObjectNew, false, queue)
+		},
+		DeleteFunc: func(_ context.Context, event event.TypedDeleteEvent[client.Object], queue workqueue.TypedRateLimitingInterface[podReconcileRequest]) {
+			enqueue(event.Object, true, queue)
+		},
+		GenericFunc: func(_ context.Context, event event.TypedGenericEvent[client.Object], queue workqueue.TypedRateLimitingInterface[podReconcileRequest]) {
+			enqueue(event.Object, false, queue)
+		},
+	}
+}
+
+func statefulSetEventHandler() handler.TypedEventHandler[client.Object, podReconcileRequest] {
+	return handler.TypedEnqueueRequestsFromMapFunc(func(_ context.Context, object client.Object) []podReconcileRequest {
+		statefulSet, ok := object.(*appsv1.StatefulSet)
+		if !ok || statefulSet == nil {
+			return nil
+		}
+		owner := metav1.GetControllerOf(statefulSet)
+		if owner == nil || owner.APIVersion != corev1.SchemeGroupVersion.String() || owner.Kind != "Pod" {
+			return nil
+		}
+		return []podReconcileRequest{{
+			NamespacedName: types.NamespacedName{Name: owner.Name, Namespace: statefulSet.Namespace},
+			UID:            owner.UID,
+		}}
+	})
 }

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -32,10 +32,12 @@ import (
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	revisionutils "sigs.k8s.io/lws/pkg/utils/revision"
 	"sigs.k8s.io/lws/test/wrappers"
@@ -619,6 +621,175 @@ func TestHandleRestartPolicyUsesCurrentWorkerOwnership(t *testing.T) {
 				t.Fatalf("leader pod should still exist, err = %v", err)
 			}
 		})
+	}
+}
+
+func TestPodEventHandlerKeepsDeletedPodIdentity(t *testing.T) {
+	controller := true
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sample-0-1",
+			Namespace: "default",
+			UID:       "worker-old",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     "test-sample",
+				leaderworkerset.WorkerIndexLabelKey: "1",
+				leaderworkerset.GroupIndexLabelKey:  "0",
+				leaderworkerset.RevisionKey:         "revision-1",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "StatefulSet",
+				Name:       "test-sample-0",
+				UID:        "worker-sts",
+				Controller: &controller,
+			}},
+		},
+	}
+	replacementPod := oldPod.DeepCopy()
+	replacementPod.UID = "worker-replacement"
+
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[podReconcileRequest](),
+	)
+	defer queue.ShutDown()
+
+	handler := podEventHandler()
+	handler.Delete(context.Background(), event.TypedDeleteEvent[client.Object]{Object: oldPod}, queue)
+	handler.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: replacementPod}, queue)
+
+	if got := queue.Len(); got != 2 {
+		t.Fatalf("queue length = %d, want 2 distinct requests", got)
+	}
+
+	requests := make(map[types.UID]podReconcileRequest, 2)
+	for range 2 {
+		request, shutdown := queue.Get()
+		if shutdown {
+			t.Fatal("queue shut down before returning both requests")
+		}
+		requests[request.UID] = request
+		queue.Done(request)
+	}
+
+	wantDeleted := podReconcileRequest{
+		NamespacedName:  types.NamespacedName{Name: oldPod.Name, Namespace: oldPod.Namespace},
+		UID:             oldPod.UID,
+		Deleted:         true,
+		LWSName:         "test-sample",
+		WorkerIndex:     "1",
+		GroupIndex:      "0",
+		RevisionKey:     "revision-1",
+		OwnerAPIVersion: "apps/v1",
+		OwnerKind:       "StatefulSet",
+		OwnerName:       "test-sample-0",
+		OwnerUID:        "worker-sts",
+	}
+	if diff := cmp.Diff(wantDeleted, requests[oldPod.UID]); diff != "" {
+		t.Fatalf("unexpected deleted Pod request (-want,+got):\n%s", diff)
+	}
+	if got := requests[replacementPod.UID]; got.Deleted {
+		t.Fatalf("replacement Pod request is unexpectedly marked deleted: %#v", got)
+	}
+}
+
+func TestStatefulSetEventHandlerEnqueuesControllerPod(t *testing.T) {
+	controller := true
+	statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-sample-0",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       "test-sample-0",
+			UID:        "leader-current",
+			Controller: &controller,
+		}},
+	}}
+	queue := workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[podReconcileRequest](),
+	)
+	defer queue.ShutDown()
+
+	statefulSetEventHandler().Create(
+		context.Background(),
+		event.TypedCreateEvent[client.Object]{Object: statefulSet},
+		queue,
+	)
+
+	request, shutdown := queue.Get()
+	if shutdown {
+		t.Fatal("queue shut down before returning the request")
+	}
+	queue.Done(request)
+	want := podReconcileRequest{
+		NamespacedName: types.NamespacedName{Name: "test-sample-0", Namespace: "default"},
+		UID:            "leader-current",
+	}
+	if diff := cmp.Diff(want, request); diff != "" {
+		t.Fatalf("unexpected StatefulSet owner request (-want,+got):\n%s", diff)
+	}
+}
+
+func TestReconcileDeletedWorkerAfterSameNameReplacement(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").
+		Name("test-sample").
+		Replica(1).
+		Size(2).
+		RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).
+		Obj()
+	revisionKey := "revision-1"
+
+	leaderPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-sample-0",
+		Namespace: lws.Namespace,
+		UID:       "leader-current",
+		Labels: map[string]string{
+			leaderworkerset.SetNameLabelKey:     lws.Name,
+			leaderworkerset.WorkerIndexLabelKey: "0",
+			leaderworkerset.GroupIndexLabelKey:  "0",
+			leaderworkerset.RevisionKey:         revisionKey,
+		},
+	}}
+	workerStatefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+		Name:            leaderPod.Name,
+		Namespace:       leaderPod.Namespace,
+		UID:             "worker-sts-current",
+		OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(leaderPod, corev1.SchemeGroupVersion.WithKind("Pod"))},
+	}}
+	workerLabels := map[string]string{
+		leaderworkerset.SetNameLabelKey:     lws.Name,
+		leaderworkerset.WorkerIndexLabelKey: "1",
+		leaderworkerset.GroupIndexLabelKey:  "0",
+		leaderworkerset.RevisionKey:         revisionKey,
+	}
+	deletedWorker := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:            "test-sample-0-1",
+		Namespace:       lws.Namespace,
+		UID:             "worker-old",
+		Labels:          workerLabels,
+		OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(workerStatefulSet, appsv1.SchemeGroupVersion.WithKind("StatefulSet"))},
+	}}
+	replacementWorker := deletedWorker.DeepCopy()
+	replacementWorker.UID = "worker-replacement"
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = leaderworkerset.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		lws, leaderPod, workerStatefulSet, replacementWorker,
+	).Build()
+	reconciler := PodReconciler{Client: fakeClient, Scheme: scheme, Record: fakeEventRecorder{}}
+
+	if _, err := reconciler.reconcilePod(context.Background(), podReconcileRequestForPod(deletedWorker, true)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var leader corev1.Pod
+	err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(leaderPod), &leader)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("leader Pod still exists after deleted worker replacement, err = %v", err)
 	}
 }
 

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -34,7 +34,6 @@ import (
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -648,6 +647,7 @@ func TestPodEventHandlerKeepsDeletedPodIdentity(t *testing.T) {
 	}
 	replacementPod := oldPod.DeepCopy()
 	replacementPod.UID = "worker-replacement"
+	wantDeletedPod := oldPod.DeepCopy()
 
 	queue := workqueue.NewTypedRateLimitingQueue(
 		workqueue.DefaultTypedControllerRateLimiter[podReconcileRequest](),
@@ -657,6 +657,7 @@ func TestPodEventHandlerKeepsDeletedPodIdentity(t *testing.T) {
 	handler := podEventHandler()
 	handler.Delete(context.Background(), event.TypedDeleteEvent[client.Object]{Object: oldPod}, queue)
 	handler.Create(context.Background(), event.TypedCreateEvent[client.Object]{Object: replacementPod}, queue)
+	oldPod.Labels[leaderworkerset.SetNameLabelKey] = "mutated-after-enqueue"
 
 	if got := queue.Len(); got != 2 {
 		t.Fatalf("queue length = %d, want 2 distinct requests", got)
@@ -672,23 +673,27 @@ func TestPodEventHandlerKeepsDeletedPodIdentity(t *testing.T) {
 		queue.Done(request)
 	}
 
-	wantDeleted := podReconcileRequest{
-		NamespacedName:  types.NamespacedName{Name: oldPod.Name, Namespace: oldPod.Namespace},
-		UID:             oldPod.UID,
-		Deleted:         true,
-		LWSName:         "test-sample",
-		WorkerIndex:     "1",
-		GroupIndex:      "0",
-		RevisionKey:     "revision-1",
-		OwnerAPIVersion: "apps/v1",
-		OwnerKind:       "StatefulSet",
-		OwnerName:       "test-sample-0",
-		OwnerUID:        "worker-sts",
+	gotDeleted := requests[oldPod.UID]
+	if gotDeleted.DeletedPod == nil {
+		t.Fatal("deleted Pod request does not contain a Pod snapshot")
 	}
-	if diff := cmp.Diff(wantDeleted, requests[oldPod.UID]); diff != "" {
+	if gotDeleted.DeletedPod == oldPod {
+		t.Fatal("deleted Pod request contains the informer object instead of a deep copy")
+	}
+	if gotDeleted.DeletedPod.DeletionTimestamp == nil {
+		t.Fatal("deleted Pod snapshot does not have a deletion timestamp")
+	}
+
+	wantDeletedPod.DeletionTimestamp = gotDeleted.DeletedPod.DeletionTimestamp.DeepCopy()
+	wantDeleted := podReconcileRequest{
+		NamespacedName: types.NamespacedName{Name: oldPod.Name, Namespace: oldPod.Namespace},
+		UID:            oldPod.UID,
+		DeletedPod:     wantDeletedPod,
+	}
+	if diff := cmp.Diff(wantDeleted, gotDeleted); diff != "" {
 		t.Fatalf("unexpected deleted Pod request (-want,+got):\n%s", diff)
 	}
-	if got := requests[replacementPod.UID]; got.Deleted {
+	if got := requests[replacementPod.UID]; got.DeletedPod != nil {
 		t.Fatalf("replacement Pod request is unexpectedly marked deleted: %#v", got)
 	}
 }
@@ -829,14 +834,14 @@ func TestReconcileLeaderPodDeletingSkipsHeadlessService(t *testing.T) {
 		Record: fakeEventRecorder{},
 	}
 
-	req := ctrl.Request{
+	req := podReconcileRequest{
 		NamespacedName: types.NamespacedName{
 			Name:      leaderPod.Name,
 			Namespace: leaderPod.Namespace,
 		},
 	}
 
-	res, err := reconciler.Reconcile(context.Background(), req)
+	res, err := reconciler.reconcilePod(context.Background(), req)
 	if err != nil {
 		t.Fatalf("unexpected error during reconcile: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

A worker StatefulSet may recreate a deleted Pod with the same namespace and
name before the Pod controller processes the deletion.

The default controller request only contains the namespaced name. As a result,
the delete and replacement create events may collapse into the same workqueue
key, and reconciliation may read the replacement Pod instead of observing the
deleted Pod. This causes `RecreateGroupOnPodRestart` to be skipped.

This change:

- carries the deleted Pod UID, relevant labels, and controller owner identity
  in a typed reconcile request;
- keeps delete and same-name replacement events as distinct workqueue entries;
- processes deletion metadata without fetching the replacement Pod;
- preserves the existing StatefulSet owner watch behavior;
- preserves the UID-based ownership checks that prevent stale workers from
  deleting a replacement leader.

No API, CRD, or RBAC changes are introduced.

#### Which issue(s) this PR fixes

Fixes #998

#### Special notes for your reviewer

Validation performed:

- `go test ./pkg/controllers -count=1`
- `go vet ./pkg/controllers`
- `go test ./api/... ./pkg/... ./cmd/... -count=1`
- controller and webhook envtest suites: 144/144 specs passed
- focused Kind E2E for `RecreateGroupOnPodRestart`: 5/5 consecutive runs passed

The focused E2E verification confirmed that all original Pod UIDs in the
group were replaced after deleting a worker Pod.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where `RecreateGroupOnPodRestart` could be skipped if a worker StatefulSet recreated a deleted Pod before reconciliation.
```