### PR TITLE
fix: handle pod replacement race in RecreateGroupOnPodRestart

### DIFF
--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -61,7 +61,7 @@ type PodReconciler struct {
 	Record            events.EventRecorder
 	SchedulerProvider schedulerprovider.SchedulerProvider
 	deletedPodsMu     sync.Mutex
-	deletedPods       map[types.NamespacedName][]*corev1.Pod
+	deletedPods       map[types.NamespacedName]*corev1.Pod
 }
 
 func NewPodReconciler(client client.Client, schema *runtime.Scheme, record events.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
@@ -70,8 +70,7 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 		Scheme:            schema,
 		Record:            record,
 		SchedulerProvider: sp,
-		deletedPods:       make(map[types.NamespacedName][]*corev1.Pod),
-	}
+		deletedPods:       make(map[types.NamespacedName]*corev1.Pod)}
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
@@ -80,7 +79,7 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 //+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 
-func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	key := types.NamespacedName{
 		Name:      req.Name,
 		Namespace: req.Namespace,
@@ -88,8 +87,14 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	var pod corev1.Pod
 
-	if deletedPod, ok := r.loadDeletedPod(key); ok {
+	if deletedPod, ok := r.getDeletedPod(key); ok {
 		pod = *deletedPod
+
+		defer func() {
+			if err == nil {
+				r.removeDeletedPod(key)
+			}
+		}()
 	} else {
 		if err := r.Get(ctx, key, &pod); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -539,25 +544,26 @@ func (r *PodReconciler) storeDeletedPod(pod *corev1.Pod) {
 	r.deletedPodsMu.Lock()
 	defer r.deletedPodsMu.Unlock()
 
-	r.deletedPods[key] = append(r.deletedPods[key], pod.DeepCopy())
+	// Keep only the most recent deleted Pod for each key because the
+	// workqueue coalesces requests by key.
+	r.deletedPods[key] = pod.DeepCopy()
 }
 
-func (r *PodReconciler) loadDeletedPod(key types.NamespacedName) (*corev1.Pod, bool) {
+func (r *PodReconciler) getDeletedPod(key types.NamespacedName) (*corev1.Pod, bool) {
 	r.deletedPodsMu.Lock()
 	defer r.deletedPodsMu.Unlock()
 
-	pods := r.deletedPods[key]
-	if len(pods) == 0 {
+	pod, ok := r.deletedPods[key]
+	if !ok {
 		return nil, false
 	}
 
-	pod := pods[0]
+	return pod.DeepCopy(), true
+}
 
-	if len(pods) == 1 {
-		delete(r.deletedPods, key)
-	} else {
-		r.deletedPods[key] = pods[1:]
-	}
+func (r *PodReconciler) removeDeletedPod(key types.NamespacedName) {
+	r.deletedPodsMu.Lock()
+	defer r.deletedPodsMu.Unlock()
 
-	return pod, true
+	delete(r.deletedPods, key)
 }

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,11 +34,16 @@ import (
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	metaapplyv1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	"sigs.k8s.io/lws/pkg/schedulerprovider"
@@ -54,10 +60,18 @@ type PodReconciler struct {
 	Scheme            *runtime.Scheme
 	Record            events.EventRecorder
 	SchedulerProvider schedulerprovider.SchedulerProvider
+	deletedPodsMu     sync.Mutex
+	deletedPods       map[types.NamespacedName][]*corev1.Pod
 }
 
 func NewPodReconciler(client client.Client, schema *runtime.Scheme, record events.EventRecorder, sp schedulerprovider.SchedulerProvider) *PodReconciler {
-	return &PodReconciler{Client: client, Scheme: schema, Record: record, SchedulerProvider: sp}
+	return &PodReconciler{
+		Client:            client,
+		Scheme:            schema,
+		Record:            record,
+		SchedulerProvider: sp,
+		deletedPods:       make(map[types.NamespacedName][]*corev1.Pod),
+	}
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
@@ -67,9 +81,19 @@ func NewPodReconciler(client client.Client, schema *runtime.Scheme, record event
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
 
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	key := types.NamespacedName{
+		Name:      req.Name,
+		Namespace: req.Namespace,
+	}
+
 	var pod corev1.Pod
-	if err := r.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, &pod); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+
+	if deletedPod, ok := r.loadDeletedPod(key); ok {
+		pod = *deletedPod
+	} else {
+		if err := r.Get(ctx, key, &pod); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
 	}
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(&pod))
 	ctx = ctrl.LoggerInto(ctx, log)
@@ -459,19 +483,81 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	}
 	return statefulSetConfig, nil
 }
-
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if pod, ok := object.(*corev1.Pod); ok {
-				_, exist := pod.Labels[leaderworkerset.SetNameLabelKey]
-				return exist
+				_, exists := pod.Labels[leaderworkerset.SetNameLabelKey]
+				return exists
 			}
 			if statefulSet, ok := object.(*appsv1.StatefulSet); ok {
-				_, exist := statefulSet.Labels[leaderworkerset.SetNameLabelKey]
-				return exist
+				_, exists := statefulSet.Labels[leaderworkerset.SetNameLabelKey]
+				return exists
 			}
 			return false
-		})).Owns(&appsv1.StatefulSet{}).Complete(r)
+		})).
+		Owns(&appsv1.StatefulSet{}).
+		Watches(
+			&corev1.Pod{},
+			handler.Funcs{
+				DeleteFunc: func(
+					ctx context.Context,
+					e event.DeleteEvent,
+					q workqueue.TypedRateLimitingInterface[reconcile.Request],
+				) {
+					pod, ok := e.Object.(*corev1.Pod)
+					if !ok {
+						return
+					}
+
+					if _, exists := pod.Labels[leaderworkerset.SetNameLabelKey]; !exists {
+						return
+					}
+
+					key := types.NamespacedName{
+						Name:      pod.Name,
+						Namespace: pod.Namespace,
+					}
+
+					r.storeDeletedPod(pod)
+
+					q.Add(reconcile.Request{
+						NamespacedName: key,
+					})
+				},
+			},
+		).
+		Complete(r)
+}
+func (r *PodReconciler) storeDeletedPod(pod *corev1.Pod) {
+	key := types.NamespacedName{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	r.deletedPodsMu.Lock()
+	defer r.deletedPodsMu.Unlock()
+
+	r.deletedPods[key] = append(r.deletedPods[key], pod.DeepCopy())
+}
+
+func (r *PodReconciler) loadDeletedPod(key types.NamespacedName) (*corev1.Pod, bool) {
+	r.deletedPodsMu.Lock()
+	defer r.deletedPodsMu.Unlock()
+
+	pods := r.deletedPods[key]
+	if len(pods) == 0 {
+		return nil, false
+	}
+
+	pod := pods[0]
+
+	if len(pods) == 1 {
+		delete(r.deletedPods, key)
+	} else {
+		r.deletedPods[key] = pods[1:]
+	}
+
+	return pod, true
 }

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -595,7 +595,7 @@ func TestReconcileUsesDeletedPodWhenReplacementExists(t *testing.T) {
 		Client:      client,
 		Scheme:      scheme,
 		Record:      fakeEventRecorder{},
-		deletedPods: make(map[types.NamespacedName][]*corev1.Pod),
+		deletedPods: make(map[types.NamespacedName]*corev1.Pod),
 	}
 
 	// Simulate the Delete event for the old worker arriving before
@@ -733,9 +733,9 @@ func TestHandleRestartPolicyUsesCurrentWorkerOwnership(t *testing.T) {
 		})
 	}
 }
-func TestDeletedPodQueue(t *testing.T) {
+func TestDeletedPodCache(t *testing.T) {
 	r := &PodReconciler{
-		deletedPods: make(map[types.NamespacedName][]*corev1.Pod),
+		deletedPods: make(map[types.NamespacedName]*corev1.Pod),
 	}
 
 	key := types.NamespacedName{
@@ -762,26 +762,31 @@ func TestDeletedPodQueue(t *testing.T) {
 	r.storeDeletedPod(pod1)
 	r.storeDeletedPod(pod2)
 
-	got, ok := r.loadDeletedPod(key)
+	// The latest deleted Pod replaces the previous one.
+	got, ok := r.getDeletedPod(key)
 	if !ok {
-		t.Fatal("expected first deleted pod")
-	}
-
-	if got.UID != pod1.UID {
-		t.Fatalf("expected first pod UID %q, got %q", pod1.UID, got.UID)
-	}
-
-	got, ok = r.loadDeletedPod(key)
-	if !ok {
-		t.Fatal("expected second deleted pod")
+		t.Fatal("expected deleted pod")
 	}
 
 	if got.UID != pod2.UID {
-		t.Fatalf("expected second pod UID %q, got %q", pod2.UID, got.UID)
+		t.Fatalf("expected latest pod UID %q, got %q", pod2.UID, got.UID)
 	}
 
-	if _, ok := r.loadDeletedPod(key); ok {
-		t.Fatal("expected deleted pod queue to be empty")
+	// Getting the Pod does not consume the cache.
+	got, ok = r.getDeletedPod(key)
+	if !ok {
+		t.Fatal("expected deleted pod to remain cached")
+	}
+
+	if got.UID != pod2.UID {
+		t.Fatalf("expected latest pod UID %q, got %q", pod2.UID, got.UID)
+	}
+
+	// The cache is explicitly removed after successful reconciliation.
+	r.removeDeletedPod(key)
+
+	if _, ok := r.getDeletedPod(key); ok {
+		t.Fatal("expected deleted pod cache to be empty")
 	}
 }
 func TestReconcileLeaderPodDeletingSkipsHeadlessService(t *testing.T) {

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -514,7 +515,118 @@ func TestWorkerStatefulSetApplyConfigPropagatesObjectMeta(t *testing.T) {
 		t.Errorf("unexpected StatefulSet annotations: %s", diff)
 	}
 }
+func TestReconcileUsesDeletedPodWhenReplacementExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, leaderworkerset.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	lws := wrappers.BuildLeaderWorkerSet("default").
+		Replica(1).
+		Size(2).
+		RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).
+		Obj()
 
+	revisionKey := "revision-1"
+
+	leader := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lws.Name + "-0",
+			Namespace: lws.Namespace,
+			UID:       "leader-uid",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     lws.Name,
+				leaderworkerset.WorkerIndexLabelKey: "0",
+				leaderworkerset.GroupIndexLabelKey:  "0",
+				leaderworkerset.RevisionKey:         revisionKey,
+			},
+		},
+	}
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      leader.Name,
+			Namespace: leader.Namespace,
+			UID:       "sts-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(
+					leader,
+					corev1.SchemeGroupVersion.WithKind("Pod"),
+				),
+			},
+		},
+	}
+
+	oldWorker := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      lws.Name + "-0-1",
+			Namespace: lws.Namespace,
+			UID:       "old-worker-uid",
+			Labels: map[string]string{
+				leaderworkerset.SetNameLabelKey:     lws.Name,
+				leaderworkerset.WorkerIndexLabelKey: "1",
+				leaderworkerset.GroupIndexLabelKey:  "0",
+				leaderworkerset.RevisionKey:         revisionKey,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(
+					sts,
+					appsv1.SchemeGroupVersion.WithKind("StatefulSet"),
+				),
+			},
+		},
+	}
+
+	oldWorker = oldWorker.DeepCopy()
+	now := v1.Now()
+	oldWorker.DeletionTimestamp = &now
+
+	// This is the replacement created by the StatefulSet.
+	// It has the same name but a different UID.
+	replacementWorker := oldWorker.DeepCopy()
+	replacementWorker.UID = "new-worker-uid"
+	replacementWorker.DeletionTimestamp = nil
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(lws, leader, sts, replacementWorker).
+		Build()
+
+	r := &PodReconciler{
+		Client:      client,
+		Scheme:      scheme,
+		Record:      fakeEventRecorder{},
+		deletedPods: make(map[types.NamespacedName][]*corev1.Pod),
+	}
+
+	// Simulate the Delete event for the old worker arriving before
+	// reconciliation, while the StatefulSet has already created
+	// the replacement Pod.
+	r.storeDeletedPod(oldWorker)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      oldWorker.Name,
+			Namespace: oldWorker.Namespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var gotLeader corev1.Pod
+	err = client.Get(
+		context.Background(),
+		types.NamespacedName{
+			Name:      leader.Name,
+			Namespace: leader.Namespace,
+		},
+		&gotLeader,
+	)
+
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected leader pod to be deleted, got err = %v", err)
+	}
+}
 func TestHandleRestartPolicyUsesCurrentWorkerOwnership(t *testing.T) {
 	lws := wrappers.BuildLeaderWorkerSet("default").Replica(1).Size(2).RestartPolicy(leaderworkerset.RecreateGroupOnPodRestart).Obj()
 	revisionKey := "revision-1"
@@ -621,7 +733,57 @@ func TestHandleRestartPolicyUsesCurrentWorkerOwnership(t *testing.T) {
 		})
 	}
 }
+func TestDeletedPodQueue(t *testing.T) {
+	r := &PodReconciler{
+		deletedPods: make(map[types.NamespacedName][]*corev1.Pod),
+	}
 
+	key := types.NamespacedName{
+		Namespace: "default",
+		Name:      "lws-0-2",
+	}
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lws-0-2",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+	}
+
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lws-0-2",
+			Namespace: "default",
+			UID:       "uid-2",
+		},
+	}
+
+	r.storeDeletedPod(pod1)
+	r.storeDeletedPod(pod2)
+
+	got, ok := r.loadDeletedPod(key)
+	if !ok {
+		t.Fatal("expected first deleted pod")
+	}
+
+	if got.UID != pod1.UID {
+		t.Fatalf("expected first pod UID %q, got %q", pod1.UID, got.UID)
+	}
+
+	got, ok = r.loadDeletedPod(key)
+	if !ok {
+		t.Fatal("expected second deleted pod")
+	}
+
+	if got.UID != pod2.UID {
+		t.Fatalf("expected second pod UID %q, got %q", pod2.UID, got.UID)
+	}
+
+	if _, ok := r.loadDeletedPod(key); ok {
+		t.Fatal("expected deleted pod queue to be empty")
+	}
+}
 func TestReconcileLeaderPodDeletingSkipsHeadlessService(t *testing.T) {
 	subdomainPolicy := leaderworkerset.SubdomainUniquePerReplica
 	lws := wrappers.BuildLeaderWorkerSet("default").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fix a race where `RecreateGroupOnPodRestart` can miss a deleted worker Pod when the StatefulSet quickly recreates it with the same name.

#### Which issue(s) this PR fixes

Fixes #998

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE