### PR TITLE
Add leader/worker role label to managed StatefulSets

### DIFF
--- a/api/leaderworkerset/v1/leaderworkerset_types.go
+++ b/api/leaderworkerset/v1/leaderworkerset_types.go
@@ -44,6 +44,13 @@ const (
 	// the index/identity of the pod in the group.
 	WorkerIndexLabelKey string = "leaderworkerset.sigs.k8s.io/worker-index"
 
+	// Role label records whether a managed StatefulSet/Pod is the leader or a
+	// worker, so it can be selected directly instead of inferred from other
+	// labels. Values are RoleLeader or RoleWorker.
+	RoleLabelKey string = "leaderworkerset.sigs.k8s.io/role"
+	RoleLeader   string = "leader"
+	RoleWorker   string = "worker"
+
 	// Size will be added to pods as an annotation which corresponds to
 	// LeaderWorkerSet.Spec.LeaderWorkerTemplate.Size.
 	SizeAnnotationKey string = "leaderworkerset.sigs.k8s.io/size"

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -794,6 +794,7 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 		leaderworkerset.WorkerIndexLabelKey: "0",
 		leaderworkerset.SetNameLabelKey:     lws.Name,
 		leaderworkerset.RevisionKey:         revisionKey,
+		leaderworkerset.RoleLabelKey:        leaderworkerset.RoleLeader,
 	})
 	podAnnotations := make(map[string]string)
 	podAnnotations[leaderworkerset.SizeAnnotationKey] = strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size))
@@ -839,6 +840,7 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 	statefulSetLabels := mergeMetadata(lws.Labels, map[string]string{
 		leaderworkerset.SetNameLabelKey: lws.Name,
 		leaderworkerset.RevisionKey:     revisionKey,
+		leaderworkerset.RoleLabelKey:    leaderworkerset.RoleLeader,
 	})
 	statefulSetAnnotations := mergeMetadata(lws.Annotations, map[string]string{
 		leaderworkerset.ReplicasAnnotationKey: strconv.Itoa(int(*lws.Spec.Replicas)),

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -100,6 +100,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
 				},
@@ -117,6 +118,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -168,6 +170,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
@@ -188,6 +191,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -240,6 +244,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
@@ -260,6 +265,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -310,6 +316,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
 				},
@@ -327,6 +334,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -377,6 +385,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
 				},
@@ -394,6 +403,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -447,6 +457,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/replicas":                    "1",
@@ -467,6 +478,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":                "2",
@@ -539,6 +551,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "1"},
 				},
@@ -556,6 +569,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -635,6 +649,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "0"},
 				},
@@ -652,6 +667,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -706,6 +722,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 					Labels: map[string]string{
 						"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 						"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+						"leaderworkerset.sigs.k8s.io/role":                   "leader",
 					},
 					Annotations: map[string]string{"leaderworkerset.sigs.k8s.io/replicas": "2"},
 				},
@@ -723,6 +740,7 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
+								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -799,6 +817,7 @@ func TestLeaderStatefulSetApplyConfigPropagatesObjectMeta(t *testing.T) {
 		"app":                           "inference",
 		leaderworkerset.SetNameLabelKey: "test-sample",
 		leaderworkerset.RevisionKey:     "revision-1",
+		leaderworkerset.RoleLabelKey:    leaderworkerset.RoleLeader,
 	}
 	if diff := cmp.Diff(wantLabels, stsApplyConfig.Labels); diff != "" {
 		t.Errorf("unexpected StatefulSet labels: %s", diff)

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -404,6 +404,7 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		leaderworkerset.SetNameLabelKey:         lws.Name,
 		leaderworkerset.GroupUniqueHashLabelKey: leaderPod.Labels[leaderworkerset.GroupUniqueHashLabelKey],
 		leaderworkerset.RevisionKey:             revisionutils.GetRevisionKey(&leaderPod),
+		leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 	}
 
 	podTemplateApplyConfiguration.WithLabels(labelMap)

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -89,6 +89,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupIndexLabelKey:      "1",
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
+						leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
@@ -107,6 +108,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
+								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":        "1",
@@ -164,6 +166,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupIndexLabelKey:      "1",
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
+						leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 					},
 					Annotations: map[string]string{
 						"leaderworkerset.sigs.k8s.io/exclusive-topology": "topologyKey",
@@ -185,6 +188,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
+								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -242,6 +246,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.SetNameLabelKey:         "test-sample",
 						leaderworkerset.GroupIndexLabelKey:      "1",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
+						leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 					},
 					Annotations: map[string]string{
@@ -263,6 +268,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.SetNameLabelKey:         "test-sample",
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
+								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 							},
 							Annotations: map[string]string{
@@ -343,6 +349,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 						leaderworkerset.GroupIndexLabelKey:      "1",
 						leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 						leaderworkerset.RevisionKey:             updateRevisionKey,
+						leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 					},
 				},
 				Spec: &appsapplyv1.StatefulSetSpecApplyConfiguration{
@@ -361,6 +368,7 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
+								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":        "1",
@@ -504,6 +512,7 @@ func TestWorkerStatefulSetApplyConfigPropagatesObjectMeta(t *testing.T) {
 		leaderworkerset.GroupIndexLabelKey:      "1",
 		leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 		leaderworkerset.RevisionKey:             revisionKey,
+		leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 	}
 	if diff := cmp.Diff(wantLabels, statefulSetConfig.Labels); diff != "" {
 		t.Errorf("unexpected StatefulSet labels: %s", diff)

--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -187,6 +187,7 @@ func ExpectValidLeaderStatefulSet(ctx context.Context, k8sClient client.Client, 
 			leaderworkerset.SetNameLabelKey:     lws.Name,
 			leaderworkerset.WorkerIndexLabelKey: "0",
 			leaderworkerset.RevisionKey:         hash,
+			leaderworkerset.RoleLabelKey:        leaderworkerset.RoleLeader,
 		}); diff != "" {
 			return errors.New("leader StatefulSet pod template doesn't have the correct labels: " + diff)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Today there is no direct way to tell a leader StatefulSet apart from a worker StatefulSet. You end up inferring it from other labels, since worker StatefulSets happen to carry a group index label and leaders do not. That is fragile and undocumented.

This adds a `leaderworkerset.sigs.k8s.io/role` label with the value `leader` or `worker` on the managed StatefulSets and their pod templates, so users, custom controllers, and operational scripts can select on the role directly. For example `kubectl get sts -l leaderworkerset.sigs.k8s.io/role=leader`.

It is controller applied metadata, set alongside the labels the controller already stamps such as name and template revision hash, so there is no API, CRD, or webhook change involved.

#### Which issue(s) this PR fixes

fix #942


#### Special notes for your reviewer

The label is added in the two places the StatefulSet labels are built, one for the leader in `leaderworkerset_controller.go` and one for the worker in `pod_controller.go`, plus their pod templates for symmetry. The selectors are intentionally left untouched. Existing unit tests were updated to expect the new label and all pass.

Happy to follow up with a docs note, and to extend the label to pods and Services, once the key and scope are agreed.

#### Does this PR introduce a user-facing change?

```release-note
Add a `leaderworkerset.sigs.k8s.io/role` label (`leader` or `worker`) to the StatefulSets and pod templates managed by a LeaderWorkerSet, so the role can be selected directly instead of inferred from other labels.
```
