### PR TITLE
Add Helm-based upgrade E2E test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ INTEGRATION_TARGET ?= ./test/integration/...
 E2E_KIND_VERSION ?= kindest/node:v1.36.1
 CERT_MANAGER_VERSION ?= v1.17.0
 USE_EXISTING_CLUSTER ?= false
-LWS_UPGRADE_FROM_VERSION ?= v0.9.0
+# Newest released tag to upgrade from; falls back to v0.9.0 on shallow clones
+# without tags. Override to pin a specific version.
+LWS_UPGRADE_FROM_VERSION ?= $(shell git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1 | grep . || echo v0.9.0)
 UPGRADE_KIND_CLUSTER_NAME ?= lws-upgrade
 
 # For local testing, we should allow user to use different kind cluster name
@@ -179,11 +181,15 @@ test-e2e: kustomize manifests fmt vet envtest ginkgo kind-image-build
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 .PHONY: test-e2e-upgrade
-test-e2e-upgrade: test-e2e-upgrade-manifests
+test-e2e-upgrade: test-e2e-upgrade-manifests test-e2e-upgrade-helm
 
 .PHONY: test-e2e-upgrade-manifests
 test-e2e-upgrade-manifests: kustomize manifests fmt vet ginkgo kind-image-build
 	LWS_UPGRADE_FROM_VERSION=$(LWS_UPGRADE_FROM_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(UPGRADE_KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) USE_EXISTING_CLUSTER=false IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
+
+.PHONY: test-e2e-upgrade-helm
+test-e2e-upgrade-helm: kustomize manifests fmt vet ginkgo helm kind-image-build
+	LWS_UPGRADE_METHOD=helm LWS_UPGRADE_FROM_VERSION=$(LWS_UPGRADE_FROM_VERSION) E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(UPGRADE_KIND_CLUSTER_NAME) KIND=$(KIND) KUBECTL=$(KUBECTL) KUSTOMIZE=$(KUSTOMIZE) GINKGO=$(GINKGO) HELM=$(HELM) USE_EXISTING_CLUSTER=false IMAGE_TAG=$(IMG) ARTIFACTS=$(ARTIFACTS) ./hack/e2e-test.sh
 
 .PHONY: test-e2e-cert-manager
 test-e2e-cert-manager: kustomize manifests fmt vet envtest ginkgo kind-image-build

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -20,6 +20,12 @@ set -o pipefail
 
 SCHEDULER_PROVIDER=${SCHEDULER_PROVIDER:-""}
 LWS_UPGRADE_FROM_VERSION=${LWS_UPGRADE_FROM_VERSION:-""}
+# LWS_UPGRADE_METHOD selects how the old release is installed and upgraded:
+# "manifests" (default, kustomize) or "helm".
+LWS_UPGRADE_METHOD=${LWS_UPGRADE_METHOD:-"manifests"}
+HELM=${HELM:-"./bin/helm"}
+HELM_CHART_REPO=${HELM_CHART_REPO:-"registry.k8s.io/lws/charts"}
+HELM_RELEASE_NAME=${HELM_RELEASE_NAME:-"lws"}
 LWS_NAMESPACE=${LWS_NAMESPACE:-"lws-system"}
 export CWD=$(pwd)
 
@@ -159,6 +165,40 @@ function install_old_release {
         -n "$LWS_NAMESPACE" --timeout=5m
 }
 
+function install_old_release_helm {
+    # Install the previous released chart from the OCI registry. The old chart
+    # pins its controller image to the release tag with pullPolicy IfNotPresent,
+    # and that image is already loaded into kind by kind_load, so nothing is
+    # pulled from inside the cluster.
+    $HELM install "$HELM_RELEASE_NAME" "oci://${HELM_CHART_REPO}/lws" \
+        --version "$LWS_UPGRADE_FROM_VERSION" \
+        --namespace "$LWS_NAMESPACE" --create-namespace \
+        --set enableDisaggregatedSet=true \
+        --wait --timeout 5m
+    $KUBECTL rollout status deployment/lws-controller-manager \
+        -n "$LWS_NAMESPACE" --timeout=5m
+}
+
+function upgrade_to_current_helm {
+    # Follow the documented Helm upgrade procedure: reconcile CRDs explicitly
+    # (helm upgrade never touches crds/), then upgrade the release in place with
+    # the locally built, kind-loaded controller image.
+    $KUBECTL apply --server-side --force-conflicts -f "$CWD/charts/lws/crds"
+
+    local image_repo="${IMAGE_TAG%:*}"
+    local image_tag="${IMAGE_TAG##*:}"
+
+    $HELM upgrade "$HELM_RELEASE_NAME" "$CWD/charts/lws" \
+        --namespace "$LWS_NAMESPACE" \
+        --set image.manager.repository="$image_repo" \
+        --set image.manager.tag="$image_tag" \
+        --set image.manager.pullPolicy=IfNotPresent \
+        --set enableDisaggregatedSet=true \
+        --wait --timeout 5m
+    $KUBECTL rollout status deployment/lws-controller-manager \
+        -n "$LWS_NAMESPACE" --timeout=5m
+}
+
 function run_upgrade_phase {
     local phase="$1"
     LWS_UPGRADE_PHASE="$phase" \
@@ -194,11 +234,18 @@ function upgrade_to_current {
 }
 
 function upgrade_test_flow {
-    echo "Upgrade test: $LWS_UPGRADE_FROM_VERSION -> current"
-    install_old_release
-    run_upgrade_phase before
-    save_controller_logs "$ARTIFACTS/old-controller.log"
-    upgrade_to_current
+    echo "Upgrade test ($LWS_UPGRADE_METHOD): $LWS_UPGRADE_FROM_VERSION -> current"
+    if [ "$LWS_UPGRADE_METHOD" == "helm" ]; then
+        install_old_release_helm
+        run_upgrade_phase before
+        save_controller_logs "$ARTIFACTS/old-controller.log"
+        upgrade_to_current_helm
+    else
+        install_old_release
+        run_upgrade_phase before
+        save_controller_logs "$ARTIFACTS/old-controller.log"
+        upgrade_to_current
+    fi
 }
 
 function lws_deploy {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind failing-test

#### What this PR does / why we need it

We have hit Helm upgrade regressions before (#529, #880), but the upgrade E2E from #928 only covers the kustomize path. Helm behaves differently on upgrade, most importantly it never touches the `crds/` directory, so CRDs have to be reconciled by hand first. Nothing tests that today.

This adds a Kind based Helm upgrade test. It installs the previous released chart, creates LeaderWorkerSet and DisaggregatedSet workloads, applies the current CRDs the way the docs tell users to, runs helm upgrade in place with the freshly built image, and then checks that the release, controller and webhooks are healthy, the old workloads survived, and new ones still come up.

There is no new Go test. The existing phase driven upgrade test only talks to the cluster through the client, so the same before and after phases work for Helm too. Everything Helm specific lives in the shell script.

The changes:

1. `hack/e2e-test.sh` gets a helm branch behind `LWS_UPGRADE_METHOD=helm`. It installs the old chart from the OCI registry and, on upgrade, applies `charts/lws/crds` before running helm upgrade. The manifests path is untouched.
2. A new `test-e2e-upgrade-helm` make target, folded into `test-e2e-upgrade`.
3. `LWS_UPGRADE_FROM_VERSION` now defaults to the newest released git tag instead of a hardcoded value, so both upgrade tests track releases on their own. Still overridable.

#### Which issue(s) this PR fixes

Fix #962

#### Special notes for your reviewer

The Prow presubmit is not in this repo. The plan is a job running `make test-e2e-upgrade-helm` scoped to changes under `charts/`. Happy to open the test-infra PR once this looks right.

I left the v0.7 to v0.8 CRD move case (the one behind #880) out on purpose. It needs the extra resource policy annotation step, so it fits better as a second entry in the matrix later rather than bloating this one.

Validated as far as a cluster free run allows: `bash -n` passes, the make target parses, `helm show chart` confirms the old chart resolves from the registry, and `helm template` confirms the image split and the DisaggregatedSet webhook render correctly.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
