### PR TITLE
Use LWS ownership for DisaggregatedSet Services

### DIFF
--- a/keps/766-DisaggregatedSet/README.md
+++ b/keps/766-DisaggregatedSet/README.md
@@ -303,7 +303,7 @@ Headless Services are automatically created for each role per revision. This all
 
 - **Naming**: `{disaggregatedset-name}-{revision}-{role}-prv` (e.g., `my-llm-abc12345-prefill-prv`)
 - **Selector**: Selects pods from the specific revision's LeaderWorkerSet for that role
-- **Cleanup**: Managed via owner references and garbage collected with the DisaggregatedSet
+- **Cleanup**: Owned by the corresponding LeaderWorkerSet and garbage collected with it
 
 ### Controller Architecture
 

--- a/keps/846-disaggregatedset-slices/README.md
+++ b/keps/846-disaggregatedset-slices/README.md
@@ -159,7 +159,7 @@ Services remain per `(slice, revision, role)`, named `<ds>-<slice>-<revision>-<r
 
 ### Scale-Down
 
-Decreasing `slices` from M to N directly deletes the LWS and Services whose slice index is `>= N`. Their pods terminate via the normal pod grace period; no controller-orchestrated drain is performed.
+Decreasing `slices` from M to N directly deletes the LWS whose slice index is `>= N`. Their Services are owned by those LWS objects and are garbage collected with them. Their pods terminate via the normal pod grace period; no controller-orchestrated drain is performed.
 
 This is intentional and differs from revision teardown. The existing multi-phase drain exists to preserve the cross-role, same-version invariant *within* a slice during a rollout. Slice removal has no cross-slice invariant to protect (slices are independent), so it is a plain scale operation, mirroring how reducing a role's `replicas` removes the highest-ordinal groups directly.
 
@@ -169,9 +169,9 @@ DisaggregatedSet shipped before this feature, so clusters already run Disaggrega
 
 **Adoption.** Per-slice listing buckets any LWS with no slice label into slice 0, so a legacy LWS is reconciled as slice 0 under its existing name and its existing Service keeps serving it. Every LWS created from now on uses the slice-aware name, including the `-0-` segment for slice 0. A plain upgrade with no spec change recreates nothing.
 
-**Migration on the next rollout.** A template change creates the new revision's slice-0 LWS in slice-aware form while the legacy LWS drains through the normal rolling update. The two are at different revisions and Services are revision-scoped, so they never select each other's pods, and the legacy Service is deleted when the old revision drains.
+**Migration on the next rollout.** A template change creates the new revision's slice-0 LWS in slice-aware form while the legacy LWS drains through the normal rolling update. The two are at different revisions and Services are revision-scoped, so they never select each other's pods, and the legacy Service is garbage collected when the old LWS is deleted after draining.
 
-**Migration when `slices` increases above 1.** Here no new revision is created, and the legacy slice-0 Service is revision-scoped but slice-agnostic, so it would also select the new sibling slices' pods. For example, with legacy slice 0 at revision `r`, a `slice 1` created at the same `r` is matched by the legacy `{set, role, revision: r}` selector because the new `{set, slice: 1, role, revision: r}` pod is a superset of it. To prevent this, before creating any sibling the controller deletes the legacy slice-0 objects (its slice-agnostic Service first, then its LWS), and the normal reconcile recreates slice 0 in slice-aware form alongside the siblings. This restarts slice 0 once, which is accepted in place of an in-place migration. Because the Service is deleted before the LWS and before any sibling exists, the slice-agnostic Service never coexists with sibling pods, so no blocking is needed.
+**Migration when `slices` increases above 1.** Here no new revision is created, and the legacy slice-0 Service is revision-scoped but slice-agnostic, so it would also select the new sibling slices' pods. For example, with legacy slice 0 at revision `r`, a `slice 1` created at the same `r` is matched by the legacy `{set, role, revision: r}` selector because the new `{set, slice: 1, role, revision: r}` pod is a superset of it. To prevent this, before creating any sibling the controller transfers the legacy Service ownership to its LWS, deletes that LWS, and waits for Kubernetes GC to remove the Service. The normal reconcile then recreates slice 0 in slice-aware form alongside the siblings. This restarts slice 0 once, which is accepted in place of an in-place migration. The wait ensures that the slice-agnostic Service never coexists with sibling pods.
 
 ### Object Cardinality
 
@@ -190,8 +190,8 @@ During a rollout, a slice that is mid-transition holds two revisions at once (ol
 #### Unit tests
 
 - Name/label helpers: slice segment in names, slice label emitted.
-- Controller: fan-out creates `slices x roles` LWS with correct slice labels; slice scale-down deletes only the removed slices' LWS and Services and leaves lower slices intact.
-- Service manager: per-slice Service naming, labels, and selector; per-slice drained cleanup.
+- Controller: fan-out creates `slices x roles` LWS with correct slice labels; slice scale-down deletes only the removed slices' LWS and leaves lower slices intact; legacy slice-0 migration waits for Service GC before creating siblings.
+- Service manager: per-slice Service naming, labels, selector, and LeaderWorkerSet ownership.
 - Executor: slice is threaded through rolling-update calls; the planner is exercised per slice (existing planner tests are unchanged).
 
 #### Integration tests

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,6 +48,11 @@ type DisaggregatedSetReconciler struct {
 	ScalerManager  *ScalerManager
 }
 
+// legacyServiceGCRequeue paces the retries while a legacy Service is being garbage
+// collected. A finalizer on that Service blocks slice creation for as long as it is
+// held, so this must not turn into a per-second busy loop.
+const legacyServiceGCRequeue = 5 * time.Second
+
 // +kubebuilder:rbac:groups=disaggregatedset.x-k8s.io,resources=disaggregatedsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=disaggregatedset.x-k8s.io,resources=disaggregatedsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=disaggregatedset.x-k8s.io,resources=disaggregatedsets/finalizers,verbs=update
@@ -54,6 +60,8 @@ type DisaggregatedSetReconciler struct {
 // +kubebuilder:rbac:groups=disaggregatedset.x-k8s.io,resources=disaggregatedsetrolescalers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/status,verbs=get
+// Needed to set blockOwnerDeletion on the Services this controller hands to a LeaderWorkerSet.
+// +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
@@ -81,9 +89,23 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
 	sliceCount := int(disaggregatedsetutils.GetSlices(disaggregatedSet))
 
-	// Step 2: Delete LWS/services for slices beyond the desired count (slice
-	// scale-down). Per-revision drained cleanup runs per slice in reconcileSlice.
-	if err := r.cleanupRemovedSlices(ctx, disaggregatedSet, sliceCount); err != nil {
+	// One listing feeds both steps below; the migration only patches Services, so
+	// the slice scale-down still sees an accurate view of the LWS objects.
+	allLWS, err := r.LWSManager.List(ctx, disaggregatedSet, -1, "")
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Migrate Services created by older controllers before any LWS deletion, so
+	// foreground deletion garbage-collects them instead of leaving DS-owned orphans.
+	if err := r.ServiceManager.migrateLegacyServices(ctx, disaggregatedSet, allLWS); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Step 2: Delete LWS for slices beyond the desired count (slice scale-down).
+	// Their Services are garbage-collected through the LWS owner reference.
+	// Per-revision drained cleanup runs per slice in reconcileSlice.
+	if err := r.cleanupRemovedSlices(ctx, disaggregatedSet, allLWS, sliceCount); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -114,13 +136,21 @@ func (r *DisaggregatedSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// and recreate an existing deployment. When slices > 1, the pre-slices (label-less)
 	// slice-0 still at the target revision must become slice-aware before any sibling
 	// slice is created, otherwise its slice-agnostic service would also select the
-	// siblings' same-revision pods. Delete the legacy slice-0 objects here (service
-	// first); the slice loop below then recreates slice 0 in slice-aware form. Running
-	// before the loop, and returning on error, keeps the legacy service from ever
-	// coexisting with sibling slices.
+	// siblings' same-revision pods. Delete the legacy slice-0 LWS objects here and
+	// wait for their Services to be garbage-collected before the slice loop recreates
+	// slice 0 and adds siblings.
 	if sliceCount > 1 {
-		if err := r.recreateLegacySlice0(ctx, disaggregatedSet, revision, roleNames); err != nil {
+		pendingServices, err := r.deleteLegacySlice0(ctx, disaggregatedSet, revision, roleNames)
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if len(pendingServices) > 0 {
+			// A finalizer on one of these Services stalls slice creation indefinitely,
+			// so name them instead of only reporting that we are waiting.
+			log.Info("Waiting for legacy Service garbage collection before recreating slice 0", "services", pendingServices)
+			r.Record.Eventf(disaggregatedSet, nil, corev1.EventTypeWarning, EventReasonWaitingForServiceGC,
+				"Migrate", "Waiting for legacy Services %v to be garbage-collected before creating slice-aware LeaderWorkerSets", pendingServices)
+			return ctrl.Result{RequeueAfter: legacyServiceGCRequeue}, nil
 		}
 	}
 
@@ -422,7 +452,7 @@ func (r *DisaggregatedSetReconciler) reconcileSlice(
 	}
 	revisionRoles := disaggregatedsetutils.GroupByRevision(allLWS)
 
-	if err := r.ServiceManager.ReconcileServices(ctx, disaggregatedSet, slice, revisionRoles, revision); err != nil {
+	if err := r.ServiceManager.ReconcileServices(ctx, disaggregatedSet, revisionRoles, revision); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile services: %w", err)
 	}
 
@@ -437,30 +467,37 @@ func earliestRequeue(a, b ctrl.Result) ctrl.Result {
 	return a
 }
 
-// cleanupRemovedSlices deletes LWS and services for slice indices at or above the
-// desired slice count. Removal is a direct delete; pods terminate via the normal
-// pod grace period.
-func (r *DisaggregatedSetReconciler) cleanupRemovedSlices(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, desiredSlices int) error {
+// deleteLWS validates or transfers the private Service owner before deleting its LWS.
+func (r *DisaggregatedSetReconciler) deleteLWS(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, lws *leaderworkersetv1.LeaderWorkerSet) (bool, error) {
+	serviceExists, controlled, err := r.ServiceManager.transferServiceOwnership(ctx, disaggregatedSet, lws)
+	if err != nil {
+		return false, fmt.Errorf("failed to transfer Service ownership for LWS %s: %w", lws.Name, err)
+	}
+	if serviceExists && !controlled {
+		return false, fmt.Errorf("service %s is not controlled by DisaggregatedSet %s or LeaderWorkerSet %s", disaggregatedsetutils.PrivateServiceName(lws.Name), disaggregatedSet.Name, lws.Name)
+	}
+	return serviceExists, r.LWSManager.deleteInForeground(ctx, lws)
+}
+
+// cleanupRemovedSlices deletes LWS for slice indices at or above the desired
+// slice count. Their Services are garbage-collected with them.
+func (r *DisaggregatedSetReconciler) cleanupRemovedSlices(ctx context.Context, disaggregatedSet *disaggregatedsetv1.DisaggregatedSet, lwsList []*leaderworkersetv1.LeaderWorkerSet, desiredSlices int) error {
 	log := logf.FromContext(ctx)
 
-	lwsList, err := r.LWSManager.List(ctx, disaggregatedSet, -1, "")
-	if err != nil {
-		return fmt.Errorf("failed to list LWS for slice cleanup: %w", err)
-	}
 	for _, lws := range lwsList {
 		sliceIdx, parseErr := strconv.Atoi(lws.Labels[disaggregatedsetv1.SliceLabelKey])
 		if parseErr != nil || sliceIdx < desiredSlices {
 			continue
 		}
 		log.Info("Deleting LWS for removed slice", "name", lws.Name, "slice", sliceIdx)
-		if err := r.LWSManager.Delete(ctx, disaggregatedSet.Namespace, lws.Name); err != nil {
+		if _, err := r.deleteLWS(ctx, disaggregatedSet, lws); err != nil {
 			return fmt.Errorf("failed to delete LWS %s: %w", lws.Name, err)
 		}
 		r.Record.Eventf(disaggregatedSet, nil, corev1.EventTypeNormal, EventReasonLWSDeleted,
 			"Delete", "Deleted LWS %s for removed slice %d", lws.Name, sliceIdx)
 	}
 
-	return r.ServiceManager.CleanupRemovedSlices(ctx, disaggregatedSet, desiredSlices)
+	return nil
 }
 
 func (r *DisaggregatedSetReconciler) createRollingUpdateExecutor() *RollingUpdateExecutor {
@@ -577,7 +614,7 @@ func (r *DisaggregatedSetReconciler) cleanupDrainedLWS(ctx context.Context, disa
 
 		for _, lws := range roles {
 			log.Info("Deleting drained LWS", "name", lws.Name)
-			if err := r.LWSManager.Delete(ctx, disaggregatedSet.Namespace, lws.Name); err != nil {
+			if _, err := r.deleteLWS(ctx, disaggregatedSet, lws); err != nil {
 				return fmt.Errorf("failed to delete LWS %s: %w", lws.Name, err)
 			}
 			r.Record.Eventf(disaggregatedSet, nil, corev1.EventTypeNormal, EventReasonLWSDeleted,
@@ -589,50 +626,84 @@ func (r *DisaggregatedSetReconciler) cleanupDrainedLWS(ctx context.Context, disa
 }
 
 // TODO(0.11.0): remove legacy slice-0 handling once pre-slices DisaggregatedSets are no
-// longer supported. The related legacy-compat code to remove with it: GenerateLegacyName,
-// GetForRole's legacy-name fallback, DeleteLegacyService, and the label-less branch in
-// SliceLabelMatches.
+// longer supported: GenerateLegacyName, GetForRole's legacy-name fallback, the label-less
+// branch in SliceLabelMatches, transferServiceOwnership and migrateLegacyServices (both
+// only needed for legacy DS-owned Services).
 //
-// recreateLegacySlice0 converts a pre-slices (label-less) slice-0 deployment to the
+// deleteLegacySlice0 removes a pre-slices (label-less) slice-0 deployment before the
 // slice-aware form when slices is increased above 1. The legacy slice-0 uses legacy names
 // and a slice-agnostic service (selector {name, role, revision}) that would also select
-// the new siblings' same-revision pods. For each role it deletes the legacy service first
-// (so a partial failure leaves the LWS present and this retries, and the service never
-// lingers alongside siblings), then the legacy LWS. The caller runs this before the slice
-// loop, which then recreates slice 0 in slice-aware form. This restarts slice 0 once,
-// which we accept in place of an in-place migration. A legacy slice-0 at an older revision
-// is left alone: the normal rolling update migrates it without a restart.
-func (r *DisaggregatedSetReconciler) recreateLegacySlice0(
+// the new siblings' same-revision pods. For each role it deletes the legacy LWS and waits
+// for its Service to be garbage-collected before the caller enters the slice loop. This
+// restarts slice 0 once, which we accept in place of an in-place migration. A legacy
+// slice-0 at an older revision is left alone: the normal rolling update migrates it
+// without a restart. The returned names are the legacy Services that must disappear
+// before the caller may create any slice-aware LWS.
+func (r *DisaggregatedSetReconciler) deleteLegacySlice0(
 	ctx context.Context,
 	disaggregatedSet *disaggregatedsetv1.DisaggregatedSet,
 	revision string,
 	roleNames []string,
-) error {
+) ([]string, error) {
 	log := logf.FromContext(ctx)
+	var pendingServices []string
 
 	for _, role := range roleNames {
-		// Get is ownership-filtered: a foreign object occupying the legacy
-		// name must not be adopted/deleted here.
-		lws, err := r.LWSManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role))
-		if err != nil {
-			return err
+		legacyName := disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role)
+		legacyServiceName := disaggregatedsetutils.PrivateServiceName(legacyName)
+
+		// Read directly rather than through LWSManager.Get, which folds a foreign
+		// object occupying the legacy name into nil: below we need to tell a live
+		// foreign owner apart from a deleted one whose Service is still being collected.
+		lws := &leaderworkersetv1.LeaderWorkerSet{}
+		lwsFound := true
+		if err := r.Get(ctx, client.ObjectKey{Name: legacyName, Namespace: disaggregatedSet.Namespace}, lws); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get legacy LWS %s: %w", legacyName, err)
+			}
+			lwsFound = false
 		}
-		if lws == nil || disaggregatedsetutils.HasSliceLabel(lws.Labels) {
+
+		if !lwsFound || !metav1.IsControlledBy(lws, disaggregatedSet) {
+			service := &corev1.Service{}
+			if err := r.Get(ctx, client.ObjectKey{Name: legacyServiceName, Namespace: disaggregatedSet.Namespace}, service); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return nil, fmt.Errorf("failed to get legacy service %s: %w", legacyServiceName, err)
+			}
+			owner := metav1.GetControllerOf(service)
+			// Still ours means migrateLegacyServices already deleted it and we are
+			// only waiting for GC; otherwise the legacy LWS must be the owner.
+			if !metav1.IsControlledBy(service, disaggregatedSet) {
+				if owner == nil || owner.APIVersion != leaderworkersetv1.GroupVersion.String() || owner.Kind != "LeaderWorkerSet" || owner.Name != legacyName {
+					return nil, fmt.Errorf("legacy service %s is not controlled by the expected LeaderWorkerSet %s", service.Name, legacyName)
+				}
+				if lwsFound && lws.UID == owner.UID {
+					// The owner is alive and not ours, so this Service will never be collected.
+					return nil, fmt.Errorf("legacy service %s is controlled by foreign LeaderWorkerSet %s", service.Name, legacyName)
+				}
+			}
+			pendingServices = append(pendingServices, legacyServiceName)
+			continue
+		}
+		if disaggregatedsetutils.HasSliceLabel(lws.Labels) {
 			continue
 		}
 
 		log.Info("Recreating legacy slice-0 in slice-aware form", "role", role, "name", lws.Name)
-		if err := r.ServiceManager.DeleteLegacyService(ctx, disaggregatedSet, revision, role); err != nil {
-			return err
+		serviceExists, err := r.deleteLWS(ctx, disaggregatedSet, lws)
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete legacy LWS %s: %w", lws.Name, err)
 		}
-		if err := r.LWSManager.Delete(ctx, disaggregatedSet.Namespace, lws.Name); err != nil {
-			return fmt.Errorf("failed to delete legacy LWS %s: %w", lws.Name, err)
+		if serviceExists {
+			pendingServices = append(pendingServices, legacyServiceName)
 		}
 		r.Record.Eventf(disaggregatedSet, nil, corev1.EventTypeNormal, EventReasonLWSDeleted,
 			"Migrate", "Deleted legacy slice-0 LWS %s to recreate it in slice-aware form", lws.Name)
 	}
 
-	return nil
+	return pendingServices, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
+++ b/pkg/controllers/disaggregatedset/disaggregatedset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -82,7 +83,7 @@ func createLegacyLeaderWorkerSet(disaggregatedSet *disaggregatedsetv1.Disaggrega
 		disaggregatedsetv1.RevisionLabelKey: revision,
 	}
 
-	return wrappers.BuildBasicLeaderWorkerSet(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role), disaggregatedSet.Namespace).
+	lws := wrappers.BuildBasicLeaderWorkerSet(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, role), disaggregatedSet.Namespace).
 		Labels(labels).
 		Replica(2).
 		Size(1).
@@ -97,6 +98,8 @@ func createLegacyLeaderWorkerSet(disaggregatedSet *disaggregatedsetv1.Disaggrega
 		}).
 		WorkerTemplateSpec(corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:1.0"}}}).
 		Obj()
+	lws.UID = types.UID(lws.Name + "-uid")
+	return lws
 }
 
 func TestFreshDeploymentNoRollingUpdate(t *testing.T) {
@@ -361,13 +364,9 @@ func TestLegacyMigratesToSliceAwareOnRollout(t *testing.T) {
 	assert.NotNil(t, legacy, "legacy prefill LWS should still exist while draining")
 }
 
-// TestSlicesIncreaseBlocksUntilLegacyMigrated: increasing slices above 1 over a legacy
-// slice-0 deployment starts a same-revision migration of slice 0 and does not create the
-// sibling slice until that migration completes.
 // TestSlicesIncreaseRecreatesLegacySlice0: increasing slices above 1 over a pre-slices
-// (label-less) slice-0 deletes the legacy LWS and its slice-agnostic service, and the
-// slice loop then recreates slice 0 in slice-aware form alongside the new sibling, with no
-// blocking.
+// (label-less) slice-0 transfers its Service to the legacy LWS, deletes that LWS, and
+// waits for Kubernetes GC before creating slice-aware LWS objects.
 func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 	ctx := context.Background()
 	scheme := wrappers.DisaggregatedSetTestScheme()
@@ -382,21 +381,30 @@ func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 	// The legacy slice-agnostic service that would otherwise select the new sibling's pods.
 	legacyPrefillSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill) + "-prv",
+			Name:      disaggregatedsetutils.PrivateServiceName(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill)),
 			Namespace: disaggregatedSet.Namespace,
 			Labels: map[string]string{
 				disaggregatedsetv1.SetNameLabelKey:  disaggregatedSet.Name,
 				disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
 				disaggregatedsetv1.RevisionLabelKey: revision,
 			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: disaggregatedsetv1.GroupVersion.String(),
+				Kind:       "DisaggregatedSet",
+				Name:       disaggregatedSet.Name,
+				UID:        disaggregatedSet.UID,
+				Controller: ptr.To(true),
+			}},
 		},
 		Spec: corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone},
 	}
 
+	legacyPrefillLWS := createLegacyLeaderWorkerSet(disaggregatedSet, testControllerRolePrefill, revision)
+	legacyDecodeLWS := createLegacyLeaderWorkerSet(disaggregatedSet, testControllerRoleDecode, revision)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		disaggregatedSet,
-		createLegacyLeaderWorkerSet(disaggregatedSet, testControllerRolePrefill, revision),
-		createLegacyLeaderWorkerSet(disaggregatedSet, testControllerRoleDecode, revision),
+		legacyPrefillLWS,
+		legacyDecodeLWS,
 		legacyPrefillSvc,
 	).WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
 	reconciler := &controller.DisaggregatedSetReconciler{
@@ -407,8 +415,9 @@ func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 		Record:         events.NewFakeRecorder(100),
 	}
 
-	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
 	require.NoError(t, err, "Reconcile should succeed")
+	assert.Positive(t, result.RequeueAfter, "Reconcile should wait for asynchronous Service GC")
 
 	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
 
@@ -418,15 +427,173 @@ func TestSlicesIncreaseRecreatesLegacySlice0(t *testing.T) {
 	legacyD, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRoleDecode))
 	assert.Nil(t, legacyD, "legacy slice-0 decode LWS should be deleted")
 
-	// Legacy slice-agnostic service deleted (before any sibling could be selected).
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: legacyPrefillSvc.Name, Namespace: disaggregatedSet.Namespace}, &corev1.Service{})
-	assert.Error(t, err, "legacy slice-agnostic service should be deleted")
-
-	// Slice 0 recreated slice-aware, and sibling slice 1 created in the same pass.
+	// The fake client does not run GC, so the Service remains but is now owned by
+	// the deleted legacy LWS. No slice-aware sibling may be created yet.
+	remainingService := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: legacyPrefillSvc.Name, Namespace: disaggregatedSet.Namespace}, remainingService))
+	assert.True(t, metav1.IsControlledBy(remainingService, legacyPrefillLWS))
 	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
-	require.NotNil(t, s0, "slice-aware slice-0 prefill should be recreated")
+	assert.Nil(t, s0, "slice-aware slice 0 must wait for the legacy Service to disappear")
 	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
-	require.NotNil(t, s1, "sibling slice 1 prefill should be created (no blocking)")
+	assert.Nil(t, s1, "sibling slice 1 must wait for the legacy Service to disappear")
+
+	// Simulate asynchronous Kubernetes GC, then reconcile again.
+	require.NoError(t, fakeClient.Delete(ctx, remainingService))
+	result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err, "Reconcile after GC should succeed")
+	assert.Zero(t, result.RequeueAfter)
+
+	s0, _ = lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	require.NotNil(t, s0, "slice-aware slice 0 should be recreated after GC")
+	s1, _ = lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	require.NotNil(t, s1, "sibling slice 1 should be created after GC")
+}
+
+// TestSlicesIncreaseWaitsForOrphanedLegacyService: if the legacy LWS is already gone but
+// its Service is still owned by the DisaggregatedSet directly (ownership was never
+// transferred, e.g. the LWS was deleted out-of-band), deleteLegacySlice0 must wait for
+// the Service to reach NotFound before creating slice-aware siblings.
+func TestSlicesIncreaseWaitsForOrphanedLegacyService(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("legacy-orphan", "default").
+		Slices(2).
+		WithRole(testControllerRolePrefill, 2, "nginx:1.0").
+		WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+		Obj()
+	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+
+	orphanService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       disaggregatedsetutils.PrivateServiceName(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill)),
+			Namespace:  disaggregatedSet.Namespace,
+			Finalizers: []string{"test.lws.x-k8s.io/hold-deletion"},
+			Labels: map[string]string{
+				disaggregatedsetv1.SetNameLabelKey:  disaggregatedSet.Name,
+				disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
+				disaggregatedsetv1.RevisionLabelKey: revision,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: disaggregatedsetv1.GroupVersion.String(),
+				Kind:       "DisaggregatedSet",
+				Name:       disaggregatedSet.Name,
+				UID:        disaggregatedSet.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		disaggregatedSet,
+		orphanService,
+	).WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err)
+	assert.Positive(t, result.RequeueAfter, "Reconcile should wait while the legacy Service is terminating")
+
+	remainingService := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: orphanService.Name, Namespace: orphanService.Namespace}, remainingService))
+	require.NotNil(t, remainingService.DeletionTimestamp)
+
+	lwsManager := controller.NewLeaderWorkerSetManager(fakeClient)
+	s0, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	assert.Nil(t, s0, "slice-aware slice 0 must wait for the legacy Service to disappear")
+	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	assert.Nil(t, s1, "sibling slice 1 must wait for the legacy Service to disappear")
+
+	remainingService.Finalizers = nil
+	require.NoError(t, fakeClient.Update(ctx, remainingService))
+	result, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	s0, _ = lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 0, revision, testControllerRolePrefill))
+	require.NotNil(t, s0, "slice-aware slice 0 should be created after the legacy Service disappears")
+	s1, _ = lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	require.NotNil(t, s1, "sibling slice 1 should be created after the legacy Service disappears")
+}
+
+func TestUpgradeDeletesOldRevisionOrphanService(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("upgrade-orphan", "default").
+		WithRole(testControllerRolePrefill, 2, "nginx:2.0").
+		WithRole(testControllerRoleDecode, 2, "nginx:2.0").
+		Obj()
+
+	orphanService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      disaggregatedsetutils.PrivateServiceName(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, "old12345", testControllerRolePrefill)),
+		Namespace: disaggregatedSet.Namespace,
+		Labels: map[string]string{
+			disaggregatedsetv1.SetNameLabelKey:  disaggregatedSet.Name,
+			disaggregatedsetv1.RoleLabelKey:     testControllerRolePrefill,
+			disaggregatedsetv1.RevisionLabelKey: "old12345",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: disaggregatedsetv1.GroupVersion.String(),
+			Kind:       "DisaggregatedSet",
+			Name:       disaggregatedSet.Name,
+			UID:        disaggregatedSet.UID,
+			Controller: ptr.To(true),
+		}},
+	}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet, orphanService).
+		WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.NoError(t, err)
+	getErr := fakeClient.Get(ctx, types.NamespacedName{Name: orphanService.Name, Namespace: orphanService.Namespace}, &corev1.Service{})
+	require.True(t, apierrors.IsNotFound(getErr), "old-revision orphan Service should be deleted during upgrade migration")
+}
+
+func TestSlicesIncreaseRejectsUncontrolledLegacyService(t *testing.T) {
+	ctx := context.Background()
+	scheme := wrappers.DisaggregatedSetTestScheme()
+	disaggregatedSet := wrappers.BuildDisaggregatedSet("legacy-collision", "default").
+		Slices(2).
+		WithRole(testControllerRolePrefill, 2, "nginx:1.0").
+		WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+		Obj()
+	revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      disaggregatedsetutils.PrivateServiceName(disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill)),
+		Namespace: disaggregatedSet.Namespace,
+	}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet, service).
+		WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+	reconciler := &controller.DisaggregatedSetReconciler{
+		Client:         fakeClient,
+		Scheme:         scheme,
+		LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+		ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+		Record:         events.NewFakeRecorder(100),
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+	require.ErrorContains(t, err, "not controlled by the expected LeaderWorkerSet")
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
+
+	lws, _ := controller.NewLeaderWorkerSetManager(fakeClient).Get(ctx, disaggregatedSet,
+		disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
+	assert.Nil(t, lws, "a sibling slice must not be created while the legacy Service name is occupied")
 }
 
 // TestSlicesIncreaseWithRolloutNotBlocked: when slices increases at the same time as a
@@ -851,7 +1018,7 @@ func TestSlicesIncreaseWithRolloutNotBlocked(t *testing.T) {
 }
 
 // TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0 is a regression test for
-// #981: recreateLegacySlice0 must not delete/migrate a legacy-named LWS that
+// #981: deleteLegacySlice0 must not delete/migrate a legacy-named LWS that
 // exists but is owned by a different DisaggregatedSet (e.g. left over from a
 // same-named DisaggregatedSet that was deleted and recreated before GC ran).
 // The foreign object is left untouched, and the normal create path still
@@ -922,4 +1089,65 @@ func TestSlicesIncreaseIgnoresForeignOwnedLegacySlice0(t *testing.T) {
 	assert.NotNil(t, s0, "slice-aware slice-0 prefill should still be created")
 	s1, _ := lwsManager.Get(ctx, disaggregatedSet, disaggregatedsetutils.GenerateName(disaggregatedSet.Name, 1, revision, testControllerRolePrefill))
 	assert.NotNil(t, s1, "sibling slice 1 prefill should still be created")
+}
+
+func TestSlicesIncreaseRejectsForeignLegacyService(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		foreignLWS    bool
+		expectedError string
+	}{
+		{name: "foreign LWS owns the service", foreignLWS: true, expectedError: "controlled by foreign LeaderWorkerSet"},
+		{name: "owned LWS collides with a foreign service", expectedError: "is not controlled by DisaggregatedSet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := wrappers.DisaggregatedSetTestScheme()
+			disaggregatedSet := wrappers.BuildDisaggregatedSet("legacy-foreign-service", "default").
+				Slices(2).
+				WithRole(testControllerRolePrefill, 2, "nginx:1.0").
+				WithRole(testControllerRoleDecode, 2, "nginx:1.0").
+				Obj()
+			revision := disaggregatedsetutils.ComputeRevision(disaggregatedSet.Spec.Roles)
+			legacyName := disaggregatedsetutils.GenerateLegacyName(disaggregatedSet.Name, revision, testControllerRolePrefill)
+			legacyLWS := createLegacyLeaderWorkerSet(disaggregatedSet, testControllerRolePrefill, revision)
+
+			serviceOwnerName := "foreign-lws"
+			serviceOwnerUID := types.UID("foreign-lws-uid")
+			if tc.foreignLWS {
+				legacyLWS.OwnerReferences[0].Name = "foreign-ds"
+				legacyLWS.OwnerReferences[0].UID = "foreign-ds-uid"
+				legacyLWS.UID = "foreign-lws-uid"
+				serviceOwnerName = legacyLWS.Name
+				serviceOwnerUID = legacyLWS.UID
+			}
+
+			service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+				Name:      disaggregatedsetutils.PrivateServiceName(legacyName),
+				Namespace: disaggregatedSet.Namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: leaderworkersetv1.GroupVersion.String(),
+					Kind:       "LeaderWorkerSet",
+					Name:       serviceOwnerName,
+					UID:        serviceOwnerUID,
+					Controller: ptr.To(true),
+				}},
+			}}
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(disaggregatedSet, legacyLWS, service).
+				WithStatusSubresource(&disaggregatedsetv1.DisaggregatedSet{}, &leaderworkersetv1.LeaderWorkerSet{}).Build()
+			reconciler := &controller.DisaggregatedSetReconciler{
+				Client:         fakeClient,
+				Scheme:         scheme,
+				LWSManager:     controller.NewLeaderWorkerSetManager(fakeClient),
+				ServiceManager: controller.NewServiceManager(fakeClient, scheme),
+				Record:         events.NewFakeRecorder(100),
+			}
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: disaggregatedSet.Name, Namespace: disaggregatedSet.Namespace}})
+			require.ErrorContains(t, err, tc.expectedError)
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: legacyLWS.Name, Namespace: legacyLWS.Namespace}, &leaderworkersetv1.LeaderWorkerSet{}))
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
+		})
+	}
 }

--- a/pkg/controllers/disaggregatedset/executor.go
+++ b/pkg/controllers/disaggregatedset/executor.go
@@ -39,6 +39,7 @@ const (
 	EventReasonScalingUp              = "ScalingUp"
 	EventReasonScalingDown            = "ScalingDown"
 	EventReasonLWSDeleted             = "LWSDeleted"
+	EventReasonWaitingForServiceGC    = "WaitingForServiceGarbageCollection"
 )
 
 type RollingUpdateExecutor struct {

--- a/pkg/controllers/disaggregatedset/lws_manager.go
+++ b/pkg/controllers/disaggregatedset/lws_manager.go
@@ -221,19 +221,18 @@ func (manager *LeaderWorkerSetManager) GetForRole(ctx context.Context, ds *disag
 	return manager.Get(ctx, ds, disaggregatedsetutils.GenerateLegacyName(ds.Name, revision, role))
 }
 
-func (manager *LeaderWorkerSetManager) Delete(ctx context.Context, namespace, name string) error {
-	leaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-
-	if err := manager.client.Delete(ctx, leaderWorkerSet); err != nil {
+// deleteInForeground deletes the LWS so Kubernetes removes its children — including
+// the private Service — before the LWS itself. The UID precondition keeps a same-named
+// replacement created since the caller read this object from being deleted instead.
+func (manager *LeaderWorkerSetManager) deleteInForeground(ctx context.Context, leaderWorkerSet *leaderworkersetv1.LeaderWorkerSet) error {
+	if err := manager.client.Delete(ctx, leaderWorkerSet,
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
+		client.Preconditions{UID: ptr.To(leaderWorkerSet.UID)},
+	); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to delete LeaderWorkerSet %s: %w", name, err)
+		return fmt.Errorf("failed to delete LeaderWorkerSet %s: %w", leaderWorkerSet.Name, err)
 	}
 
 	return nil

--- a/pkg/controllers/disaggregatedset/lws_manager_test.go
+++ b/pkg/controllers/disaggregatedset/lws_manager_test.go
@@ -25,9 +25,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
@@ -173,16 +175,29 @@ func TestManagerDelete(t *testing.T) {
 
 	t.Run("successfully deletes existing LWS", func(t *testing.T) {
 		existingLWS := buildManagerTestLWS(nil)
+		existingLWS.UID = types.UID("test-lws-uid")
 
+		var deleteOptions client.DeleteOptions
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithRuntimeObjects(existingLWS).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					deleteOptions.ApplyOptions(opts)
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).
 			Build()
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
-		err := manager.Delete(context.Background(), "default", "test-lws")
+		err := manager.deleteInForeground(context.Background(), existingLWS)
 
 		require.NoError(t, err)
+		require.NotNil(t, deleteOptions.PropagationPolicy)
+		assert.Equal(t, metav1.DeletePropagationForeground, *deleteOptions.PropagationPolicy)
+		require.NotNil(t, deleteOptions.Preconditions)
+		require.NotNil(t, deleteOptions.Preconditions.UID)
+		assert.Equal(t, existingLWS.UID, *deleteOptions.Preconditions.UID)
 	})
 
 	t.Run("returns nil when LWS not found (idempotent)", func(t *testing.T) {
@@ -191,7 +206,9 @@ func TestManagerDelete(t *testing.T) {
 			Build()
 
 		manager := NewLeaderWorkerSetManager(fakeClient)
-		err := manager.Delete(context.Background(), "default", "nonexistent")
+		err := manager.deleteInForeground(context.Background(), &leaderworkersetv1.LeaderWorkerSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"},
+		})
 
 		require.NoError(t, err) // Should not error, deletion is idempotent
 	})

--- a/pkg/controllers/disaggregatedset/service_manager.go
+++ b/pkg/controllers/disaggregatedset/service_manager.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
@@ -47,10 +47,62 @@ func NewServiceManager(k8sClient client.Client, scheme *runtime.Scheme) *Service
 	}
 }
 
+// migrateLegacyServices transfers Services created by an older controller to
+// their matching LWS. A DS-owned Service without a matching LWS is an orphan
+// left by an interrupted old-controller cleanup and is deleted. Foreign and
+// ownerless Services are never changed.
+func (manager *ServiceManager) migrateLegacyServices(
+	ctx context.Context,
+	deployment *disaggregatedsetv1.DisaggregatedSet,
+	lwsList []*leaderworkersetv1.LeaderWorkerSet,
+) error {
+	lwsByService := make(map[string]*leaderworkersetv1.LeaderWorkerSet, len(lwsList))
+	for _, lws := range lwsList {
+		lwsByService[disaggregatedsetutils.PrivateServiceName(lws.Name)] = lws
+	}
+
+	serviceList := &corev1.ServiceList{}
+	if err := manager.client.List(ctx, serviceList,
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: deployment.Name},
+	); err != nil {
+		return fmt.Errorf("failed to list legacy services: %w", err)
+	}
+
+	log := logf.FromContext(ctx)
+	for i := range serviceList.Items {
+		service := &serviceList.Items[i]
+		if !metav1.IsControlledBy(service, deployment) || !isPrivateRoleService(service) {
+			continue
+		}
+
+		if lws := lwsByService[service.Name]; lws != nil {
+			if exists, controlled, err := manager.transferServiceOwnership(ctx, deployment, lws); err != nil {
+				return err
+			} else if exists && !controlled {
+				return fmt.Errorf("legacy service %s could not be transferred to LeaderWorkerSet %s", service.Name, lws.Name)
+			}
+			continue
+		}
+
+		log.Info("Deleting orphaned legacy Service", "service", service.Name)
+		if err := manager.client.Delete(ctx, service); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete orphaned legacy service %s: %w", service.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func isPrivateRoleService(service *corev1.Service) bool {
+	return strings.HasSuffix(service.Name, disaggregatedsetutils.PrivateServiceSuffix) &&
+		service.Labels[disaggregatedsetv1.RoleLabelKey] != "" &&
+		service.Labels[disaggregatedsetv1.RevisionLabelKey] != ""
+}
+
 func (manager *ServiceManager) ReconcileServices(
 	ctx context.Context,
 	deployment *disaggregatedsetv1.DisaggregatedSet,
-	slice int,
 	revisionRoles disaggregatedsetutils.RevisionRolesList,
 	targetRevision string,
 ) error {
@@ -84,10 +136,6 @@ func (manager *ServiceManager) ReconcileServices(
 		}
 	}
 
-	if err := manager.cleanupDrainedServices(ctx, deployment, slice, revisionRoles, targetRevision, roleNames); err != nil {
-		return fmt.Errorf("failed to cleanup drained services: %w", err)
-	}
-
 	return nil
 }
 
@@ -110,10 +158,24 @@ func (manager *ServiceManager) ensureService(
 ) error {
 	log := logf.FromContext(ctx)
 
-	service := manager.buildService(deployment, lws)
+	service, err := manager.buildService(deployment, lws)
+	if err != nil {
+		return fmt.Errorf("failed to set owner for service %s: %w", disaggregatedsetutils.PrivateServiceName(lws.Name), err)
+	}
 
 	if err := manager.client.Create(ctx, service); err != nil {
 		if apierrors.IsAlreadyExists(err) {
+			exists, controlled, transferErr := manager.transferServiceOwnership(ctx, deployment, lws)
+			if transferErr != nil {
+				return transferErr
+			}
+			if !exists {
+				// Deleted between our Create and this Get; the next reconcile recreates it.
+				return nil
+			}
+			if !controlled {
+				return fmt.Errorf("service %s exists but is not controlled by LeaderWorkerSet %s (owned by another object or pending garbage collection from a previous generation)", service.Name, lws.Name)
+			}
 			log.V(1).Info("Service already exists", "service", service.Name)
 			return nil
 		}
@@ -132,7 +194,7 @@ func (manager *ServiceManager) ensureService(
 func (manager *ServiceManager) buildService(
 	deployment *disaggregatedsetv1.DisaggregatedSet,
 	lws *leaderworkersetv1.LeaderWorkerSet,
-) *corev1.Service {
+) (*corev1.Service, error) {
 	selector := map[string]string{
 		disaggregatedsetv1.SetNameLabelKey:  deployment.Name,
 		disaggregatedsetv1.RoleLabelKey:     lws.Labels[disaggregatedsetv1.RoleLabelKey],
@@ -142,124 +204,55 @@ func (manager *ServiceManager) buildService(
 		selector[disaggregatedsetv1.SliceLabelKey] = lws.Labels[disaggregatedsetv1.SliceLabelKey]
 	}
 
-	return &corev1.Service{
+	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      lws.Name + "-prv",
+			Name:      disaggregatedsetutils.PrivateServiceName(lws.Name),
 			Namespace: deployment.Namespace,
 			Labels:    maps.Clone(selector),
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: disaggregatedsetv1.GroupVersion.String(),
-				Kind:       "DisaggregatedSet",
-				Name:       deployment.Name,
-				UID:        deployment.UID,
-				Controller: ptr.To(true),
-			}},
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
 			Selector:  selector,
 		},
 	}
+	if err := controllerutil.SetControllerReference(lws, service, manager.scheme); err != nil {
+		return nil, err
+	}
+	return service, nil
 }
 
-func (manager *ServiceManager) cleanupDrainedServices(
+// transferServiceOwnership moves a Service created by an older controller from
+// the DisaggregatedSet to its corresponding LWS. Foreign Services are untouched.
+// The booleans report whether the Service exists and whether it is controlled by
+// the LWS after the call.
+func (manager *ServiceManager) transferServiceOwnership(
 	ctx context.Context,
 	deployment *disaggregatedsetv1.DisaggregatedSet,
-	slice int,
-	revisionRoles disaggregatedsetutils.RevisionRolesList,
-	targetRevision string,
-	roleNames []string,
-) error {
-	log := logf.FromContext(ctx)
-
-	readyRevisionSet := make(map[string]bool)
-	for _, group := range revisionRoles {
-		if revisionReadyOnAllRoles(group, roleNames) {
-			readyRevisionSet[group.Revision] = true
+	lws *leaderworkersetv1.LeaderWorkerSet,
+) (bool, bool, error) {
+	service := &corev1.Service{}
+	if err := manager.client.Get(ctx, client.ObjectKey{Name: disaggregatedsetutils.PrivateServiceName(lws.Name), Namespace: deployment.Namespace}, service); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, false, nil
 		}
+		return false, false, fmt.Errorf("failed to get service %s: %w", disaggregatedsetutils.PrivateServiceName(lws.Name), err)
+	}
+	if metav1.IsControlledBy(service, lws) {
+		return true, true, nil
+	}
+	if !metav1.IsControlledBy(service, deployment) {
+		return true, false, nil
 	}
 
-	readyRevisionSet[targetRevision] = true
-
-	// List all of the DisaggregatedSet's services and filter to this slice client-side
-	// so a legacy slice-0 service (which has no slice label) is included in slice 0's
-	// cleanup and removed once its revision drains.
-	serviceList := &corev1.ServiceList{}
-	if err := manager.client.List(ctx, serviceList,
-		client.InNamespace(deployment.Namespace),
-		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: deployment.Name},
-	); err != nil {
-		return fmt.Errorf("failed to list services: %w", err)
+	patch := client.MergeFromWithOptions(service.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	if err := controllerutil.RemoveControllerReference(deployment, service, manager.scheme); err != nil {
+		return true, false, fmt.Errorf("failed to remove DisaggregatedSet owner from service %s: %w", service.Name, err)
 	}
-
-	for i := range serviceList.Items {
-		service := &serviceList.Items[i]
-		if !disaggregatedsetutils.SliceLabelMatches(service.Labels, slice) {
-			continue
-		}
-		serviceRevision := service.Labels[disaggregatedsetv1.RevisionLabelKey]
-
-		if !readyRevisionSet[serviceRevision] {
-			log.Info("Deleting drained Service", "service", service.Name, "revision", serviceRevision, "targetRevision", targetRevision)
-			if err := manager.client.Delete(ctx, service); err != nil {
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-				return fmt.Errorf("failed to delete service %s: %w", service.Name, err)
-			}
-		}
+	if err := controllerutil.SetControllerReference(lws, service, manager.scheme); err != nil {
+		return true, false, fmt.Errorf("failed to set LeaderWorkerSet owner on service %s: %w", service.Name, err)
 	}
-
-	return nil
-}
-
-// CleanupRemovedSlices deletes services whose slice index is at or above the
-// desired slice count.
-func (manager *ServiceManager) CleanupRemovedSlices(
-	ctx context.Context,
-	deployment *disaggregatedsetv1.DisaggregatedSet,
-	desiredSlices int,
-) error {
-	log := logf.FromContext(ctx)
-
-	serviceList := &corev1.ServiceList{}
-	if err := manager.client.List(ctx, serviceList,
-		client.InNamespace(deployment.Namespace),
-		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: deployment.Name},
-	); err != nil {
-		return fmt.Errorf("failed to list services: %w", err)
+	if err := manager.client.Patch(ctx, service, patch); err != nil {
+		return true, false, fmt.Errorf("failed to transfer ownership of service %s: %w", service.Name, err)
 	}
-
-	for i := range serviceList.Items {
-		service := &serviceList.Items[i]
-		sliceIdx, err := strconv.Atoi(service.Labels[disaggregatedsetv1.SliceLabelKey])
-		if err != nil || sliceIdx < desiredSlices {
-			continue
-		}
-		log.Info("Deleting Service for removed slice", "service", service.Name, "slice", sliceIdx)
-		if err := manager.client.Delete(ctx, service); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return fmt.Errorf("failed to delete service %s: %w", service.Name, err)
-		}
-	}
-
-	return nil
-}
-
-// DeleteLegacyService deletes the pre-slices, slice-agnostic service for a role and
-// revision. Used during legacy slice-0 migration: the legacy service shares the target
-// revision, so per-revision drained cleanup never removes it.
-func (manager *ServiceManager) DeleteLegacyService(
-	ctx context.Context,
-	deployment *disaggregatedsetv1.DisaggregatedSet,
-	revision, role string,
-) error {
-	name := disaggregatedsetutils.GenerateLegacyName(deployment.Name, revision, role) + "-prv"
-	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: deployment.Namespace}}
-	if err := manager.client.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete legacy service %s: %w", name, err)
-	}
-	return nil
+	return true, true, nil
 }

--- a/pkg/controllers/disaggregatedset/service_manager_test.go
+++ b/pkg/controllers/disaggregatedset/service_manager_test.go
@@ -23,472 +23,343 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	disaggregatedsetutils "sigs.k8s.io/lws/pkg/utils/disaggregatedset"
 	"sigs.k8s.io/lws/test/wrappers"
 )
 
-// Test-local role names
 const (
 	testServiceRolePrefill = "prefill"
 	testServiceRoleDecode  = "decode"
 )
 
-// readyLWS builds a slice-0 LWS fixture with the standard name and labels and a
-// given ready replica count. Services are derived from the LWS, so fixtures must
-// carry realistic names and labels.
 func readyLWS(dsName, revision, role string, ready int32) *leaderworkersetv1.LeaderWorkerSet {
+	name := disaggregatedsetutils.GenerateName(dsName, 0, revision, role)
 	lws := &leaderworkersetv1.LeaderWorkerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   disaggregatedsetutils.GenerateName(dsName, 0, revision, role),
-			Labels: disaggregatedsetutils.GenerateLabels(dsName, 0, revision, role),
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name + "-uid"),
+			Labels:    disaggregatedsetutils.GenerateLabels(dsName, 0, revision, role),
 		},
 	}
 	lws.Status.ReadyReplicas = ready
 	return lws
 }
 
-// serviceName mirrors the production service name (<lws-name>-prv, where the LWS
-// name is GenerateName) for slice 0, for building expected names in assertions.
 func serviceName(base, revision, role string) string {
-	return disaggregatedsetutils.GenerateName(base, 0, revision, role) + "-prv"
+	return disaggregatedsetutils.PrivateServiceName(disaggregatedsetutils.GenerateName(base, 0, revision, role))
+}
+
+func revisionRoles(dsName, revision string, decodeReady int32) disaggregatedsetutils.RevisionRolesList {
+	return disaggregatedsetutils.RevisionRolesList{{
+		Revision: revision,
+		Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
+			testServiceRolePrefill: readyLWS(dsName, revision, testServiceRolePrefill, 1),
+			testServiceRoleDecode:  readyLWS(dsName, revision, testServiceRoleDecode, decodeReady),
+		},
+	}}
 }
 
 func TestServiceManager(t *testing.T) {
 	ctx := context.Background()
 	scheme := testSchemeForUnit()
 
-	t.Run("no service created when only one role is ready", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
+	t.Run("does not create services until every role is ready", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
 		serviceManager := NewServiceManager(fakeClient, scheme)
 
-		// Only prefill is ready
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 2),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 0), // not ready
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
+		err := serviceManager.ReconcileServices(ctx, deployment, revisionRoles(deployment.Name, "abc12345", 0), "abc12345")
 		require.NoError(t, err)
 
-		// Verify no services created
-		serviceList := &corev1.ServiceList{}
-		err = fakeClient.List(ctx, serviceList)
-		require.NoError(t, err)
-		assert.Empty(t, serviceList.Items, "no services should be created when only one role is ready")
+		services := &corev1.ServiceList{}
+		require.NoError(t, fakeClient.List(ctx, services))
+		assert.Empty(t, services.Items)
 	})
 
-	t.Run("services created when both roles have >= 1 ready replica", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
+	t.Run("creates an LWS-owned headless service for each role", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+		roles := revisionRoles(deployment.Name, "abc12345", 1)
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
 		serviceManager := NewServiceManager(fakeClient, scheme)
 
-		// Both roles ready
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 1),
-				},
-			},
+		require.NoError(t, serviceManager.ReconcileServices(ctx, deployment, roles, "abc12345"))
+
+		for _, role := range []string{testServiceRolePrefill, testServiceRoleDecode} {
+			service := &corev1.Service{}
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+				Name: serviceName(deployment.Name, "abc12345", role), Namespace: deployment.Namespace,
+			}, service))
+			assert.True(t, metav1.IsControlledBy(service, roles[0].Roles[role]))
+			assert.False(t, metav1.IsControlledBy(service, deployment))
+			assert.Equal(t, corev1.ClusterIPNone, service.Spec.ClusterIP)
+			assert.Empty(t, service.Spec.Ports)
+			assert.Equal(t, deployment.Name, service.Labels[disaggregatedsetv1.SetNameLabelKey])
+			assert.Equal(t, "0", service.Labels[disaggregatedsetv1.SliceLabelKey])
+			assert.Equal(t, role, service.Spec.Selector[disaggregatedsetv1.RoleLabelKey])
+			assert.Equal(t, "abc12345", service.Spec.Selector[disaggregatedsetv1.RevisionLabelKey])
 		}
+	})
 
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
-		require.NoError(t, err)
-
-		// Verify services created for both roles
-		prefillService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRolePrefill),
+	t.Run("transfers an existing service from the DisaggregatedSet to its LWS", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+		roles := revisionRoles(deployment.Name, "abc12345", 1)
+		decodeLWS := roles[0].Roles[testServiceRoleDecode]
+		existing := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name:      disaggregatedsetutils.PrivateServiceName(decodeLWS.Name),
 			Namespace: deployment.Namespace,
-		}, prefillService)
-		require.NoError(t, err, "prefill service should exist")
-
-		decodeService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, decodeService)
-		require.NoError(t, err, "decode service should exist")
-	})
-
-	t.Run("service is headless with clusterIP None", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: disaggregatedsetv1.GroupVersion.String(),
+				Kind:       "DisaggregatedSet",
+				Name:       deployment.Name,
+				UID:        deployment.UID,
+				Controller: ptr.To(true),
+			}},
+		}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, existing).Build()
 		serviceManager := NewServiceManager(fakeClient, scheme)
 
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
+		require.NoError(t, serviceManager.ReconcileServices(ctx, deployment, roles, "abc12345"))
+
+		got := &corev1.Service{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, got))
+		assert.True(t, metav1.IsControlledBy(got, decodeLWS))
+		assert.False(t, metav1.IsControlledBy(got, deployment))
+	})
+
+	t.Run("does not adopt a colliding uncontrolled service", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+
+		for _, tc := range []struct {
+			name  string
+			owner []metav1.OwnerReference
+		}{
 			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 1),
-				},
+				name: "foreign owner",
+				owner: []metav1.OwnerReference{{
+					APIVersion: disaggregatedsetv1.GroupVersion.String(),
+					Kind:       "DisaggregatedSet",
+					Name:       "other",
+					UID:        "other-uid",
+					Controller: ptr.To(true),
+				}},
 			},
+			{name: "no owner"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				roles := revisionRoles(deployment.Name, "abc12345", 1)
+				decodeLWS := roles[0].Roles[testServiceRoleDecode]
+				colliding := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+					Name:            disaggregatedsetutils.PrivateServiceName(decodeLWS.Name),
+					Namespace:       deployment.Namespace,
+					OwnerReferences: tc.owner,
+				}}
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, colliding).Build()
+				serviceManager := NewServiceManager(fakeClient, scheme)
+
+				require.Error(t, serviceManager.ReconcileServices(ctx, deployment, roles, "abc12345"))
+
+				got := &corev1.Service{}
+				require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: colliding.Name, Namespace: colliding.Namespace}, got))
+				assert.Equal(t, tc.owner, got.OwnerReferences)
+			})
 		}
+	})
 
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
-		require.NoError(t, err)
-
-		prefillService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRolePrefill),
+	t.Run("creates target services without deleting an older revision", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+		oldService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName(deployment.Name, "old12345", testServiceRolePrefill),
 			Namespace: deployment.Namespace,
-		}, prefillService)
-		require.NoError(t, err)
-
-		// Verify headless service
-		assert.Equal(t, corev1.ClusterIPNone, prefillService.Spec.ClusterIP, "service should be headless (clusterIP: None)")
-	})
-
-	t.Run("service is portless with no ports defined", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
-		serviceManager := NewServiceManager(fakeClient, scheme)
-
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 1),
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
-		require.NoError(t, err)
-
-		decodeService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, decodeService)
-		require.NoError(t, err)
-
-		// Verify portless service
-		assert.Empty(t, decodeService.Spec.Ports, "service should be portless (no ports)")
-	})
-
-	t.Run("service name uses prv prefix", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("my-app", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
-		serviceManager := NewServiceManager(fakeClient, scheme)
-
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "ef53f2d7",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("my-app", "ef53f2d7", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("my-app", "ef53f2d7", testServiceRoleDecode, 1),
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "ef53f2d7")
-		require.NoError(t, err)
-
-		// Check expected service names with prv suffix
-		expectedPrefillName := "my-app-0-ef53f2d7-prefill-prv"
-		expectedDecodeName := "my-app-0-ef53f2d7-decode-prv"
-
-		prefillService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{Name: expectedPrefillName, Namespace: "default"}, prefillService)
-		require.NoError(t, err, "service should have correct name: %s", expectedPrefillName)
-
-		decodeService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{Name: expectedDecodeName, Namespace: "default"}, decodeService)
-		require.NoError(t, err, "service should have correct name: %s", expectedDecodeName)
-	})
-
-	t.Run("standard labels are applied", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
-		serviceManager := NewServiceManager(fakeClient, scheme)
-
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 1),
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
-		require.NoError(t, err)
-
-		decodeService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, decodeService)
-		require.NoError(t, err)
-
-		// Verify standard labels are present
-		assert.Equal(t, "test-deploy", decodeService.Labels[disaggregatedsetv1.SetNameLabelKey], "name label should be set")
-		assert.Equal(t, "abc12345", decodeService.Labels[disaggregatedsetv1.RevisionLabelKey], "revision label should be set")
-		assert.Equal(t, testServiceRoleDecode, decodeService.Labels[disaggregatedsetv1.RoleLabelKey], "role label should be set")
-		assert.Equal(t, "0", decodeService.Labels[disaggregatedsetv1.SliceLabelKey], "slice label should be set")
-	})
-
-	t.Run("selector matches pod labels for role and revision", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
-		serviceManager := NewServiceManager(fakeClient, scheme)
-
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "abc12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "abc12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "abc12345", testServiceRoleDecode, 1),
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "abc12345")
-		require.NoError(t, err)
-
-		decodeService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "abc12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, decodeService)
-		require.NoError(t, err)
-
-		// Verify selector matches expected pod labels
-		assert.Equal(t, "test-deploy", decodeService.Spec.Selector[disaggregatedsetv1.SetNameLabelKey])
-		assert.Equal(t, "abc12345", decodeService.Spec.Selector[disaggregatedsetv1.RevisionLabelKey])
-		assert.Equal(t, testServiceRoleDecode, decodeService.Spec.Selector[disaggregatedsetv1.RoleLabelKey])
-		assert.Equal(t, "0", decodeService.Spec.Selector[disaggregatedsetv1.SliceLabelKey])
-	})
-
-	t.Run("old services deleted when revision is drained", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		// Create an old service
-		oldService := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName(deployment.Name, "old12345", testServiceRoleDecode),
-				Namespace: deployment.Namespace,
-				Labels: map[string]string{
-					disaggregatedsetv1.SetNameLabelKey:  deployment.Name,
-					disaggregatedsetv1.SliceLabelKey:    "0",
-					disaggregatedsetv1.RoleLabelKey:     testServiceRoleDecode,
-					disaggregatedsetv1.RevisionLabelKey: "old12345",
-				},
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP: corev1.ClusterIPNone,
-			},
-		}
-
+		}}
+		roles := append(
+			revisionRoles(deployment.Name, "old12345", 1),
+			revisionRoles(deployment.Name, "new12345", 1)...,
+		)
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, oldService).Build()
 		serviceManager := NewServiceManager(fakeClient, scheme)
 
-		// New revision is ready, old is drained
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "new12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "new12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "new12345", testServiceRoleDecode, 1),
-				},
-			},
-		}
-
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "new12345")
-		require.NoError(t, err)
-
-		// Verify old service is deleted
-		oldServiceCheck := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "old12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, oldServiceCheck)
-		assert.Error(t, err, "old service should be deleted")
-
-		// Verify new service exists
-		newService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "new12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, newService)
-		require.NoError(t, err, "new service should exist")
+		require.NoError(t, serviceManager.ReconcileServices(ctx, deployment, roles, "new12345"))
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: oldService.Name, Namespace: oldService.Namespace}, &corev1.Service{}))
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+			Name: serviceName(deployment.Name, "new12345", testServiceRolePrefill), Namespace: deployment.Namespace,
+		}, &corev1.Service{}))
 	})
 
-	t.Run("legacy slice-agnostic service is adopted and cleaned up on drain", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		// A legacy (pre-slices) service: legacy name, no slice label.
-		legacyPrefill := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      disaggregatedsetutils.GenerateLegacyName(deployment.Name, "old12345", testServiceRolePrefill) + "-prv",
-				Namespace: deployment.Namespace,
-				Labels: map[string]string{
-					disaggregatedsetv1.SetNameLabelKey:  deployment.Name,
-					disaggregatedsetv1.RoleLabelKey:     testServiceRolePrefill,
-					disaggregatedsetv1.RevisionLabelKey: "old12345",
-				},
+	t.Run("recovers when the service is deleted between Create's AlreadyExists and the ownership check", func(t *testing.T) {
+		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+		roles := revisionRoles(deployment.Name, "abc12345", 1)
+		baseClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+		// Simulate a Service that is deleted (e.g. by GC) in the window between
+		// Create's AlreadyExists and the follow-up ownership check: Create always
+		// reports AlreadyExists, but the Service was never actually persisted.
+		fakeClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+			Create: func(ctx context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "services"}, obj.GetName())
 			},
-			Spec: corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone},
-		}
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, legacyPrefill).Build()
+		})
 		serviceManager := NewServiceManager(fakeClient, scheme)
 
-		// New slice-aware revision is ready; the legacy revision is drained.
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "new12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "new12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "new12345", testServiceRoleDecode, 1),
-				},
-			},
-		}
+		err := serviceManager.ReconcileServices(ctx, deployment, roles, "abc12345")
+		require.NoError(t, err, "a service deleted before the ownership check should be left for the next reconcile to recreate")
+	})
+}
 
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, "new12345")
-		require.NoError(t, err)
+// dsOwnedService builds a Service as an older controller created it: named after
+// the LWS, labelled with name/role/revision, and controlled by the DisaggregatedSet.
+func dsOwnedService(name string, ds *disaggregatedsetv1.DisaggregatedSet, role, revision string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      name,
+		Namespace: ds.Namespace,
+		UID:       types.UID(name + "-uid"),
+		Labels: map[string]string{
+			disaggregatedsetv1.SetNameLabelKey:  ds.Name,
+			disaggregatedsetv1.RoleLabelKey:     role,
+			disaggregatedsetv1.RevisionLabelKey: revision,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: disaggregatedsetv1.GroupVersion.String(),
+			Kind:       "DisaggregatedSet",
+			Name:       ds.Name,
+			UID:        ds.UID,
+			Controller: ptr.To(true),
+		}},
+	}}
+}
 
-		// The legacy slice-agnostic service belongs to slice 0 and its revision is
-		// drained, so it should be deleted.
-		err = fakeClient.Get(ctx, types.NamespacedName{Name: legacyPrefill.Name, Namespace: deployment.Namespace}, &corev1.Service{})
-		assert.Error(t, err, "legacy service should be deleted once its revision drains")
+func TestMigrateLegacyServices(t *testing.T) {
+	ctx := context.Background()
+	scheme := testSchemeForUnit()
+	const revision = "abc12345"
+
+	newDeployment := func() *disaggregatedsetv1.DisaggregatedSet {
+		return wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").
+			WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").
+			WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
+	}
+
+	t.Run("hands a DisaggregatedSet-owned service to its LWS in place", func(t *testing.T) {
+		deployment := newDeployment()
+		lws := readyLWS(deployment.Name, revision, testServiceRolePrefill, 1)
+		service := dsOwnedService(disaggregatedsetutils.PrivateServiceName(lws.Name), deployment, testServiceRolePrefill, revision)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, lws, service).Build()
+
+		require.NoError(t, NewServiceManager(fakeClient, scheme).
+			migrateLegacyServices(ctx, deployment, []*leaderworkersetv1.LeaderWorkerSet{lws}))
+
+		got := &corev1.Service{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, got))
+		assert.True(t, metav1.IsControlledBy(got, lws))
+		assert.False(t, metav1.IsControlledBy(got, deployment))
+		assert.Equal(t, service.UID, got.UID, "the service must be migrated in place, never recreated")
 	})
 
-	t.Run("no flip-flop when multiple revisions are ready during rolling update", func(t *testing.T) {
-		deployment := wrappers.BuildDisaggregatedSet("test-deploy", "default").UID("test-uid").WithRoleNoReplicas(testServiceRolePrefill, "nginx:1.0").WithRoleNoReplicas(testServiceRoleDecode, "nginx:1.0").Obj()
-
-		// Create services for old revision (simulating existing state)
-		oldPrefillService := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName(deployment.Name, "old12345", testServiceRolePrefill),
-				Namespace: deployment.Namespace,
-				Labels: map[string]string{
-					disaggregatedsetv1.SetNameLabelKey:  deployment.Name,
-					disaggregatedsetv1.SliceLabelKey:    "0",
-					disaggregatedsetv1.RoleLabelKey:     testServiceRolePrefill,
-					disaggregatedsetv1.RevisionLabelKey: "old12345",
+	t.Run("tolerates a service deleted between list and ownership transfer", func(t *testing.T) {
+		deployment := newDeployment()
+		lws := readyLWS(deployment.Name, revision, testServiceRolePrefill, 1)
+		service := dsOwnedService(disaggregatedsetutils.PrivateServiceName(lws.Name), deployment, testServiceRolePrefill, revision)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, lws, service).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if key.Name == service.Name {
+						return apierrors.NewNotFound(schema.GroupResource{Resource: "services"}, key.Name)
+					}
+					return c.Get(ctx, key, obj, opts...)
 				},
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP: corev1.ClusterIPNone,
-			},
-		}
-		oldDecodeService := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceName(deployment.Name, "old12345", testServiceRoleDecode),
-				Namespace: deployment.Namespace,
-				Labels: map[string]string{
-					disaggregatedsetv1.SetNameLabelKey:  deployment.Name,
-					disaggregatedsetv1.SliceLabelKey:    "0",
-					disaggregatedsetv1.RoleLabelKey:     testServiceRoleDecode,
-					disaggregatedsetv1.RevisionLabelKey: "old12345",
-				},
-			},
-			Spec: corev1.ServiceSpec{
-				ClusterIP: corev1.ClusterIPNone,
-			},
-		}
+			}).Build()
 
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, oldPrefillService, oldDecodeService).Build()
-		serviceManager := NewServiceManager(fakeClient, scheme)
+		require.NoError(t, NewServiceManager(fakeClient, scheme).
+			migrateLegacyServices(ctx, deployment, []*leaderworkersetv1.LeaderWorkerSet{lws}))
+	})
 
-		// Both old and new revisions are ready (rolling update in progress)
-		revisionRoles := disaggregatedsetutils.RevisionRolesList{
+	// An old controller that stopped after deleting a drained LWS but before
+	// deleting its Service leaves this behind; nothing else would ever remove it.
+	t.Run("deletes a DisaggregatedSet-owned service whose LWS is already gone", func(t *testing.T) {
+		deployment := newDeployment()
+		orphan := dsOwnedService(serviceName(deployment.Name, "old12345", testServiceRolePrefill), deployment, testServiceRolePrefill, "old12345")
+		live := readyLWS(deployment.Name, revision, testServiceRolePrefill, 1)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, live, orphan).Build()
+
+		require.NoError(t, NewServiceManager(fakeClient, scheme).
+			migrateLegacyServices(ctx, deployment, []*leaderworkersetv1.LeaderWorkerSet{live}))
+
+		err := fakeClient.Get(ctx, types.NamespacedName{Name: orphan.Name, Namespace: orphan.Namespace}, &corev1.Service{})
+		assert.True(t, apierrors.IsNotFound(err), "orphaned legacy service should be deleted")
+	})
+
+	t.Run("never touches a service this DisaggregatedSet does not control", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			owner []metav1.OwnerReference
+		}{
 			{
-				Revision: "old12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "old12345", testServiceRolePrefill, 2),
-					testServiceRoleDecode:  readyLWS("test-deploy", "old12345", testServiceRoleDecode, 2),
-				},
+				name: "foreign owner",
+				owner: []metav1.OwnerReference{{
+					APIVersion: disaggregatedsetv1.GroupVersion.String(),
+					Kind:       "DisaggregatedSet",
+					Name:       "other",
+					UID:        "other-uid",
+					Controller: ptr.To(true),
+				}},
 			},
-			{
-				Revision: "new12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "new12345", testServiceRolePrefill, 1),
-					testServiceRoleDecode:  readyLWS("test-deploy", "new12345", testServiceRoleDecode, 1),
-				},
-			},
+			{name: "no owner"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				deployment := newDeployment()
+				lws := readyLWS(deployment.Name, revision, testServiceRolePrefill, 1)
+				// Carries this DisaggregatedSet's labels, so it is listed but must be skipped.
+				service := dsOwnedService(disaggregatedsetutils.PrivateServiceName(lws.Name), deployment, testServiceRolePrefill, revision)
+				service.OwnerReferences = tc.owner
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, lws, service).Build()
+
+				require.NoError(t, NewServiceManager(fakeClient, scheme).
+					migrateLegacyServices(ctx, deployment, []*leaderworkersetv1.LeaderWorkerSet{lws}))
+
+				got := &corev1.Service{}
+				require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, got))
+				assert.Equal(t, tc.owner, got.OwnerReferences)
+			})
 		}
+	})
 
-		// Target revision is the new one
-		targetRevision := "new12345"
+	t.Run("never touches a DisaggregatedSet-owned service that is not a private role service", func(t *testing.T) {
+		deployment := newDeployment()
+		lws := readyLWS(deployment.Name, revision, testServiceRolePrefill, 1)
+		unsuffixed := dsOwnedService(deployment.Name+"-user-facing", deployment, testServiceRolePrefill, revision)
+		unlabelled := dsOwnedService(disaggregatedsetutils.PrivateServiceName(lws.Name), deployment, "", "")
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, lws, unsuffixed, unlabelled).Build()
 
-		// First reconcile - new services created, old services kept (both still ready)
-		err := serviceManager.ReconcileServices(ctx, deployment, 0, revisionRoles, targetRevision)
-		require.NoError(t, err)
+		require.NoError(t, NewServiceManager(fakeClient, scheme).
+			migrateLegacyServices(ctx, deployment, []*leaderworkersetv1.LeaderWorkerSet{lws}))
 
-		// Verify new services are created
-		newPrefillService := &corev1.Service{}
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "new12345", testServiceRolePrefill),
-			Namespace: deployment.Namespace,
-		}, newPrefillService)
-		require.NoError(t, err, "new prefill service should exist")
-
-		// Old services should STILL exist (both revisions are ready during rolling update)
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "old12345", testServiceRolePrefill),
-			Namespace: deployment.Namespace,
-		}, &corev1.Service{})
-		require.NoError(t, err, "old prefill service should still exist during rolling update")
-
-		// Now simulate old revision being fully drained
-		drainedWorkloads := disaggregatedsetutils.RevisionRolesList{
-			{
-				Revision: "old12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "old12345", testServiceRolePrefill, 0),
-					testServiceRoleDecode:  readyLWS("test-deploy", "old12345", testServiceRoleDecode, 0),
-				},
-			},
-			{
-				Revision: "new12345",
-				Roles: map[string]*leaderworkersetv1.LeaderWorkerSet{
-					testServiceRolePrefill: readyLWS("test-deploy", "new12345", testServiceRolePrefill, 2),
-					testServiceRoleDecode:  readyLWS("test-deploy", "new12345", testServiceRoleDecode, 2),
-				},
-			},
+		for _, service := range []*corev1.Service{unsuffixed, unlabelled} {
+			got := &corev1.Service{}
+			require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, got),
+				"service %s should be left alone", service.Name)
+			assert.True(t, metav1.IsControlledBy(got, deployment), "service %s ownership should be unchanged", service.Name)
 		}
-
-		// Reconcile after drain - old services should be deleted
-		err = serviceManager.ReconcileServices(ctx, deployment, 0, drainedWorkloads, targetRevision)
-		require.NoError(t, err)
-
-		// Old services should now be deleted
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "old12345", testServiceRolePrefill),
-			Namespace: deployment.Namespace,
-		}, &corev1.Service{})
-		assert.Error(t, err, "old prefill service should be deleted after drain")
-
-		err = fakeClient.Get(ctx, types.NamespacedName{
-			Name:      serviceName(deployment.Name, "old12345", testServiceRoleDecode),
-			Namespace: deployment.Namespace,
-		}, &corev1.Service{})
-		assert.Error(t, err, "old decode service should be deleted after drain")
 	})
 }

--- a/pkg/utils/disaggregatedset/utils.go
+++ b/pkg/utils/disaggregatedset/utils.go
@@ -100,6 +100,16 @@ func GenerateLegacyName(baseName, revision, role string) string {
 	return fmt.Sprintf("%s-%s-%s", baseName, revision, role)
 }
 
+// PrivateServiceSuffix distinguishes the Service this controller creates for an
+// LWS's own pods from the public one the LWS controller creates under the bare
+// LWS name. Changing it renames every existing Service and breaks resolved DNS.
+const PrivateServiceSuffix = "-prv"
+
+// PrivateServiceName returns the private headless Service name for an LWS.
+func PrivateServiceName(lwsName string) string {
+	return lwsName + PrivateServiceSuffix
+}
+
 func GenerateLabels(baseName string, slice int, revision, role string) map[string]string {
 	return map[string]string{
 		"app":                               fmt.Sprintf("%s-%d-%s", baseName, slice, role),

--- a/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
+++ b/pkg/webhooks/disaggregatedset/disaggregatedset_webhook.go
@@ -28,6 +28,7 @@ import (
 
 	disaggv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	disaggregatedsetutils "sigs.k8s.io/lws/pkg/utils/disaggregatedset"
 	"sigs.k8s.io/lws/pkg/webhooks"
 )
 
@@ -127,8 +128,8 @@ func (w *DisaggregatedSetWebhook) validateGeneratedNames(obj *disaggv1.Disaggreg
 
 	const (
 		dns1035MaxLen                     = 63
-		revisionLen                       = 8  // hex characters in the revision hash
-		serviceSuffixLen                  = 4  // len("-prv")
+		revisionLen                       = 8 // hex characters in the revision hash
+		serviceSuffixLen                  = len(disaggregatedsetutils.PrivateServiceSuffix)
 		separators                        = 3  // three "-" between dsName, slice, revision, roleName
 		statefulSetRevisionLabelSuffixLen = 11 // len("-<10-char-hash>")
 	)

--- a/test/e2e/disaggregatedset/e2e_test.go
+++ b/test/e2e/disaggregatedset/e2e_test.go
@@ -200,6 +200,11 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("waiting for rolling update to complete")
 			kubectl.ForSingleActiveRevision(deploymentName, oldRevision)
 
+			By("verifying Services from old revisions are garbage collected via their owning LWS")
+			Eventually(func(g Gomega) {
+				g.Expect(kubectl.CountService(deploymentName)).To(Equal(2))
+			}, kubectl.DefaultTimeout, kubectl.DefaultInterval).Should(Succeed())
+
 			By("verifying no orphaned single-role workloads exist")
 			output, err := kubectl.LWS(deploymentName).
 				JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/revision},{.metadata.labels.disaggregatedset\.x-k8s\.io/role},{.spec.replicas}{"\n"}{end}`).

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -33,6 +33,7 @@ import (
 
 	disaggregatedsetv1 "sigs.k8s.io/lws/api/disaggregatedset/v1"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	disaggregatedsetutils "sigs.k8s.io/lws/pkg/utils/disaggregatedset"
 	testutils "sigs.k8s.io/lws/test/testutils"
 	"sigs.k8s.io/lws/test/wrappers"
 )
@@ -58,6 +59,11 @@ type generatedLWSSnapshot struct {
 	Revision string    `json:"revision"`
 }
 
+type serviceSnapshot struct {
+	Name string    `json:"name"`
+	UID  types.UID `json:"uid"`
+}
+
 type podSnapshot struct {
 	Name                  string           `json:"name"`
 	UID                   types.UID        `json:"uid"`
@@ -69,6 +75,7 @@ type upgradeSnapshot struct {
 	LeaderWorkerSet  objectSnapshot         `json:"leaderWorkerSet"`
 	DisaggregatedSet objectSnapshot         `json:"disaggregatedSet"`
 	GeneratedLWS     []generatedLWSSnapshot `json:"generatedLWS"`
+	GeneratedService []serviceSnapshot      `json:"generatedService"`
 	WorkloadPods     []podSnapshot          `json:"workloadPods"`
 }
 
@@ -86,6 +93,7 @@ var _ = ginkgo.Describe("Controller upgrade", ginkgo.Ordered, func() {
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(current).To(gomega.Equal(expected))
 			}, 30*time.Second, time.Second).Should(gomega.Succeed())
+			expectServicesOwnedByLeaderWorkerSets()
 			createNewWorkloads()
 		}
 	})
@@ -280,6 +288,11 @@ func captureSnapshot() (upgradeSnapshot, error) {
 		return generatedSnapshots[i].Name < generatedSnapshots[j].Name
 	})
 
+	services, err := generatedServiceSnapshots()
+	if err != nil {
+		return upgradeSnapshot{}, err
+	}
+
 	pods, err := workloadPodSnapshots()
 	if err != nil {
 		return upgradeSnapshot{}, err
@@ -289,8 +302,64 @@ func captureSnapshot() (upgradeSnapshot, error) {
 		LeaderWorkerSet:  objectSnapshot{UID: lws.UID, Generation: lws.Generation},
 		DisaggregatedSet: objectSnapshot{UID: ds.UID, Generation: ds.Generation},
 		GeneratedLWS:     generatedSnapshots,
+		GeneratedService: services,
 		WorkloadPods:     pods,
 	}, nil
+}
+
+// generatedServiceSnapshots records the identity of the DisaggregatedSet's private
+// Services. Their UIDs surviving the upgrade is what proves they were migrated to
+// their LWS owner in place instead of being deleted and recreated.
+func generatedServiceSnapshots() ([]serviceSnapshot, error) {
+	services, err := listDisaggregatedSetServices()
+	if err != nil {
+		return nil, err
+	}
+	snapshots := make([]serviceSnapshot, 0, len(services.Items))
+	for _, service := range services.Items {
+		snapshots = append(snapshots, serviceSnapshot{Name: service.Name, UID: service.UID})
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Name < snapshots[j].Name
+	})
+	return snapshots, nil
+}
+
+func listDisaggregatedSetServices() (*corev1.ServiceList, error) {
+	services := &corev1.ServiceList{}
+	if err := k8sClient.List(ctx, services,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels{disaggregatedsetv1.SetNameLabelKey: existingDSName},
+	); err != nil {
+		return nil, err
+	}
+	if len(services.Items) != 2 {
+		return nil, fmt.Errorf("expected 2 DisaggregatedSet services, got %d", len(services.Items))
+	}
+	return services, nil
+}
+
+// expectServicesOwnedByLeaderWorkerSets verifies the upgraded controller moved each
+// private Service from the DisaggregatedSet to its LeaderWorkerSet, so Kubernetes GC
+// removes it with the LWS.
+func expectServicesOwnedByLeaderWorkerSets() {
+	ginkgo.By("verifying the private Services are now owned by their LeaderWorkerSet")
+	gomega.Eventually(func(g gomega.Gomega) {
+		services, err := listDisaggregatedSetServices()
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		for _, service := range services.Items {
+			owner := metav1.GetControllerOf(&service)
+			g.Expect(owner).NotTo(gomega.BeNil(), "service %s has no controller owner", service.Name)
+			g.Expect(owner.APIVersion).To(gomega.Equal(leaderworkersetv1.GroupVersion.String()), "service %s owner", service.Name)
+			g.Expect(owner.Kind).To(gomega.Equal("LeaderWorkerSet"), "service %s owner", service.Name)
+			g.Expect(owner.BlockOwnerDeletion).To(gomega.HaveValue(gomega.BeTrue()), "service %s owner", service.Name)
+			g.Expect(service.Name).To(gomega.Equal(disaggregatedsetutils.PrivateServiceName(owner.Name)))
+
+			lws := &leaderworkersetv1.LeaderWorkerSet{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: service.Namespace}, lws)).To(gomega.Succeed())
+			g.Expect(owner.UID).To(gomega.Equal(lws.UID), "service %s owner", service.Name)
+		}
+	}, 2*time.Minute, time.Second).Should(gomega.Succeed())
 }
 
 func workloadPodSnapshots() ([]podSnapshot, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it

Makes each DisaggregatedSet `-prv` Service owned by its corresponding LeaderWorkerSet, allowing Kubernetes GC to clean it up with the LWS instead of using manual deletion paths.

Existing Services are migrated to the matching LWS owner. Legacy slice-0 migration waits for Service GC before creating sibling slices.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
