### PR TITLE
Emit linkTitle and weight from the genref template

### DIFF
--- a/hack/genref/markdown/pkg.tpl
+++ b/hack/genref/markdown/pkg.tpl
@@ -5,6 +5,8 @@
   {{- if .IsMain -}}
 ---
 title: {{ .Title }}
+linkTitle: {{ .Title }}
+weight: {{ if eq .GroupName "leaderworkerset.x-k8s.io" }}10{{ else }}20{{ end }}
 content_type: tool-reference
 package: {{ .DisplayName }}
 auto_generated: true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

#989 added `linkTitle` and `weight` frontmatter to the auto-generated API reference files, but the genref template doesn't emit those fields, so `make verify` regenerates them without it and `pull-lws-verify-main` now fails for any PR based on current main. This adds the two fields to the template. Verified `make generate-apiref` now produces a clean diff against the checked-in files.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```