### PR TITLE
docs: restore autoscaling coverage lost in the examples restructure

### DIFF
--- a/docs/examples/leaderworkerset/autoscaling/nginx-memory-hpa.yaml
+++ b/docs/examples/leaderworkerset/autoscaling/nginx-memory-hpa.yaml
@@ -1,0 +1,26 @@
+# Memory-based autoscaling for the nginx example in this directory.
+#
+# This REPLACES the CPU HorizontalPodAutoscaler shipped in nginx.yaml. Two HPAs
+# targeting one LeaderWorkerSet will fight over its replica count, so delete
+# the CPU one first:
+#
+#   kubectl delete hpa lws-hpa
+#   kubectl apply -f nginx-memory-hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: lws-memory-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: leaderworkerset.x-k8s.io/v1
+    kind: LeaderWorkerSet
+    name: leaderworkerset-sample
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/docs/examples/leaderworkerset/autoscaling/nginx-multi-metric-hpa.yaml
+++ b/docs/examples/leaderworkerset/autoscaling/nginx-multi-metric-hpa.yaml
@@ -1,0 +1,53 @@
+# CPU + memory autoscaling, with scaling behavior tuned to damp oscillation,
+# for the nginx example in this directory.
+#
+# The HPA computes a desired replica count per metric and takes the largest, so
+# either metric alone can scale the LeaderWorkerSet up.
+#
+# This REPLACES the CPU HorizontalPodAutoscaler shipped in nginx.yaml. Two HPAs
+# targeting one LeaderWorkerSet will fight over its replica count, so delete
+# the CPU one first:
+#
+#   kubectl delete hpa lws-hpa
+#   kubectl apply -f nginx-multi-metric-hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: lws-multi-metric-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: leaderworkerset.x-k8s.io/v1
+    kind: LeaderWorkerSet
+    name: leaderworkerset-sample
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    # Scale up immediately, at most doubling every 15s. Scale down only after
+    # 5 minutes below target, at most halving every 60s. Bringing up a replica
+    # group means starting a leader and its workers, so a short scale-down
+    # window would thrash the whole group.
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60

--- a/docs/examples/leaderworkerset/autoscaling/nginx.yaml
+++ b/docs/examples/leaderworkerset/autoscaling/nginx.yaml
@@ -1,0 +1,59 @@
+# LeaderWorkerSet + HorizontalPodAutoscaler: nginx (CPU only, no GPU).
+# The vLLM and SGLang examples in this directory need GPUs and a Hugging Face
+# token. This one runs on any cluster with metrics-server, so it is the
+# quickest way to watch an HPA drive LWS replica groups.
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: leaderworkerset-sample
+spec:
+  replicas: 2
+  leaderWorkerTemplate:
+    size: 3
+    leaderTemplate:
+      spec:
+        containers:
+          - name: leader
+            image: nginx:1.27 # pinned; bump to the latest release
+            # HPA computes utilization as a percentage of requests, so every
+            # container has to set them or the HPA reports <unknown>.
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+    workerTemplate:
+      spec:
+        containers:
+          - name: worker
+            image: nginx:1.27 # pinned; bump to the latest release
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+---
+# Autoscaling: HPA scales the number of replica groups via the LWS scale
+# subresource (it monitors leader pods only). Requires metrics-server.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: lws-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: leaderworkerset.x-k8s.io/v1
+    kind: LeaderWorkerSet
+    name: leaderworkerset-sample
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/site/content/en/docs/examples/leaderworkerset/autoscaling/_index.md
+++ b/site/content/en/docs/examples/leaderworkerset/autoscaling/_index.md
@@ -10,8 +10,8 @@ aliases:
 
 This guide is the [basic](../basic/) deployment plus a HorizontalPodAutoscaler.
 The HPA scales the *number of replica groups* through the LWS `scale`
-subresource (it monitors leader pods only), between `minReplicas: 2` and
-`maxReplicas: 5` at 50% CPU utilization. It needs
+subresource (it monitors leader pods only), targeting 50% CPU utilization
+between the `minReplicas` and `maxReplicas` each manifest sets. It needs
 [metrics-server](https://github.com/kubernetes-sigs/metrics-server).
 
 ## Deploy
@@ -52,8 +52,9 @@ See [basic](../basic/) for how to reach the service once pods are running.
 
 The HPA computes utilization as a percentage of a pod's resource *requests*.
 If a container has no request for the metric being targeted, the HPA reports
-`<unknown>` for it and will not scale. Every container in these examples sets
-both requests and limits for that reason.
+`<unknown>` for it and will not scale. That is why every container in the
+manifests above requests the metric its HPA targets: CPU in all three, plus
+memory in the nginx one, which is the deployment the variants below use.
 
 ## Scaling on other metrics
 
@@ -122,7 +123,9 @@ before it starts.
 
 ## Cleanup
 
+Delete whichever HPA you ended up with, then the LeaderWorkerSet:
+
 ```shell
-kubectl delete hpa lws-hpa
+kubectl delete hpa lws-hpa lws-memory-hpa lws-multi-metric-hpa --ignore-not-found
 kubectl delete leaderworkerset leaderworkerset-sample
 ```

--- a/site/content/en/docs/examples/leaderworkerset/autoscaling/_index.md
+++ b/site/content/en/docs/examples/leaderworkerset/autoscaling/_index.md
@@ -29,7 +29,16 @@ export HF_TOKEN=<your-hf-token>
 curl https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/leaderworkerset/autoscaling/sglang.yaml -s | envsubst | kubectl apply -f -
 ```
 {{% /tab %}}
+{{% tab header="nginx (no GPU)" %}}
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/leaderworkerset/autoscaling/nginx.yaml
+```
+{{% /tab %}}
 {{% /tabpane %}}
+
+The vLLM and SGLang examples need GPUs and a Hugging Face token. The nginx one
+runs on any cluster with metrics-server, including kind, so it is the quickest
+way to see the behavior described here.
 
 Watch the HPA react to load:
 
@@ -38,3 +47,82 @@ kubectl get hpa -w
 ```
 
 See [basic](../basic/) for how to reach the service once pods are running.
+
+## Resource requests are required
+
+The HPA computes utilization as a percentage of a pod's resource *requests*.
+If a container has no request for the metric being targeted, the HPA reports
+`<unknown>` for it and will not scale. Every container in these examples sets
+both requests and limits for that reason.
+
+## Scaling on other metrics
+
+The examples above scale on CPU. Two variants of the same HPA are included for
+the nginx deployment, one on memory and one on CPU and memory together.
+
+An HPA takes ownership of its target's replica count, so pointing a second one
+at the same LeaderWorkerSet makes the two fight. Delete the CPU HPA before
+applying a variant:
+
+```shell
+kubectl delete hpa lws-hpa
+```
+
+{{% tabpane text=true %}}
+{{% tab header="Memory" %}}
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/leaderworkerset/autoscaling/nginx-memory-hpa.yaml
+```
+{{% /tab %}}
+{{% tab header="CPU + memory" %}}
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/leaderworkerset/autoscaling/nginx-multi-metric-hpa.yaml
+```
+{{% /tab %}}
+{{% /tabpane %}}
+
+With several metrics the HPA computes a desired replica count for each and
+takes the largest, so either one alone can scale the deployment up.
+
+The CPU + memory variant also sets `behavior`, which is worth tuning for LWS in
+particular: each replica is a whole group, so scaling down aggressively tears
+down a leader and its workers together. It scales up immediately but waits five
+minutes below target before scaling down.
+
+## Generating load
+
+The HPA reads *leader* pods only, so load has to land on a leader to trigger
+scaling. With the nginx deployment running:
+
+```shell
+kubectl exec leaderworkerset-sample-0 -- /bin/sh -c "for i in \$(seq 1 4); do yes > /dev/null & done"
+```
+
+CPU utilization should cross the 50% target within a couple of minutes and the
+replica count should climb. To clear the load, restart the pod, since the nginx
+image has no `pkill`:
+
+```shell
+kubectl delete pod leaderworkerset-sample-0
+```
+
+Scale-down waits for the HPA stabilization window, five minutes by default,
+before it starts.
+
+## Troubleshooting
+
+`kubectl describe hpa <name>` reports why a decision was or was not made.
+
+- **Targets show `<unknown>`**: metrics-server is not running, or a container
+  is missing the resource request for the metric being targeted.
+- **Load does not trigger scaling**: confirm it is on a leader pod. Worker pod
+  usage is not read by the HPA.
+- **Replica count oscillates**: raise `behavior.scaleDown.stabilizationWindowSeconds`,
+  as the CPU + memory variant does.
+
+## Cleanup
+
+```shell
+kubectl delete hpa lws-hpa
+kubectl delete leaderworkerset leaderworkerset-sample
+```


### PR DESCRIPTION
**What this PR does / why we need it**

Reworked on top of #1021. The original version of this PR extracted inline YAML into `site/static/examples/` and pulled it back with the `{{< include >}}` shortcode. #1021 solved that same problem a different way, with canonical files under `docs/examples/<workload>/<scenario>/` referenced by `curl`, and deleted both pages this PR was editing. That approach is gone and this PR now follows the merged convention instead.

What is left is the material the restructure dropped. The new `leaderworkerset/autoscaling/` guide covers vLLM and SGLang scaling on CPU. The old HPA page also had:

- a minimal deployment needing no GPU and no Hugging Face token, so the behavior can be seen on kind
- memory-based and CPU-plus-memory HPA variants, the latter with `behavior` tuning
- why resource requests are mandatory, how to generate load the HPA actually reads, and the common failure modes

**What this adds**

Three manifests alongside the existing engine examples, following the same one-file bundle convention:

| File | Contents |
|---|---|
| `nginx.yaml` | LeaderWorkerSet + CPU HPA, no GPU required |
| `nginx-memory-hpa.yaml` | memory-based HPA |
| `nginx-multi-metric-hpa.yaml` | CPU + memory HPA with `behavior` tuning |

The two variants replace rather than supplement the CPU HPA from `nginx.yaml`, since two HPAs pointing at one LeaderWorkerSet fight over its replica count. Both the manifests and the page say so explicitly.

The prose is folded back into `site/content/en/docs/examples/leaderworkerset/autoscaling/_index.md` as sections on resource requests, alternative metrics, load generation, troubleshooting, and cleanup. Scaling behavior is called out for LWS specifically: a replica is a whole group, so an aggressive scale-down tears down a leader and its workers together.

**Testing**

All three manifests validate with `kubectl apply --dry-run=client`. Shortcode and code-fence nesting in the page is balanced.

**Note on review state**

The force-push to rework this dropped the earlier `/lgtm`. The change is substantially different from what was reviewed in August, so it needs a fresh look rather than a reinstated label.

/cc @yankay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
