### PR TITLE
Document resizing groups via leaderWorkerTemplate.size

### DIFF
--- a/site/content/en/docs/concepts/leaderworkerset/pod-templates/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/pod-templates/_index.md
@@ -10,7 +10,7 @@ LeaderWorkerSet supports defining distinct specifications for leader and worker 
 
 ## Leader and Worker Templates
 
-An LWS replica consists of one leader pod and *N - 1* worker pods (where *N* is defined by `.spec.leaderWorkerTemplate.size`).
+An LWS replica consists of one leader pod and *N - 1* worker pods (where *N* is defined by `.spec.leaderWorkerTemplate.size`). `size` can be changed on a running LeaderWorkerSet, which recreates every pod in every group. See [Resizing](../resizing/).
 
 You can configure pod specifications using two template fields:
 

--- a/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
@@ -36,9 +36,21 @@ If you need to add capacity without disturbing pods that are already serving, sc
 
 ## Resizing With Subgroups
 
-`subGroupSize` is immutable, but `size` is not. The two are validated against each other on every update, so a resize that breaks the [subgroup sizing rules](../subgroups/) is rejected by the webhook with `size or size - 1 must be divisible by subGroupSize`.
+`subGroupSize` is immutable, but `size` is not, and the two are validated against each other on every update. A resize that breaks the [subgroup sizing rules](../subgroups/) is rejected, and which sizes are valid depends on the subgroup policy type.
 
-The rejection is reported against `spec.leaderWorkerTemplate.subGroupPolicy.subGroupSize`, even though `size` is the field you changed. With `subGroupSize: 8`, valid sizes are 8, 9, 16, 17, 24, 25 and so on. To move to a size that does not fit, recreate the LeaderWorkerSet with both fields set together.
+Under `LeaderWorker`, the default, either `size` or `size - 1` must be divisible by `subGroupSize`. With `subGroupSize: 8` that allows 8, 9, 16, 17, 24, 25 and so on, and anything else is rejected with:
+
+```
+size or size - 1 must be divisible by subGroupSize
+```
+
+Under `LeaderExcluded` the leader belongs to no subgroup, so `size - 1` must be divisible on its own. With `subGroupSize: 8` that allows 9, 17, 25 and so on. Note that `size: 8` is rejected here even though it is valid under the default policy:
+
+```
+size-1 must be divisible by subGroupSize when using LeaderExcluded
+```
+
+Either way the rejection is reported against `spec.leaderWorkerTemplate.SubGroupPolicy.subGroupSize`, naming a field you did not change. To move to a size that does not fit, recreate the LeaderWorkerSet with both `size` and `subGroupSize` set together.
 
 ## Crossing size: 1
 

--- a/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
@@ -1,0 +1,45 @@
+---
+title: "Resizing Groups"
+linkTitle: "Resizing"
+weight: 65
+description: >
+  Changing the number of pods per group on a running LeaderWorkerSet.
+---
+
+`.spec.leaderWorkerTemplate.size` can be changed on a running LeaderWorkerSet. This was added in [KEP-552](https://github.com/kubernetes-sigs/lws/tree/main/keps/552-worker-resizing) so that a group can be resized with `kubectl apply` or a GitOps commit, instead of deleting and recreating the object.
+
+```yaml
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: leaderworkerset-sample
+spec:
+  replicas: 2
+  leaderWorkerTemplate:
+    size: 4      # edit this and re-apply
+    workerTemplate:
+      spec:
+        containers:
+        - name: worker
+          image: worker-image:latest
+```
+
+## Resizing Recreates Every Pod
+
+A resize is not an in-place operation. `size` is part of `leaderWorkerTemplate`, and `leaderWorkerTemplate` is what LWS stores in a `ControllerRevision`, so changing `size` produces a new revision exactly like changing a container image does. Every pod in every group is replaced, leaders included, even though only the worker count changed.
+
+This happens because each pod carries its group size as the `leaderworkerset.sigs.k8s.io/size` annotation, which is read once at pod creation to populate `LWS_GROUP_SIZE`. An existing pod cannot learn about the new size, so it has to be recreated.
+
+The replacement runs through the normal [rollout strategy](../rollout-strategy/): groups are updated in batches according to `maxUnavailable` and `maxSurge`, and a non-zero `rollingUpdate.partition` will hold back the groups below it. Plan a resize the same way you would plan an image rollout, not as a scaling operation.
+
+If you need to add capacity without disturbing pods that are already serving, scale `.spec.replicas` instead. That adds whole groups and leaves existing ones running. Growing a group in place, where new workers join a running group and the engine reconfigures itself, is not supported. It was listed as a non-goal in KEP-552.
+
+## Resizing With Subgroups
+
+`subGroupSize` is immutable, but `size` is not. The two are validated against each other on every update, so a resize that breaks the [subgroup sizing rules](../subgroups/) is rejected by the webhook with `size or size - 1 must be divisible by subGroupSize`.
+
+The rejection is reported against `spec.leaderWorkerTemplate.subGroupPolicy.subGroupSize`, even though `size` is the field you changed. With `subGroupSize: 8`, valid sizes are 8, 9, 16, 17, 24, 25 and so on. To move to a size that does not fit, recreate the LeaderWorkerSet with both fields set together.
+
+## Crossing size: 1
+
+A group of `size: 1` is a leader on its own, and LWS creates no worker StatefulSet for it. Resizing across that boundary is supported in both directions, and the worker StatefulSet appears or disappears as part of the rollout rather than being scaled. Each worker StatefulSet is owned by its leader pod, so replacing the leader takes the old worker StatefulSet with it.

--- a/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/resizing/_index.md
@@ -50,7 +50,7 @@ Under `LeaderExcluded` the leader belongs to no subgroup, so `size - 1` must be 
 size-1 must be divisible by subGroupSize when using LeaderExcluded
 ```
 
-Either way the rejection is reported against `spec.leaderWorkerTemplate.SubGroupPolicy.subGroupSize`, naming a field you did not change. To move to a size that does not fit, recreate the LeaderWorkerSet with both `size` and `subGroupSize` set together.
+Either way the rejection is reported against `spec.leaderWorkerTemplate.subGroupPolicy.subGroupSize`, naming a field you did not change. To move to a size that does not fit, recreate the LeaderWorkerSet with both `size` and `subGroupSize` set together.
 
 ## Crossing size: 1
 

--- a/site/content/en/docs/concepts/leaderworkerset/subgroups/_index.md
+++ b/site/content/en/docs/concepts/leaderworkerset/subgroups/_index.md
@@ -26,6 +26,8 @@ Sizing constraints:
 - `subGroupSize` must not be greater than `size`.
 - `size` must be divisible by `subGroupSize` (yielding equal-sized subgroups under `LeaderWorker`), **or** `size - 1` must be divisible by `subGroupSize` (where the leader is an extra pod in the first subgroup under `LeaderWorker`, or excluded under `LeaderExcluded`).
 
+`subGroupSize` cannot be changed after the LeaderWorkerSet is created, while `size` can. Both constraints above are re-checked on every update, so a [resize](../resizing/) that no longer fits `subGroupSize` is rejected.
+
 ## SubGroup Policy Types
 
 The `subGroupPolicyType` field (`.spec.leaderWorkerTemplate.subGroupPolicy.subGroupPolicyType`) defines how leader and worker pods are partitioned into subgroups:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

`.spec.leaderWorkerTemplate.size` became mutable in KEP-552 (#557, #576, #601), but the website never documented it. `pod-templates` only says that `size` defines the group, and `rollout-strategy` covers template rollouts. So a user has no way to learn from the docs that the field can be edited at all, and no way to predict what happens when they do.

This adds a Resizing Groups concept page under `concepts/leaderworkerset/` covering:

- that `size` can be changed on a running LeaderWorkerSet
- that a resize is not in-place: `size` is part of `leaderWorkerTemplate`, so changing it cuts a new `ControllerRevision` and every pod in every group is recreated, leaders included. The page explains why, which is that each pod's `LWS_GROUP_SIZE` is populated at creation time from the size annotation and cannot be updated in place
- that the replacement runs through the configured `rolloutStrategy`, so `maxUnavailable`, `maxSurge` and `partition` all apply
- the subgroup interaction, which is currently a trap: `subGroupSize` is immutable while `size` is not, so a resize that breaks the divisibility rule is rejected with an error reported against `subGroupSize`, naming a field the user did not touch
- the `size: 1` boundary, where no worker StatefulSet exists

Also adds a one-line cross-link from the subgroups and pod templates pages.

#### Which issue(s) this PR fixes

None.

#### Special notes for your reviewer

Two things I checked against the code rather than against the existing docs, worth a reviewer's eye:

1. The `size: 1` section follows the controller, not the API docstring. `leaderworkerset_types.go` says that at `size: 1` a "0-replica StatefulSet for the workers" is created, but `pod_controller.go` returns before creating one. The page says no worker StatefulSet exists. If that reading is right, the docstring is stale and I am happy to fix it in a separate PR, since it is an API comment change and does not belong in a docs PR.

2. The page states that going from N to 1 removes the worker StatefulSet. That follows from each worker StatefulSet being owned by its leader pod, so replacing the leader garbage-collects it, rather than from any explicit deletion path.

I deliberately did not quote the webhook's rejection verbatim, since the value in the `field.Invalid` call is a `*int32` and I did not want to guess how it renders. The page quotes only the detail string.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
