### PR TITLE
[docs] Fix DisaggregatedSet version framing and CRD upgrade steps

### DIFF
--- a/charts/lws/README.md
+++ b/charts/lws/README.md
@@ -88,11 +88,12 @@ the new chart version expects. `--server-side` lets the apply coexist with the
 ownership Helm records for the resource:
 
 ```bash
-kubectl apply --server-side --force-conflicts \
-  -f charts/lws/crds/leaderworkerset.x-k8s.io_leaderworkersets.yaml \
-  -f charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+kubectl apply --server-side --force-conflicts -f charts/lws/crds
 helm upgrade lws charts/lws --namespace lws-system
 ```
+
+The directory form also picks up CRDs added later, such as
+`disaggregatedsetrolescalers` in v0.10.0, which backs `scaling.mode: External`.
 
 > **Note**: neither `helm upgrade` nor `helm uninstall` + `helm install` will
 > update CRD schemas — Helm never modifies CRDs placed in the `crds/` directory

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -241,16 +241,23 @@ kubectl get validatingwebhookconfiguration lws-validating-webhook-configuration 
 
 ### Upgrade from an older version
 
-Helm does not automatically install newly added CRDs during `helm upgrade`. If you are upgrading
-from a version older than v0.9.0, manually apply the CRD first:
+`helm upgrade` does not install newly added CRDs. DisaggregatedSet ships two:
+`disaggregatedsets` since v0.9.0 and `disaggregatedsetrolescalers` since v0.10.0. Apply only
+`disaggregatedsets` and the controller cannot create the `DisaggregatedSetRoleScaler` a role with
+`scaling.mode: External` depends on, so External scaling never takes effect.
+
+Use the [Upgrade by Helm](#upgrade-by-helm) steps, which apply every CRD in the chart, with the
+DisaggregatedSet flag added:
 
 ```shell
-kubectl apply --server-side \
-  -f https://raw.githubusercontent.com/kubernetes-sigs/lws/main/charts/lws/crds/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
-
+CHART_VERSION=0.10.0
+helm pull oci://registry.k8s.io/lws/charts/lws --version=$CHART_VERSION --untar
+kubectl apply --server-side --force-conflicts -f lws/crds
 helm upgrade lws oci://registry.k8s.io/lws/charts/lws \
+  --version=$CHART_VERSION \
   --namespace lws-system \
-  --set enableDisaggregatedSet=true
+  --set enableDisaggregatedSet=true \
+  --wait --timeout 300s
 ```
 
 [feature_gate]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it
`charts/lws/crds/` ships three CRDs. Both documented upgrade paths apply two of
them, so a v0.9.0 to v0.10.0 upgrade that follows either one leaves
`scaling.mode: External` quietly broken.

- `site/content/en/docs/installation/_index.md`: the upgrade section applied only
  `disaggregatedsets`, and framed the step as something you do when coming from a
  version older than v0.9.0.  Without that CRD the
  controller cannot create the scaler behind a role, so a role set to
  `scaling.mode: External` never scales. This now points at the Upgrade by Helm
  flow, which applies every CRD the chart ships, plus the `enableDisaggregatedSet`
  flag.

- `charts/lws/README.md`: the manual apply named two CRD files by path. Applying
  the whole `crds/` directory covers all three, and picks up CRDs added later
  without another doc edit.
#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1006 

#### Special notes for your reviewer
Rebased onto main after #1021, which cut this down from four files to two. That PR
deleted `site/content/en/docs/examples/disaggregatedset.md` and rewrote
`site/content/en/docs/examples/_index.md`, covering two of the four items agreed in
#1006. The missing role-scaler CRD in the two upgrade docs is untouched on main, so
that is all that remains here.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
