### PR TITLE
fix: use parameter expansion to avoid unbound variable in RETURN trap

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -122,7 +122,7 @@ function kind_load_image {
     local image="$1"
     local archive
     archive="$(mktemp)"
-    trap 'rm -f "$archive"' RETURN
+    trap 'rm -f "${archive:-}"' RETURN
     docker save "$image" -o "$archive"
 
     while IFS= read -r node; do


### PR DESCRIPTION
## What does this PR do?

Fixes the `archive: unbound variable` error in `hack/e2e-test.sh` that causes the `pull-lws-test-e2e-upgrade-main` job to exit before running upgrade tests.

## Problem

The `kind_load_image` function sets a `RETURN` trap referencing the function-local `archive` variable:

```bash
local archive
archive="$(mktemp)"
trap 'rm -f "$archive"' RETURN
```

Because `RETURN` traps are **not function-scoped** in Bash, the trap persists after the function returns. When the calling function (e.g. `kind_load`) returns, the trap fires again, but `archive` is now out of scope. With `set -o nounset` enabled (line 18), this terminates the script:

```
hack/e2e-test.sh: line 136: archive: unbound variable
```

## Fix

Use parameter expansion with a default empty value (`${archive:-}`) in the trap so that when `archive` is out of scope, `rm -f` receives an empty argument and becomes a safe no-op:

```bash
trap 'rm -f "${archive:-}"' RETURN
```

This was introduced by #928 (`78ea4be`).

Fixes #992

/kind bug