### PR TITLE
Migrate config/default from deprecated commonLabels to labels

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,9 +9,13 @@ namespace: lws-system
 namePrefix: lws-
 
 # Common labels to add to all resources and selectors (matches Helm behavior).
-commonLabels:
-  app.kubernetes.io/name: lws
-  app.kubernetes.io/instance: lws
+# includeSelectors is required to preserve the selector injection that the
+# deprecated commonLabels field performed implicitly.
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: lws
+    app.kubernetes.io/instance: lws
 
 resources:
 - ../crd


### PR DESCRIPTION
Migrates `config/default/kustomization.yaml` from the deprecated `commonLabels` field to `labels` with `includeSelectors: true`, preserving the selector injection that `commonLabels` performed implicitly.

`kustomize build config/default` output is byte-identical before and after this change, so no CRD or chart regeneration is required.

Note: `includeSelectors: true` is required here. A plain `labels:` migration (as `kustomize edit fix` would produce) is metadata-only and would drop the label from selectors, mutating immutable selector fields on already-deployed Deployments and Services.

Fixes #866