### PR TITLE
Report subGroupPolicy field path with its serialized casing

### DIFF
--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -100,13 +100,13 @@ func (r *LeaderWorkerSetWebhook) ValidateUpdate(ctx context.Context, oldLws, new
 	specPath := field.NewPath("spec")
 
 	if newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil && oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(*newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, *oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, field.NewPath("spec", "leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(*newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, *oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, field.NewPath("spec", "leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"))...)
 	}
 	if newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil && oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy == nil {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "cannot enable subGroupSize after the lws is already created"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "cannot enable subGroupSize after the lws is already created"))
 	}
 	if newLws.Spec.LeaderWorkerTemplate.SubGroupPolicy == nil && oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy != nil {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "cannot remove subGroupSize after enabled"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "cannot remove subGroupSize after enabled"))
 	}
 	if newLws.Spec.NetworkConfig != nil && newLws.Spec.NetworkConfig.SubdomainPolicy == nil {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("networkConfig", "subdomainPolicy"), oldLws.Spec.NetworkConfig.SubdomainPolicy, "cannot set subdomainPolicy as null"))
@@ -244,18 +244,18 @@ func validateUpdateSubGroupPolicy(specPath *field.Path, lws *v1.LeaderWorkerSet)
 	size := int32(*lws.Spec.LeaderWorkerTemplate.Size)
 	subGroupSize := int32(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize)
 	if subGroupSize < 1 {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "subGroupSize must be equal or greater than 1"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "subGroupSize must be equal or greater than 1"))
 	}
 	if (size%subGroupSize != 0) && ((size-1)%subGroupSize != 0) {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "size or size - 1 must be divisible by subGroupSize"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "size or size - 1 must be divisible by subGroupSize"))
 	}
 	if size < subGroupSize {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "subGroupSize cannot be larger than size"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "subGroupSize cannot be larger than size"))
 	}
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type != nil &&
 		(*lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.Type == v1.SubGroupPolicyTypeLeaderExcluded) &&
 		((size-1)%subGroupSize != 0) {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "SubGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "size-1 must be divisible by subGroupSize when using LeaderExcluded"))
+		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize"), lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize, "size-1 must be divisible by subGroupSize when using LeaderExcluded"))
 	}
 	return allErrs
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Every `subGroupSize` validation error in the LeaderWorkerSet webhook is built against `spec.leaderWorkerTemplate.SubGroupPolicy.subGroupSize`, but the JSON tag on the field is `subGroupPolicy` (`api/leaderworkerset/v1/leaderworkerset_types.go:185`). Note the inconsistency within a single path: `leaderWorkerTemplate` and `subGroupSize` are both serialized casing, only the middle segment is the Go field name.

Field paths in admission errors are meant to be the serialized path, so a user can map the error back onto their manifest. The capitalized segment does not appear anywhere in their YAML.

So a rejected resize currently reports:

```
spec.leaderWorkerTemplate.SubGroupPolicy.subGroupSize: Invalid value: 8:
size-1 must be divisible by subGroupSize when using LeaderExcluded
```

This changes all seven paths to `subGroupPolicy`. No behaviour changes and no test asserted the old string.

This came out of review on #1008, which documents resizing and had to describe the emitted path.

#### Which issue(s) this PR fixes

None.

#### Special notes for your reviewer

The error string is user-visible, so this is technically observable to anyone matching on it. I think that is worth doing anyway for a field path that cannot be found in the user's own YAML, but it is your call, and I am happy to close this if you would rather leave it.

If this merges, #1008 needs a one-line follow-up, since it currently documents the capitalized path. I will update it either way, whichever order they land in.

Unrelated and not changed here: `validateUpdateSubGroupPolicy` is called from `generalValidate`, so it also runs on create and the `Update` in the name is misleading. Happy to rename it here or separately if you want it.

#### Does this PR introduce a user-facing change?

```release-note
The field path in LeaderWorkerSet `subGroupSize` validation errors now uses the serialized `subGroupPolicy` casing instead of `SubGroupPolicy`.
```
