### PR TITLE
Keep role label on StatefulSet metadata, not pod templates

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -122,7 +122,6 @@ function kind_load_image {
     local image="$1"
     local archive
     archive="$(mktemp)"
-    trap 'rm -f "$archive"' RETURN
     docker save "$image" -o "$archive"
 
     while IFS= read -r node; do

--- a/pkg/controllers/leaderworkerset_controller.go
+++ b/pkg/controllers/leaderworkerset_controller.go
@@ -794,7 +794,6 @@ func constructLeaderStatefulSetApplyConfiguration(lws *leaderworkerset.LeaderWor
 		leaderworkerset.WorkerIndexLabelKey: "0",
 		leaderworkerset.SetNameLabelKey:     lws.Name,
 		leaderworkerset.RevisionKey:         revisionKey,
-		leaderworkerset.RoleLabelKey:        leaderworkerset.RoleLeader,
 	})
 	podAnnotations := make(map[string]string)
 	podAnnotations[leaderworkerset.SizeAnnotationKey] = strconv.Itoa(int(*lws.Spec.LeaderWorkerTemplate.Size))

--- a/pkg/controllers/leaderworkerset_controller_test.go
+++ b/pkg/controllers/leaderworkerset_controller_test.go
@@ -118,7 +118,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -191,7 +190,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -265,7 +263,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -334,7 +331,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -403,7 +399,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -478,7 +473,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey1,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":                "2",
@@ -569,7 +563,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -667,7 +660,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",
@@ -740,7 +732,6 @@ func TestLeaderStatefulSetApplyConfig(t *testing.T) {
 								"leaderworkerset.sigs.k8s.io/name":                   "test-sample",
 								"leaderworkerset.sigs.k8s.io/worker-index":           "0",
 								"leaderworkerset.sigs.k8s.io/template-revision-hash": revisionKey2,
-								"leaderworkerset.sigs.k8s.io/role":                   "leader",
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size": "1",

--- a/pkg/controllers/pod_controller.go
+++ b/pkg/controllers/pod_controller.go
@@ -404,7 +404,6 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 		leaderworkerset.SetNameLabelKey:         lws.Name,
 		leaderworkerset.GroupUniqueHashLabelKey: leaderPod.Labels[leaderworkerset.GroupUniqueHashLabelKey],
 		leaderworkerset.RevisionKey:             revisionutils.GetRevisionKey(&leaderPod),
-		leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 	}
 
 	podTemplateApplyConfiguration.WithLabels(labelMap)
@@ -434,6 +433,7 @@ func constructWorkerStatefulSetApplyConfiguration(leaderPod corev1.Pod, lws lead
 	}
 	// construct statefulset apply configuration
 	statefulSetLabels := mergeMetadata(lws.Labels, labelMap)
+	statefulSetLabels[leaderworkerset.RoleLabelKey] = leaderworkerset.RoleWorker
 	statefulSetConfig := appsapplyv1.StatefulSet(leaderPod.Name, leaderPod.Namespace).
 		WithSpec(appsapplyv1.StatefulSetSpec().
 			WithServiceName(serviceName).

--- a/pkg/controllers/pod_controller_test.go
+++ b/pkg/controllers/pod_controller_test.go
@@ -108,7 +108,6 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
-								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":        "1",
@@ -188,7 +187,6 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
-								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":               "2",
@@ -268,7 +266,6 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.SetNameLabelKey:         "test-sample",
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
-								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 							},
 							Annotations: map[string]string{
@@ -368,7 +365,6 @@ func TestConstructWorkerStatefulSetApplyConfiguration(t *testing.T) {
 								leaderworkerset.GroupIndexLabelKey:      "1",
 								leaderworkerset.GroupUniqueHashLabelKey: "test-key",
 								leaderworkerset.RevisionKey:             updateRevisionKey,
-								leaderworkerset.RoleLabelKey:            leaderworkerset.RoleWorker,
 							},
 							Annotations: map[string]string{
 								"leaderworkerset.sigs.k8s.io/size":        "1",

--- a/test/testutils/validators.go
+++ b/test/testutils/validators.go
@@ -183,12 +183,12 @@ func ExpectValidLeaderStatefulSet(ctx context.Context, k8sClient client.Client, 
 			podTemplateSpec = *lws.Spec.LeaderWorkerTemplate.WorkerTemplate.DeepCopy()
 		}
 		// check pod template has correct label
-		if diff := cmp.Diff(sts.Spec.Template.Labels, map[string]string{
+		wantPodLabels := map[string]string{
 			leaderworkerset.SetNameLabelKey:     lws.Name,
 			leaderworkerset.WorkerIndexLabelKey: "0",
 			leaderworkerset.RevisionKey:         hash,
-			leaderworkerset.RoleLabelKey:        leaderworkerset.RoleLeader,
-		}); diff != "" {
+		}
+		if diff := cmp.Diff(sts.Spec.Template.Labels, wantPodLabels); diff != "" {
 			return errors.New("leader StatefulSet pod template doesn't have the correct labels: " + diff)
 		}
 		// we can't do a full diff of the pod template since there will be default fields added to pod template


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind regression

#### What this PR does / why we need it

#1002 added the `leaderworkerset.sigs.k8s.io/role` label to managed StatefulSets and their pod templates. Adding it to the pod template mutates the template, so on a controller upgrade the existing workloads roll even when the LeaderWorkerSet spec has not changed. In the upgrade e2e all existing Pods were replaced.

Selecting leader vs worker StatefulSets (the goal of #942) only needs the label on StatefulSet metadata. This PR keeps the label on leader and worker StatefulSet metadata and drops it from both pod templates, so an upgrade no longer rolls running workloads. The shared validator is updated to match, which also lets it validate workloads created by an older controller.

It also removes a leaking `RETURN` trap in `hack/e2e-test.sh`. The trap fired again when the caller returned, with `$archive` out of scope, and aborted the upgrade job under `set -o nounset` before any test ran.

#### Which issue(s) this PR fixes

Fixes #1016. Related to #942. Broken job: pull-lws-test-e2e-upgrade-main.

#### Special notes for your reviewer

The role label is no longer applied to Pods. Leader vs worker Pods can still be told apart by `worker-index` (0 is the leader). If pod-level selection by role is wanted later, it should be stamped by the pod webhook, not the pod template, to avoid the rollout.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
