### PR TITLE
fix(test): prevent scaler race in DisaggregatedSet HPA e2e tests

### DIFF
--- a/test/e2e/disaggregatedset/hpa_test.go
+++ b/test/e2e/disaggregatedset/hpa_test.go
@@ -38,105 +38,131 @@ import (
 //     HPA reads /scale before writing; a 500 here deadlocks the HPA loop).
 //   - kubectl scale on the scaler propagates through to the underlying LWS.
 //   - Deleting the parent DS cascades and removes the scaler via the ownerRef.
-var _ = Describe("DisaggregatedSet HPA External Scaling", Ordered, func() {
+var _ = Describe("DisaggregatedSet HPA External Scaling", func() {
 	SetDefaultEventuallyTimeout(2 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
-	const dsName = "test-hpa"
-	const scalerName = "test-hpa-prefill"
+	Context("auto-creation", func() {
+		const dsName = "test-hpa-get"
+		const scalerName = "test-hpa-get-prefill"
 
-	AfterEach(func() {
-		By("cleaning up the DisaggregatedSet")
-		kubectl.CleanupDeployment(dsName)
-	})
+		AfterEach(func() {
+			By("cleaning up the DisaggregatedSet")
+			kubectl.CleanupDeployment(dsName)
+		})
 
-	It("auto-creates a scaler and GET /scale succeeds on it before any write", func() {
-		By("creating a DisaggregatedSet with an External prefill role")
-		yaml := fixtures.PrefillDecode(dsName,
-			fixtures.Role{External: true},
-			fixtures.Role{Replicas: 1},
-		).YAML()
-		Expect(applyYAML(yaml)).To(Succeed())
+		It("auto-creates a scaler and GET /scale succeeds on it before any write", func() {
+			By("creating a DisaggregatedSet with an External prefill role")
+			yaml := fixtures.PrefillDecode(dsName,
+				fixtures.Role{External: true},
+				fixtures.Role{Replicas: 1},
+			).YAML()
+			Expect(applyYAML(yaml)).To(Succeed())
 
-		By("waiting for the controller to auto-create the scaler")
-		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
+			By("waiting for the controller to auto-create the scaler")
+			Eventually(func(g Gomega) {
+				_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
+				g.Expect(err).NotTo(HaveOccurred())
+			}).Should(Succeed())
 
-		By("verifying the scaler carries the parent DS as controller ownerRef")
-		out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-			"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(strings.TrimSpace(out)).To(Equal(dsName))
-
-		By("calling GET /scale on the fresh scaler — this is the regression guard for yankay/lws#15")
-		// The apiserver's CRD /scale handler extracts spec.replicas at read time.
-		// A pristine scaler MUST expose a materialised replicas value so HPA/KEDA
-		// can perform their bootstrap read before their first write. If this ever
-		// returns "the spec replicas field does not exist", HPA deadlocks in
-		// AbleToScale=False / FailedGetScale.
-		scaleURL := fmt.Sprintf(
-			"/apis/disaggregatedset.x-k8s.io/v1/namespaces/default/disaggregatedsetrolescalers/%s/scale",
-			scalerName)
-		Eventually(func(g Gomega) {
-			raw, err := utils.Run(exec.Command("kubectl", "get", "--raw", scaleURL))
-			g.Expect(err).NotTo(HaveOccurred(),
-				"GET /scale on a freshly auto-created scaler must succeed; a 500 here deadlocks HPA")
-			g.Expect(raw).To(ContainSubstring(`"kind":"Scale"`))
-			g.Expect(raw).To(ContainSubstring(`"spec"`))
-		}).Should(Succeed())
-	})
-
-	It("kubectl scale on the scaler propagates spec.replicas to the LWS", func() {
-		By("creating a DisaggregatedSet with an External prefill role")
-		yaml := fixtures.PrefillDecode(dsName,
-			fixtures.Role{External: true},
-			fixtures.Role{Replicas: 1},
-		).YAML()
-		Expect(applyYAML(yaml)).To(Succeed())
-
-		By("waiting for the scaler to exist")
-		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
-
-		By("writing spec.replicas=3 via the /scale subresource (same call HPA/KEDA use)")
-		_, err := utils.Run(exec.Command("kubectl", "scale",
-			"disaggregatedsetrolescaler/"+scalerName, "-n", "default", "--replicas=3"))
-		Expect(err).NotTo(HaveOccurred())
-
-		By("verifying the LWS for prefill scales to 3")
-		Eventually(func(g Gomega) {
-			g.Expect(kubectl.GetTotalReplicas(dsName, kubectl.GetRevision(dsName))).To(BeNumerically(">=", 3))
-		}).Should(Succeed())
-	})
-
-	It("cascades: deleting the DS removes the auto-created scaler via ownerRef", func() {
-		By("creating a DisaggregatedSet with an External prefill role")
-		yaml := fixtures.PrefillDecode(dsName,
-			fixtures.Role{External: true},
-			fixtures.Role{Replicas: 1},
-		).YAML()
-		Expect(applyYAML(yaml)).To(Succeed())
-
-		By("waiting for the scaler to exist")
-		Eventually(func(g Gomega) {
-			_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
-
-		By("deleting the DisaggregatedSet")
-		_, err := kubectl.Delete("disaggregatedset", dsName).Namespace("default").Run()
-		Expect(err).NotTo(HaveOccurred())
-
-		By("verifying the scaler is garbage-collected")
-		Eventually(func(g Gomega) {
+			By("verifying the scaler carries the parent DS as controller ownerRef")
 			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-				"--ignore-not-found", "-o", "name"))
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(strings.TrimSpace(out)).To(BeEmpty())
-		}).Should(Succeed())
+				"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(out)).To(Equal(dsName))
+
+			By("calling GET /scale on the fresh scaler — this is the regression guard for yankay/lws#15")
+			// The apiserver's CRD /scale handler extracts spec.replicas at read time.
+			// A pristine scaler MUST expose a materialised replicas value so HPA/KEDA
+			// can perform their bootstrap read before their first write. If this ever
+			// returns "the spec replicas field does not exist", HPA deadlocks in
+			// AbleToScale=False / FailedGetScale.
+			scaleURL := fmt.Sprintf(
+				"/apis/disaggregatedset.x-k8s.io/v1/namespaces/default/disaggregatedsetrolescalers/%s/scale",
+				scalerName)
+			Eventually(func(g Gomega) {
+				raw, err := utils.Run(exec.Command("kubectl", "get", "--raw", scaleURL))
+				g.Expect(err).NotTo(HaveOccurred(),
+					"GET /scale on a freshly auto-created scaler must succeed; a 500 here deadlocks HPA")
+				g.Expect(raw).To(ContainSubstring(`"kind":"Scale"`))
+				g.Expect(raw).To(ContainSubstring(`"spec"`))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("scale propagation", func() {
+		const dsName = "test-hpa-scale"
+		const scalerName = "test-hpa-scale-prefill"
+
+		AfterEach(func() {
+			By("cleaning up the DisaggregatedSet")
+			kubectl.CleanupDeployment(dsName)
+		})
+
+		It("kubectl scale on the scaler propagates spec.replicas to the LWS", func() {
+			By("creating a DisaggregatedSet with an External prefill role")
+			yaml := fixtures.PrefillDecode(dsName,
+				fixtures.Role{External: true},
+				fixtures.Role{Replicas: 1},
+			).YAML()
+			Expect(applyYAML(yaml)).To(Succeed())
+
+			By("waiting for the scaler to exist")
+			Eventually(func(g Gomega) {
+				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
+					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).To(Equal(dsName))
+			}).Should(Succeed())
+
+			By("writing spec.replicas=3 via the /scale subresource (same call HPA/KEDA use)")
+			_, err := utils.Run(exec.Command("kubectl", "scale",
+				"disaggregatedsetrolescaler/"+scalerName, "-n", "default", "--replicas=3"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the LWS for prefill scales to 3")
+			Eventually(func(g Gomega) {
+				g.Expect(kubectl.GetTotalReplicas(dsName, kubectl.GetRevision(dsName))).To(BeNumerically(">=", 3))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("cascade deletion", func() {
+		const dsName = "test-hpa-cascade"
+		const scalerName = "test-hpa-cascade-prefill"
+
+		AfterEach(func() {
+			By("cleaning up the DisaggregatedSet")
+			kubectl.CleanupDeployment(dsName)
+		})
+
+		It("cascades: deleting the DS removes the auto-created scaler via ownerRef", func() {
+			By("creating a DisaggregatedSet with an External prefill role")
+			yaml := fixtures.PrefillDecode(dsName,
+				fixtures.Role{External: true},
+				fixtures.Role{Replicas: 1},
+			).YAML()
+			Expect(applyYAML(yaml)).To(Succeed())
+
+			By("waiting for the scaler to exist")
+			Eventually(func(g Gomega) {
+				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
+					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).To(Equal(dsName))
+			}).Should(Succeed())
+
+			By("deleting the DisaggregatedSet")
+			_, err := kubectl.Delete("disaggregatedset", dsName).Namespace("default").Run()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the scaler is garbage-collected")
+			Eventually(func(g Gomega) {
+				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
+					"--ignore-not-found", "-o", "name"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(out)).To(BeEmpty())
+			}).Should(Succeed())
+		})
 	})
 })

--- a/test/testutils/disaggregatedset/kubectl/queries.go
+++ b/test/testutils/disaggregatedset/kubectl/queries.go
@@ -205,4 +205,5 @@ func CleanupDeployment(deploymentName string) {
 	_, _ = Delete("lws").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().Timeout("30s").RunQuiet()
 	_, _ = Delete("pods").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().GracePeriod(0).Force().RunQuiet()
 	_, _ = Delete("svc").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().RunQuiet()
+	_, _ = Delete("dsrs").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().RunQuiet()
 }


### PR DESCRIPTION
Sequential specs in test/e2e/disaggregatedset/hpa_test.go shared the same DisaggregatedSet and DisaggregatedSetRoleScaler names ("test-hpa" and "test-hpa-prefill") in an Ordered container.

When the first spec completed, CleanupDeployment deleted the DS but did not delete or await garbage collection of the scaler. When the second spec started immediately after, it matched the stale, dying scaler from the first spec and scaled it to 3, while the DS controller detected the ownership mismatch, refused to adopt it (ScalerConflict), and created the LWS with 0 replicas. Once GC deleted the stale scaler, the controller created a new scaler seeded at 0, causing the test to time out waiting for replicas >= 3.

Fix this by:
1. Isolating each spec into its own Context with unique deployment and scaler names (test-hpa-get, test-hpa-scale, test-hpa-cascade), matching the convention used across the rest of the e2e test suite.
2. Removing the artificial Ordered constraint on the suite.
3. Adding explicit dsrs cleanup to kubectl.CleanupDeployment.
4. Verifying ownerRef when waiting for the scaler to exist.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
