### PR TITLE
Document Kubernetes version support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,24 @@ Read the [documentation](https://lws.sigs.k8s.io/docs/) or watch the [related ta
   <img src="site/static/images/ds-concept.svg" width="700" alt="DisaggregatedSet Concept">
 </p>
 
+## Production Readiness status
+
+- ✔️ API version: v1alpha2, respecting [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+- ✔️ Maintains support for latest 3 Kubernetes minor versions.
+- ✔️ Up-to-date [documentation](https://lws.sigs.k8s.io/docs).
+- ✔️ Test Coverage:
+  - ✔️ Unit Test [testgrid](https://testgrid.k8s.io/sig-apps#pull-lws-test-unit-main)
+  - ✔️ Integration Test [testgrid](https://testgrid.k8s.io/sig-apps#pull-lws-test-integration-main)
+  - ✔️ E2E Tests for Kubernetes
+    [1.33](https://testgrid.k8s.io/sig-apps#pull-lws-test-e2e-main-1-33)
+    [1.34](https://testgrid.k8s.io/sig-apps#pull-lws-test-e2e-main-1-34)
+    [1.35](https://testgrid.k8s.io/sig-apps#pull-lws-test-e2e-main-1-35)
+    [1.36](https://testgrid.k8s.io/sig-apps#pull-lws-test-e2e-main-1-36)
+    on Kind.
+
 ## Installation
+
+**Requires a Kubernetes cluster running one of the last 3 Kubernetes minor versions (currently 1.33-1.36).**
 
 Read the [installation guide](https://lws.sigs.k8s.io/docs/installation/) to learn more.
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -26,8 +26,7 @@ description: >
 
 Make sure the following conditions are met:
 
-- A Kubernetes cluster with version >= 1.26 is **Required**, or it will behave unexpected. Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
-    - For any cluster with version 1.26, you need to enable the [feature gate][feature_gate] for [Start Ordinal][start_ordinal] manually. For version greater than 1.26, it's enabled by default.
+- A Kubernetes cluster with version >= 1.33 is **Required** (lws supports the latest 3 Kubernetes minor versions, currently 1.33-1.36). Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
     - Rolling update with max unavailable Pods, you must enable the [MaxUnavailableStatefulSet][max_unavailable] feature gate, which is still in alpha since Kubernetes v1.24, see discussion [here][max_unavailable_enhancement]. Or lws will roll out the pods one by one.
 - Your cluster has at least 1 node with 1+ CPUs and 1G of memory available for the LeaderWorkerSet controller manager Deployment to run on. **NOTE: On some cloud providers, the default node machine type will not have sufficient resources to run the LeaderWorkerSet controller manager and all the required kube-system pods, so you'll need to use a larger
 machine type for your nodes.**


### PR DESCRIPTION
## What this PR does

Documents the Kubernetes version support policy for lws, following the same pattern used by JobSet.

### Changes:

1. **README.md**: Add a "Production Readiness status" section that explicitly states:
   - API version (v1alpha2) following Kubernetes Deprecation Policy
   - Support for the latest 3 Kubernetes minor versions
   - TestGrid links for unit, integration, and e2e tests (1.33-1.36 on Kind)

2. **Installation guide** (): Update the version requirement from `>= 1.26` to `>= 1.33`, with a note that lws supports the latest 3 Kubernetes minor versions (currently 1.33-1.36). Removed the outdated 1.26 feature gate note since `StatefulSetStartOrdinal` is enabled by default in all supported versions.

The supported versions (1.33-1.36) are confirmed by the e2e test jobs configured in the [prow config](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml).

Ref: #1024

