### PR TITLE
Guard nil replicas and size in LeaderWorkerSet webhook validation

### DIFF
--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -142,18 +142,30 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 	// Since the lws name is used as the name for headless service, it must be DNS-1035 compliant
 	ValidateName := apivalidation.NameIsDNS1035Label
 	allErrs := apivalidation.ValidateObjectMeta(&lws.ObjectMeta, true, apivalidation.ValidateNameFunc(ValidateName), field.NewPath("metadata"))
-	// Ensure replicas and groups number are valid
-	replicas := *lws.Spec.Replicas
-	if replicas < 0 {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or greater than 0"))
+	// Ensure replicas and groups number are valid.
+	// replicas and size are backfilled to 1 by the CRD's OpenAPI schema default
+	// and by Default(), but this function can also run against an object that
+	// never picked either up (a CRD installed from an older revision, or a
+	// caller invoking the webhook logic directly), so neither is dereferenced
+	// unconditionally.
+	replicas := int32(1)
+	if lws.Spec.Replicas != nil {
+		replicas = *lws.Spec.Replicas
+		if replicas < 0 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or greater than 0"))
+		}
+		if replicas > 1000000 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or less than 1000000"))
+		}
 	}
-	if replicas > 1000000 {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or less than 1000000"))
+	size := int32(1)
+	if lws.Spec.LeaderWorkerTemplate.Size != nil {
+		size = *lws.Spec.LeaderWorkerTemplate.Size
 	}
-	if *lws.Spec.LeaderWorkerTemplate.Size < 1 {
+	if size < 1 {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "size"), lws.Spec.LeaderWorkerTemplate.Size, "size must be equal or greater than 1"))
 	}
-	if int64(replicas)*int64(*lws.Spec.LeaderWorkerTemplate.Size) > math.MaxInt32 {
+	if int64(replicas)*int64(size) > math.MaxInt32 {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, fmt.Sprintf("the product of replicas and worker replicas must not exceed %d", math.MaxInt32)))
 	}
 
@@ -284,13 +296,16 @@ func validateNonnegativeField(value int64, fldPath *field.Path) field.ErrorList 
 
 func validateUpdateSubGroupPolicy(specPath *field.Path, lws *v1.LeaderWorkerSet) field.ErrorList {
 	allErrs := field.ErrorList{}
-	size := int32(*lws.Spec.LeaderWorkerTemplate.Size)
 	subGroupSizePath := specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize")
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize == nil {
 		return append(allErrs, field.Required(subGroupSizePath, "subGroupSize is required"))
 	}
 
 	subGroupSize := *lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize
+	size := int32(1)
+	if lws.Spec.LeaderWorkerTemplate.Size != nil {
+		size = *lws.Spec.LeaderWorkerTemplate.Size
+	}
 	if subGroupSize < 1 {
 		return append(allErrs, field.Invalid(subGroupSizePath, subGroupSize, "subGroupSize must be equal or greater than 1"))
 	}

--- a/pkg/webhooks/leaderworkerset_webhook_subgroup_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_subgroup_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+// runValidateCreate calls ValidateCreate and turns a panic into a normal test
+// failure instead of crashing the whole test binary, so a regression is
+// reported as a clear assertion failure rather than a fatal signal.
+func runValidateCreate(t *testing.T, lws *v1.LeaderWorkerSet) error {
+	t.Helper()
+	webhook := &LeaderWorkerSetWebhook{}
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ValidateCreate panicked: %v", r)
+			}
+		}()
+		_, err = webhook.ValidateCreate(context.TODO(), lws)
+	}()
+	return err
+}
+
+// runValidateUpdate is the ValidateUpdate counterpart of runValidateCreate.
+func runValidateUpdate(t *testing.T, oldLws, newLws *v1.LeaderWorkerSet) error {
+	t.Helper()
+	webhook := &LeaderWorkerSetWebhook{}
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ValidateUpdate panicked: %v", r)
+			}
+		}()
+		_, err = webhook.ValidateUpdate(context.TODO(), oldLws, newLws)
+	}()
+	return err
+}
+
+// subGroupSize has no CRD default and is not a required schema field (see
+// config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml), so a
+// spec-valid request can set `subGroupPolicy: {}` without it. Before this
+// fix, validateUpdateSubGroupPolicy dereferenced SubGroupSize unconditionally
+// and panicked instead of returning a validation error.
+func TestValidateCreateSubGroupPolicyWithoutSubGroupSize(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{}
+
+	err := runValidateCreate(t, lws)
+	if err == nil {
+		t.Fatal("expected an error for subGroupPolicy without subGroupSize, got nil")
+	}
+	if !strings.Contains(err.Error(), "subGroupSize") {
+		t.Errorf("expected error to mention subGroupSize, got: %v", err)
+	}
+}
+
+// subGroupSize: 0 is schema-valid (no minimum is enforced), but the size %
+// subGroupSize checks that follow the "must be >= 1" rejection divide by
+// subGroupSize unconditionally. Before this fix that was a divide-by-zero
+// panic instead of the intended "must be equal or greater than 1" error.
+func TestValidateCreateSubGroupPolicyZeroSubGroupSize(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{
+		SubGroupSize: ptr.To[int32](0),
+	}
+
+	err := runValidateCreate(t, lws)
+	if err == nil {
+		t.Fatal("expected an error for subGroupSize: 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "subGroupSize must be equal or greater than 1") {
+		t.Errorf("expected 'subGroupSize must be equal or greater than 1' error, got: %v", err)
+	}
+}
+
+// A valid, positive subGroupSize must still be accepted; this guards against
+// the nil/zero-handling fix rejecting legitimate specs.
+func TestValidateCreateSubGroupPolicyValid(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Size(4).Obj()
+	lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{
+		SubGroupSize: ptr.To[int32](2),
+	}
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected valid subGroupPolicy to be accepted, got: %v", err)
+	}
+}
+
+// A nil rollingUpdateConfiguration must not panic: its fields were read before
+// the nil check that was meant to guard them.
+func TestValidateCreateNilRollingUpdateConfiguration(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.RolloutStrategy.RollingUpdateConfiguration = nil
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil rollingUpdateConfiguration to be accepted, got: %v", err)
+	}
+}
+
+// generalValidate reads replicas as a bare dereference, relying on the CRD
+// schema default and on Default() having run. Neither holds for an object that
+// reaches validation without them: a CRD installed from an older revision, or a
+// caller invoking ValidateCreate directly, as the controller's own tests do.
+func TestValidateCreateNilReplicas(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.Replicas = nil
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil replicas to be accepted, got: %v", err)
+	}
+}
+
+// size has the same dereference-before-nil-check shape as replicas, and unlike
+// replicas it is not backfilled by Default() either.
+func TestValidateCreateNilSize(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.Size = nil
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil size to be accepted, got: %v", err)
+	}
+}
+
+// validateUpdateSubGroupPolicy dereferences size as well, on a path reached
+// only when subGroupPolicy is set, so it needs its own case.
+func TestValidateCreateNilSizeWithSubGroupPolicy(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.Size = nil
+	lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{
+		SubGroupSize: ptr.To[int32](1),
+	}
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil size with subGroupPolicy to be accepted, got: %v", err)
+	}
+}
+
+// ValidateUpdate's immutability check dereferenced SubGroupSize on both the
+// old and new object guarded only by "SubGroupPolicy != nil", not
+// "SubGroupSize != nil". Exercise it directly so a future change to the nil
+// guard is caught even though generalValidate's own check on the new object
+// would otherwise mask this on the common path.
+func TestValidateUpdateSubGroupPolicyNilSubGroupSizeDoesNotPanic(t *testing.T) {
+	oldLws := wrappers.BuildLeaderWorkerSet("default").Size(4).Obj()
+	oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{
+		SubGroupSize: ptr.To[int32](2),
+	}
+	newLws := oldLws.DeepCopy()
+	// Simulate an old object that predates the subGroupSize-required
+	// validation alongside an otherwise-valid new object.
+	oldLws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize = nil
+
+	// Whether this is accepted or rejected is not the point of this test;
+	// what matters is that it returns rather than panicking.
+	_ = runValidateUpdate(t, oldLws, newLws)
+}
+
+// The "cannot set subdomainPolicy as null" branch is guarded on the new
+// object's networkConfig only. An object stored before subdomainPolicy was
+// defaulted has no networkConfig at all, so the old object must not be read
+// unguarded on this path.
+func TestValidateUpdateNilOldNetworkConfigDoesNotPanic(t *testing.T) {
+	oldLws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	newLws := oldLws.DeepCopy()
+	oldLws.Spec.NetworkConfig = nil
+	newLws.Spec.NetworkConfig = &v1.NetworkConfig{}
+
+	err := runValidateUpdate(t, oldLws, newLws)
+	if err == nil {
+		t.Error("expected an error for subdomainPolicy set to null, got nil")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`generalValidate` reads `replicas` and `leaderWorkerTemplate.size` as bare pointer dereferences, and `validateUpdateSubGroupPolicy` dereferences `size` again on the path reached when `subGroupPolicy` is set. None of the three is nil-guarded, so an object that reaches validation without its defaults applied panics the webhook instead of being accepted or rejected normally.

The two fields differ in how they are defaulted, and neither is safe on its own:

| field | CRD schema default | set by `Default()` |
| --- | --- | --- |
| `spec.replicas` | `+kubebuilder:default=1` | yes |
| `spec.leaderWorkerTemplate.size` | `+kubebuilder:default=1` | no |

On a normal admission path the schema default keeps both non-nil, so this is hardening rather than a panic reachable from a plain `kubectl apply`. It is reachable when an object never picks the schema default up, for example a CRD installed at an older revision, or an in-process caller invoking `ValidateCreate` directly, which this repository's own tests do. `size` is the weaker of the two, since the mutating webhook does not backfill it the way it backfills `replicas`.

Both are now read through a nil check that falls back to `1`, matching the schema default. No behavior change for any currently-passing case: the validation rules are unchanged, and only previously-panicking states now produce a clean result.

#### Which issue(s) this PR fixes

Fixes #

Left blank deliberately. See the note below on the overlap with the change that already landed.

#### Special notes for your reviewer

- **Scope of this PR shrank after `d1a1de0` landed.** This branch originally also fixed the `subGroupPolicy` nil dereference and the `size % subGroupSize` divide-by-zero. Both were fixed upstream by #932, so those hunks are gone and only the `replicas` and `size` hardening remains. It has been rebased onto current `main` and the description rewritten to match. Reviewing it fresh rather than against the earlier discussion will be less confusing.
- `d1a1de0` replaced the previous `if lws.Spec.Replicas != nil` guard in `generalValidate` with a bare `replicas := *lws.Spec.Replicas`, relying on `Default()` backfilling it. That is sound on the admission path. This restores the guard so the function does not depend on defaulting having run, which also makes it safe for the direct callers.
- New test file `pkg/webhooks/leaderworkerset_webhook_nil_defaults_test.go` calls `ValidateCreate` directly, no envtest needed, and wraps the call in `recover()` so a regression surfaces as a normal failed assertion rather than crashing the test binary.
- All three tests fail against unpatched `main` with `runtime error: invalid memory address or nil pointer dereference`, and pass here. Verified on a clean worktree at `546910f` with only the test file added:

  ```
  --- FAIL: TestValidateCreateNilReplicas (0.00s)
  --- FAIL: TestValidateCreateNilSize (0.00s)
  --- FAIL: TestValidateCreateNilSizeWithSubGroupPolicy (0.00s)
  ```

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the LeaderWorkerSet validating webhook could panic instead of
returning a validation result when `spec.replicas` or
`spec.leaderWorkerTemplate.size` reached validation unset.
```
