### PR TITLE
Restore LWS Kueue topology-aware scheduling example

### DIFF
--- a/docs/examples/disaggregatedset/topology-aware-scheduling/vllm-kueue.yaml
+++ b/docs/examples/disaggregatedset/topology-aware-scheduling/vllm-kueue.yaml
@@ -1,0 +1,80 @@
+# DisaggregatedSet + Kueue topology-aware scheduling: vLLM.
+# Requires Kueue with TAS and a LocalQueue named "default" (see the guide).
+apiVersion: disaggregatedset.x-k8s.io/v1
+kind: DisaggregatedSet
+metadata:
+  name: vllm-disagg
+  labels:
+    # Admit this workload through Kueue.
+    kueue.x-k8s.io/queue-name: default
+spec:
+  roles:
+    - name: prefill
+      spec:
+        leaderWorkerTemplate:
+          size: 1
+          workerTemplate:
+            metadata:
+              labels:
+                role: prefill
+              annotations:
+                # Co-locate the prefill role within one topology block.
+                # Set the value to your topology level's node label.
+                kueue.x-k8s.io/podset-required-topology: cloud.google.com/gce-topology-block
+            spec:
+              containers:
+                - name: vllm
+                  image: vllm/vllm-openai:v0.28.0 # pinned; bump to the latest release
+                  env:
+                    - name: HF_TOKEN
+                      value: $HF_TOKEN
+                  command:
+                    - sh
+                    - -c
+                    - "python3 -m vllm.entrypoints.openai.api_server --port 8080
+                       --model meta-llama/Meta-Llama-3.1-8B-Instruct
+                       --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
+                  resources:
+                    limits:
+                      nvidia.com/gpu: "1"
+                  ports:
+                    - containerPort: 8080
+                  readinessProbe:
+                    tcpSocket:
+                      port: 8080
+                    initialDelaySeconds: 15
+                    periodSeconds: 10
+    - name: decode
+      spec:
+        leaderWorkerTemplate:
+          size: 1
+          workerTemplate:
+            metadata:
+              labels:
+                role: decode
+              annotations:
+                # Co-locate the decode role within one topology block.
+                kueue.x-k8s.io/podset-required-topology: cloud.google.com/gce-topology-block
+            spec:
+              containers:
+                - name: vllm
+                  image: vllm/vllm-openai:v0.28.0 # pinned; bump to the latest release
+                  env:
+                    - name: HF_TOKEN
+                      value: $HF_TOKEN
+                  command:
+                    - sh
+                    - -c
+                    - "python3 -m vllm.entrypoints.openai.api_server --port 8080
+                       --model meta-llama/Meta-Llama-3.1-8B-Instruct
+                       --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
+                  resources:
+                    limits:
+                      nvidia.com/gpu: "1"
+                  ports:
+                    - containerPort: 8080
+                  readinessProbe:
+                    tcpSocket:
+                      port: 8080
+                    initialDelaySeconds: 15
+                    periodSeconds: 10

--- a/docs/examples/leaderworkerset/topology-aware-scheduling/vllm-kueue.yaml
+++ b/docs/examples/leaderworkerset/topology-aware-scheduling/vllm-kueue.yaml
@@ -1,0 +1,107 @@
+# LeaderWorkerSet + Kueue topology-aware placement: vLLM.
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: vllm
+  labels:
+    # Kueue admits this workload through the "default" LocalQueue.
+    kueue.x-k8s.io/queue-name: default
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    # RecreateGroupAfterStart recreates the whole group on a pod restart, but
+    # only after the group has reached initial deployment stability.
+    restartPolicy: RecreateGroupAfterStart
+    leaderTemplate:
+      metadata:
+        labels:
+          role: leader
+        annotations:
+          # Groups the leader and workers of this replica into one Kueue
+          # scheduling unit so they are admitted and placed together.
+          kueue.x-k8s.io/podset-group-name: "vllm-multi-host"
+          # Require the whole group inside one topology domain (all-or-nothing:
+          # Kueue only admits the group if it fits entirely within one block).
+          kueue.x-k8s.io/podset-required-topology: "cloud.google.com/gce-topology-block"
+      spec:
+        containers:
+          - name: vllm-leader
+            image: vllm/vllm-openai:v0.28.0 # pinned; bump to the latest release
+            env:
+              - name: HF_TOKEN
+                value: $HF_TOKEN
+            command:
+              - vllm
+              - serve
+              - zai-org/GLM-4.6
+              - --port
+              - "8080"
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "2"
+              - --nnodes
+              - $(LWS_GROUP_SIZE)
+              - --node-rank
+              - $(LWS_WORKER_INDEX)
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --trust-remote-code
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+            ports:
+              - containerPort: 8080
+            readinessProbe:
+              tcpSocket:
+                port: 8080
+              initialDelaySeconds: 15
+              periodSeconds: 10
+            volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 15Gi
+    workerTemplate:
+      metadata:
+        annotations:
+          kueue.x-k8s.io/podset-group-name: "vllm-multi-host"
+          kueue.x-k8s.io/podset-required-topology: "cloud.google.com/gce-topology-block"
+      spec:
+        containers:
+          - name: vllm-worker
+            image: vllm/vllm-openai:v0.28.0 # pinned; bump to the latest release
+            command:
+              - vllm
+              - serve
+              - zai-org/GLM-4.6
+              - --tensor-parallel-size
+              - "8"
+              - --pipeline-parallel-size
+              - "2"
+              - --nnodes
+              - $(LWS_GROUP_SIZE)
+              - --node-rank
+              - $(LWS_WORKER_INDEX)
+              - --master-addr
+              - $(LWS_LEADER_ADDRESS)
+              - --headless
+              - --trust-remote-code
+            resources:
+              limits:
+                nvidia.com/gpu: "8"
+            env:
+              - name: HF_TOKEN
+                value: $HF_TOKEN
+            volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 15Gi

--- a/site/content/en/docs/examples/disaggregatedset/topology-aware-scheduling/_index.md
+++ b/site/content/en/docs/examples/disaggregatedset/topology-aware-scheduling/_index.md
@@ -16,9 +16,13 @@ There are two ways to do this. Pick based on how your cluster admits workloads:
 - **Native placement policies** — `spec.placementPolicy` built into
   DisaggregatedSet. No extra components. Use this when LWS schedules directly
   against the cluster.
-- **Kueue** — hand admission and placement to
-  [Kueue topology-aware scheduling (TAS)](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/).
-  Use this when Kueue already manages quota and admission for your cluster.
+- **Kueue** — Unlike the LeaderWorkerSet API, the DisaggregatedSet API doesn't
+  currently integrate directly with Kueue. You can still use
+  [Kueue topology-aware scheduling (TAS)](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/)
+  to manage the underlying LWS pod groups: colocate a pod group into one
+  topology domain, and allow more than one group to coexist in the same
+  topology domain. Use this when Kueue already manages quota and admission for
+  your cluster.
 
 ## Option 1: Native placement policies
 
@@ -49,7 +53,8 @@ for the full set of placement types.
 
 ## Option 2: Kueue topology-aware scheduling
 
-Kueue admits the DisaggregatedSet and asks the scheduler to pack each role
+The DisaggregatedSet API doesn't integrate directly with Kueue. Instead, Kueue
+admits the underlying LWS pod groups and asks the scheduler to pack each role
 (prefill and decode) into one topology domain. Use this when Kueue already
 manages quota and admission for your cluster.
 

--- a/site/content/en/docs/examples/disaggregatedset/topology-aware-scheduling/_index.md
+++ b/site/content/en/docs/examples/disaggregatedset/topology-aware-scheduling/_index.md
@@ -3,18 +3,31 @@ title: "Topology-aware scheduling"
 linkTitle: "Topology-aware scheduling"
 weight: 4
 description: >
-  Co-locate a slice's roles in one topology domain with placementPolicy.
+  Co-locate a slice's roles in one topology domain, with native placement or Kueue.
 ---
+
+Disaggregated prefill and decode roles exchange the KV cache, so bandwidth
+between them depends on how close their nodes sit in the data center.
+Topology-aware scheduling co-locates each slice's roles in one topology domain
+to raise that bandwidth.
+
+There are two ways to do this. Pick based on how your cluster admits workloads:
+
+- **Native placement policies** — `spec.placementPolicy` built into
+  DisaggregatedSet. No extra components. Use this when LWS schedules directly
+  against the cluster.
+- **Kueue** — hand admission and placement to
+  [Kueue topology-aware scheduling (TAS)](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/).
+  Use this when Kueue already manages quota and admission for your cluster.
+
+## Option 1: Native placement policies
 
 This guide is the [basic](../basic/) deployment plus topology-aware placement.
 `spec.placementPolicy` with `type: ExclusiveSlice` co-locates a slice's roles in
-one topology domain and spreads slices across domains, which raises bandwidth
-between the prefill and decode roles that exchange the KV cache.
+one topology domain and spreads slices across domains.
 
 Set `placementPolicy.topology` to your cluster's topology key (the example uses
 `cloud.google.com/gke-nodepool`). Nodes must be labeled with that key.
-
-## Deploy
 
 {{% tabpane text=true %}}
 {{% tab header="vLLM" %}}
@@ -33,3 +46,62 @@ curl https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/
 
 See the [placement policy concepts](../../../concepts/disaggregatedset/placement-policy/)
 for the full set of placement types.
+
+## Option 2: Kueue topology-aware scheduling
+
+Kueue admits the DisaggregatedSet and asks the scheduler to pack each role
+(prefill and decode) into one topology domain. Use this when Kueue already
+manages quota and admission for your cluster.
+
+Unlike the native `placementPolicy` feature, `kueue.x-k8s.io/podset-required-topology`
+is **all-or-nothing**: Kueue only admits a role if it fits entirely within one
+topology domain, and holds it otherwise. Prefer Kueue TAS when you want
+quota-gated, all-or-nothing placement; prefer native placement when LWS
+schedules directly against the cluster.
+
+### Install the Kueue controller
+
+```shell
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version=0.16.1 \
+  --create-namespace --namespace=kueue-system
+```
+
+### Define topology levels
+
+Give kueue-populator the levels of your data center topology and the node label
+that marks schedulable capacity. It creates the `Topology`, `ResourceFlavor`,
+`ClusterQueue`, and a `default` `LocalQueue`. The example uses GKE labels; set
+them to your cluster's.
+
+```yaml
+# topology.yaml
+kueuePopulator:
+  config:
+    topology:
+      levels:
+        - nodeLabel: "cloud.google.com/gce-topology-block"
+        - nodeLabel: "cloud.google.com/gce-topology-subblock"
+        - nodeLabel: "cloud.google.com/gce-topology-host"
+        - nodeLabel: "kubernetes.io/hostname"
+    resourceFlavor:
+      nodeLabels:
+        cloud.google.com/gke-gpu: "true"
+```
+
+```shell
+helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
+  --version=0.16.1 --namespace=kueue-system --create-namespace --wait \
+  -f topology.yaml
+```
+
+### Deploy
+
+The DisaggregatedSet carries `kueue.x-k8s.io/queue-name: default` so Kueue admits
+it, and `kueue.x-k8s.io/podset-required-topology` on each role's worker template
+to require that role inside one block. Set that annotation to the topology level
+you want.
+
+```shell
+export HF_TOKEN=<your-hf-token>
+curl https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/disaggregatedset/topology-aware-scheduling/vllm-kueue.yaml -s | envsubst | kubectl apply -f -
+```

--- a/site/content/en/docs/examples/leaderworkerset/topology-aware-scheduling/_index.md
+++ b/site/content/en/docs/examples/leaderworkerset/topology-aware-scheduling/_index.md
@@ -3,20 +3,35 @@ title: "Topology-aware scheduling"
 linkTitle: "Topology-aware scheduling"
 weight: 3
 description: >
-  Pin each replica group to a single topology domain with exclusive-topology.
+  Pin each replica group to a single topology domain, with native placement or Kueue.
 aliases:
 - /docs/examples/tas/
 ---
 
+AI inference workloads need constant pod-to-pod communication, so network
+bandwidth matters. The bandwidth between pods depends on how close their nodes
+sit in the data center. Topology-aware scheduling keeps each replica group
+within one topology domain to maximize it, which raises bandwidth for tensor and
+pipeline parallelism.
+
+There are two ways to do this. Pick based on how your cluster admits workloads:
+
+- **Native placement policies** — LWS's built-in
+  `leaderworkerset.sigs.k8s.io/exclusive-topology` annotation. No extra
+  components. Use this when LWS schedules directly against the cluster.
+- **Kueue** — hand admission and placement to
+  [Kueue topology-aware scheduling (TAS)](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/).
+  Use this when Kueue already manages quota and admission for your cluster, so
+  topology placement stays consistent with the rest of your gang scheduling.
+
+## Option 1: Native placement policies
+
 This guide is the [basic](../basic/) deployment plus topology-aware placement.
 The `leaderworkerset.sigs.k8s.io/exclusive-topology` annotation keeps each
-replica group within one topology domain and excludes other groups from it,
-which raises pod-to-pod bandwidth for tensor and pipeline parallelism.
+replica group within one topology domain and excludes other groups from it.
 
 Set the annotation value to your cluster's topology key (the example uses
 `cloud.google.com/gke-nodepool`). Nodes must be labeled with that key.
-
-## Deploy
 
 {{% tabpane text=true %}}
 {{% tab header="vLLM" %}}
@@ -32,5 +47,58 @@ curl https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/
 ```
 {{% /tab %}}
 {{% /tabpane %}}
+
+## Option 2: Kueue topology-aware scheduling
+
+Use this when Kueue already manages quota and admission for your cluster.
+
+[Kueue topology-aware scheduling (TAS)](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/)
+places the group through `kueue.x-k8s.io/podset-required-topology`. Unlike the
+native `exclusive-topology` feature, this is **all-or-nothing**: Kueue only
+admits the group if it fits entirely within one topology domain, and holds it
+otherwise. Native placement instead schedules the group without that admission
+gate. Prefer Kueue TAS when you want quota-gated, all-or-nothing placement;
+prefer native placement when LWS schedules directly against the cluster.
+
+### Define topology levels
+
+In a yaml file, define the levels of your topology and the resource type you
+schedule on.
+
+```yaml
+kueuePopulator:
+  config:
+    topology:
+      levels:
+        - nodeLabel: "cloud.google.com/gce-topology-block"
+        - nodeLabel: "cloud.google.com/gce-topology-subblock"
+        - nodeLabel: "cloud.google.com/gce-topology-host"
+        - nodeLabel: "kubernetes.io/hostname"
+    resourceFlavor:
+      nodeLabels:
+        cloud.google.com/gke-gpu: "true"
+```
+
+### Install the Kueue controller
+
+```shell
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version=0.16.1 \
+  --create-namespace --namespace=kueue-system
+```
+
+Now install kueue-populator, passing the topology definition:
+
+```shell
+helm install kueue-populator oci://registry.k8s.io/kueue/charts/kueue-populator \
+  --version=0.16.1 --namespace=kueue-system --create-namespace --wait \
+  -f <topology-yaml-file>
+```
+
+### Deploy
+
+```shell
+export HF_TOKEN=<your-hf-token>
+curl https://raw.githubusercontent.com/kubernetes-sigs/lws/refs/heads/main/docs/examples/leaderworkerset/topology-aware-scheduling/vllm-kueue.yaml -s | envsubst | kubectl apply -f -
+```
 
 See [basic](../basic/) for how to reach the service once pods are running.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it

#1021 dropped the LWS + Kueue topology-aware scheduling guide when it moved the examples to native placement. Native placement and Kueue TAS are separate paths, so this restores the vLLM guide alongside the native ones.

#### Which issue(s) this PR fixes

Part of #1030

#### Special notes for your reviewer

Scoped to restoring the existing vLLM guide. SGLang and DisaggregatedSet Kueue TAS guides are tracked separately in #1030.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
