### PR TITLE
Guard nil replicas and size in leaderworkerset webhook validation

### DIFF
--- a/pkg/webhooks/leaderworkerset_webhook.go
+++ b/pkg/webhooks/leaderworkerset_webhook.go
@@ -142,18 +142,30 @@ func (r *LeaderWorkerSetWebhook) generalValidate(lws *v1.LeaderWorkerSet) field.
 	// Since the lws name is used as the name for headless service, it must be DNS-1035 compliant
 	ValidateName := apivalidation.NameIsDNS1035Label
 	allErrs := apivalidation.ValidateObjectMeta(&lws.ObjectMeta, true, apivalidation.ValidateNameFunc(ValidateName), field.NewPath("metadata"))
-	// Ensure replicas and groups number are valid
-	replicas := *lws.Spec.Replicas
-	if replicas < 0 {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or greater than 0"))
+	// Ensure replicas and groups number are valid.
+	// replicas and size are backfilled to 1 by the CRD's OpenAPI schema default
+	// and by Default(), but this function can also run against an object that
+	// never picked either up (a CRD installed from an older revision, or a
+	// caller invoking the webhook logic directly), so neither is dereferenced
+	// unconditionally.
+	replicas := int32(1)
+	if lws.Spec.Replicas != nil {
+		replicas = *lws.Spec.Replicas
+		if replicas < 0 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or greater than 0"))
+		}
+		if replicas > 1000000 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or less than 1000000"))
+		}
 	}
-	if replicas > 1000000 {
-		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, "replicas must be equal or less than 1000000"))
+	size := int32(1)
+	if lws.Spec.LeaderWorkerTemplate.Size != nil {
+		size = *lws.Spec.LeaderWorkerTemplate.Size
 	}
-	if *lws.Spec.LeaderWorkerTemplate.Size < 1 {
+	if size < 1 {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("leaderWorkerTemplate", "size"), lws.Spec.LeaderWorkerTemplate.Size, "size must be equal or greater than 1"))
 	}
-	if int64(replicas)*int64(*lws.Spec.LeaderWorkerTemplate.Size) > math.MaxInt32 {
+	if int64(replicas)*int64(size) > math.MaxInt32 {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("replicas"), lws.Spec.Replicas, fmt.Sprintf("the product of replicas and worker replicas must not exceed %d", math.MaxInt32)))
 	}
 
@@ -284,13 +296,16 @@ func validateNonnegativeField(value int64, fldPath *field.Path) field.ErrorList 
 
 func validateUpdateSubGroupPolicy(specPath *field.Path, lws *v1.LeaderWorkerSet) field.ErrorList {
 	allErrs := field.ErrorList{}
-	size := int32(*lws.Spec.LeaderWorkerTemplate.Size)
 	subGroupSizePath := specPath.Child("leaderWorkerTemplate", "subGroupPolicy", "subGroupSize")
 	if lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize == nil {
 		return append(allErrs, field.Required(subGroupSizePath, "subGroupSize is required"))
 	}
 
 	subGroupSize := *lws.Spec.LeaderWorkerTemplate.SubGroupPolicy.SubGroupSize
+	size := int32(1)
+	if lws.Spec.LeaderWorkerTemplate.Size != nil {
+		size = *lws.Spec.LeaderWorkerTemplate.Size
+	}
 	if subGroupSize < 1 {
 		return append(allErrs, field.Invalid(subGroupSizePath, subGroupSize, "subGroupSize must be equal or greater than 1"))
 	}

--- a/pkg/webhooks/leaderworkerset_webhook_nil_defaults_test.go
+++ b/pkg/webhooks/leaderworkerset_webhook_nil_defaults_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	v1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+	"sigs.k8s.io/lws/test/wrappers"
+)
+
+// runValidateCreate calls ValidateCreate and turns a panic into a normal test
+// failure instead of crashing the whole test binary, so a regression is
+// reported as a clear assertion failure rather than a fatal signal.
+func runValidateCreate(t *testing.T, lws *v1.LeaderWorkerSet) error {
+	t.Helper()
+	webhook := &LeaderWorkerSetWebhook{}
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ValidateCreate panicked: %v", r)
+			}
+		}()
+		_, err = webhook.ValidateCreate(context.TODO(), lws)
+	}()
+	return err
+}
+
+// generalValidate reads replicas as a bare dereference, relying on the CRD
+// schema default and on Default() having run. Neither holds for an object that
+// reaches validation without them: a CRD installed from an older revision, or a
+// caller invoking ValidateCreate directly.
+func TestValidateCreateNilReplicas(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.Replicas = nil
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil replicas to be accepted, got: %v", err)
+	}
+}
+
+// size has the same dereference-before-nil-check shape as replicas, and unlike
+// replicas it is not backfilled by Default() either.
+func TestValidateCreateNilSize(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.Size = nil
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil size to be accepted, got: %v", err)
+	}
+}
+
+// validateUpdateSubGroupPolicy dereferences size as well, on a path reached
+// only when subGroupPolicy is set, so it needs its own case.
+func TestValidateCreateNilSizeWithSubGroupPolicy(t *testing.T) {
+	lws := wrappers.BuildLeaderWorkerSet("default").Obj()
+	lws.Spec.LeaderWorkerTemplate.Size = nil
+	lws.Spec.LeaderWorkerTemplate.SubGroupPolicy = &v1.SubGroupPolicy{
+		SubGroupSize: ptr.To[int32](1),
+	}
+
+	if err := runValidateCreate(t, lws); err != nil {
+		t.Errorf("expected nil size with subGroupPolicy to be accepted, got: %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**

`generalValidate` reads `replicas` as a bare dereference, relying on the CRD schema default and on `Default()` having run. `leaderWorkerTemplate.size` is dereferenced unguarded in both `generalValidate` and `validateUpdateSubGroupPolicy`, and is not backfilled by `Default()` at all.

An object that reaches validation without those defaults, from a CRD installed at an older revision or from a caller invoking `ValidateCreate` directly, panics the webhook instead of being accepted or rejected normally.

Both are now read through a nil check that falls back to `1`, matching the schema default.

**Relationship to #932**

This is a follow-up on the same function. #932 fixed the `subGroupPolicy` nil-pointer and divide-by-zero panics, and moved `replicas` from a guarded read to a bare one, on the basis that `Default()` now backfills it. That holds on the normal admission path but not when validation runs without defaulting, which is the case these three tests cover.

The existing `nil replicas should be defaulted` test does not catch it: it calls `Default()` before `ValidateCreate`, so the bare dereference always sees a backfilled value.

**Testing**

Three tests calling `ValidateCreate` directly, with a `recover()` so a regression fails as a normal assertion instead of crashing the test binary. All three panic against `main` without this change:

```
--- FAIL: TestValidateCreateNilReplicas (0.00s)
    ValidateCreate panicked: runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestValidateCreateNilSize (0.00s)
    ValidateCreate panicked: runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestValidateCreateNilSizeWithSubGroupPolicy (0.00s)
    ValidateCreate panicked: runtime error: invalid memory address or nil pointer dereference
```

Supersedes #1029, which was opened before #932 merged and is now mostly redundant with it.

/cc @ahg-g

🤖 Generated with [Claude Code](https://claude.com/claude-code)
