### PR TITLE
docs: state the supported Kubernetes versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,26 @@ Read the [documentation](https://lws.sigs.k8s.io/docs/) or watch the [related ta
 
 ## Installation
 
+**Requires a Kubernetes cluster running version 1.33 through 1.36.** These are the versions
+exercised by the required end-to-end presubmit jobs; see the [support policy](#kubernetes-version-support-policy).
+
 Read the [installation guide](https://lws.sigs.k8s.io/docs/installation/) to learn more.
+
+### Kubernetes version support policy
+
+LWS is tested against the following Kubernetes versions on every pull request, via the
+required `pull-lws-test-e2e-main-1-<minor>` presubmit jobs:
+
+| Kubernetes | Kind node image used in CI |
+| --- | --- |
+| 1.33 | `kindest/node:v1.33.12` |
+| 1.34 | `kindest/node:v1.34.8` |
+| 1.35 | `kindest/node:v1.35.5` |
+| 1.36 | `kindest/node:v1.36.1` |
+
+Results for these jobs are published on
+[TestGrid](https://testgrid.k8s.io/sig-apps#Summary&include-filter-by-regex=lws).
+Versions outside this range are not covered by CI and are used at your own risk.
 
 ## Examples
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -26,8 +26,12 @@ description: >
 
 Make sure the following conditions are met:
 
-- A Kubernetes cluster with version >= 1.26 is **Required**, or it will behave unexpected. Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
-    - For any cluster with version 1.26, you need to enable the [feature gate][feature_gate] for [Start Ordinal][start_ordinal] manually. For version greater than 1.26, it's enabled by default.
+- A Kubernetes cluster running version **1.33 through 1.36** is **Required**. These are the
+  versions exercised by the required end-to-end presubmit jobs
+  (`pull-lws-test-e2e-main-1-33` through `pull-lws-test-e2e-main-1-36`), whose results are
+  published on [TestGrid](https://testgrid.k8s.io/sig-apps#Summary&include-filter-by-regex=lws).
+  Versions outside this range are not covered by CI and are used at your own risk.
+  Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
     - Rolling update with max unavailable Pods, you must enable the [MaxUnavailableStatefulSet][max_unavailable] feature gate, which is still in alpha since Kubernetes v1.24, see discussion [here][max_unavailable_enhancement]. Or lws will roll out the pods one by one.
 - Your cluster has at least 1 node with 1+ CPUs and 1G of memory available for the LeaderWorkerSet controller manager Deployment to run on. **NOTE: On some cloud providers, the default node machine type will not have sufficient resources to run the LeaderWorkerSet controller manager and all the required kube-system pods, so you'll need to use a larger
 machine type for your nodes.**
@@ -253,8 +257,6 @@ helm upgrade lws oci://registry.k8s.io/lws/charts/lws \
   --set enableDisaggregatedSet=true
 ```
 
-[feature_gate]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
-[start_ordinal]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#start-ordinal
 [max_unavailable]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#maximum-unavailable-pods
 [max_unavailable_enhancement]: https://github.com/kubernetes/enhancements/issues/961
 [helm_charts]: https://github.com/kubernetes-sigs/lws/releases


### PR DESCRIPTION
## What this PR does / why we need it

The installation guide still asked for Kubernetes `>= 1.26`, while CI only
exercises 1.33 through 1.36. Users had no accurate public statement of what is
actually tested.

This replaces the stale requirement with the real range and makes the claim
verifiable:

- Lists the four Kind node images the required e2e presubmits actually run
  against (`v1.33.12`, `v1.34.8`, `v1.35.5`, `v1.36.1`), taken from
  `config/jobs/kubernetes-sigs/lws/lws-presubmit.yaml` in kubernetes/test-infra
  rather than restated from memory.
- Links TestGrid so the table can be checked against reality.
- Adds the same statement to the README next to the installation pointer,
  following the pattern JobSet uses.

It also drops the note about manually enabling the Start Ordinal feature gate on
1.26 — that cannot apply once 1.33 is the floor. The two link definitions it
used (`[feature_gate]`, `[start_ordinal]`) are removed with it, since nothing
else in the file referenced them.

Not included: the `max_unavailable` note is left as-is. MaxUnavailableStatefulSet
is still alpha, so that caveat is independent of the version floor.

This PR was written in part with the assistance of generative AI.

## Which issue(s) this PR fixes

Fixes kubernetes-sigs/lws#1024

## Special notes for your reviewer

The version table is derived from the presubmit config, not from the issue text —
worth a second pair of eyes on whether you want the exact patch versions listed
(they drift when test-infra bumps the Kind images) or only the minor versions.
Happy to switch to minors only if you prefer lower maintenance.

## Does this PR introduce a user-facing change?

```release-note
NONE
