### PR TITLE
test: cover the PodGroup minimum resource calculation

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,6 +20,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
 )
 
 func Test_SortByIndex(t *testing.T) {
@@ -59,6 +64,103 @@ func Test_SortByIndex(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result: (-want, +got) %s", diff)
+			}
+		})
+	}
+}
+
+func Test_CalculatePGMinResources(t *testing.T) {
+	// container returns a container requesting the given amount of cpu, so that
+	// each test case can express expectations as plain multiples of that request.
+	container := func(cpu string) corev1.Container {
+		return corev1.Container{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse(cpu),
+				},
+			},
+		}
+	}
+	podSpec := func(cpu string) corev1.PodSpec {
+		return corev1.PodSpec{Containers: []corev1.Container{container(cpu)}}
+	}
+
+	testCases := []struct {
+		name string
+		lws  *leaderworkerset.LeaderWorkerSet
+		want corev1.ResourceList
+	}{
+		{
+			// Size counts the leader, so a group of 3 reserves one leader plus
+			// two workers, not three workers.
+			name: "leader plus size-1 workers",
+			lws: &leaderworkerset.LeaderWorkerSet{
+				Spec: leaderworkerset.LeaderWorkerSetSpec{
+					LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+						Size:           ptr.To[int32](3),
+						LeaderTemplate: &corev1.PodTemplateSpec{Spec: podSpec("1")},
+						WorkerTemplate: corev1.PodTemplateSpec{Spec: podSpec("2")},
+					},
+				},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5")},
+		},
+		{
+			// A group of one is just the leader; the size-1 worker term must not
+			// underflow into a negative loop count.
+			name: "size one reserves the leader only",
+			lws: &leaderworkerset.LeaderWorkerSet{
+				Spec: leaderworkerset.LeaderWorkerSetSpec{
+					LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+						Size:           ptr.To[int32](1),
+						LeaderTemplate: &corev1.PodTemplateSpec{Spec: podSpec("1")},
+						WorkerTemplate: corev1.PodTemplateSpec{Spec: podSpec("2")},
+					},
+				},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+		{
+			// An unset size defaults to 1, which again means leader only. Guards
+			// against the default changing without the reservation changing.
+			name: "unset size defaults to one",
+			lws: &leaderworkerset.LeaderWorkerSet{
+				Spec: leaderworkerset.LeaderWorkerSetSpec{
+					LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+						LeaderTemplate: &corev1.PodTemplateSpec{Spec: podSpec("1")},
+						WorkerTemplate: corev1.PodTemplateSpec{Spec: podSpec("2")},
+					},
+				},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+		{
+			// Without a leader template the leader runs the worker spec, so the
+			// reservation is size copies of the worker request.
+			name: "no leader template falls back to the worker template",
+			lws: &leaderworkerset.LeaderWorkerSet{
+				Spec: leaderworkerset.LeaderWorkerSetSpec{
+					LeaderWorkerTemplate: leaderworkerset.LeaderWorkerTemplate{
+						Size:           ptr.To[int32](3),
+						WorkerTemplate: corev1.PodTemplateSpec{Spec: podSpec("2")},
+					},
+				},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("6")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CalculatePGMinResources(tc.lws)
+			for name, wantQty := range tc.want {
+				gotQty, ok := got[name]
+				if !ok {
+					t.Fatalf("resource %s missing from result %v", name, got)
+				}
+				if gotQty.Cmp(wantQty) != 0 {
+					t.Errorf("%s: got %s, want %s", name, gotQty.String(), wantQty.String())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it

`CalculatePGMinResources` decides how much capacity a gang-scheduled PodGroup
reserves, so an off-by-one in the worker count or a missed template fallback
silently over- or under-reserves. It had no test coverage.

This adds four table-driven cases, one per behaviour the function actually
encodes:

| Case | Behaviour it pins down |
| --- | --- |
| `leader plus size-1 workers` | `Size` counts the leader, so a group of 3 reserves one leader plus two workers |
| `size one reserves the leader only` | the `size-1` worker term must not turn into a negative loop count |
| `unset size defaults to one` | an unset `Size` defaults to 1, i.e. leader only |
| `no leader template falls back to the worker template` | with no leader template the leader runs the worker spec, so the reservation is `size` copies of the worker request |

Each case was verified by mutation rather than by coverage percentage — I broke
the source three ways and checked that exactly the guarding case went red:

- dropping the `- 1` from the worker count → `leader plus size-1 workers` (got 7,
  want 5) and `size one` (got 3, want 1) fail
- changing the size default from 1 to 2 → only `unset size defaults to one`
  fails (got 3, want 1)
- replacing the nil-leader-template fallback with an empty spec → only
  `no leader template falls back...` fails (got 4, want 6)

Coverage for the function goes 0% → 100%, and the package goes 27.6% → 62.1%,
but the mutation results above are the reason I picked this function rather than
the other uncovered helpers in the file (`Sha1Hash` is a thin wrapper over the
stdlib, and `GetOperatorNamespace` reads a fixed absolute path so it would need a
production-code change to be injectable — happy to open a separate issue for that
if you think it is worth doing).

This PR was written in part with the assistance of generative AI.

## Which issue(s) this PR fixes

None — this is a small unsolicited test addition. Happy to fold it into an issue
if you would rather track it.

## Special notes for your reviewer

Assertions compare `resource.Quantity` with `Cmp` rather than `cmp.Diff`, because
`MustParse("5")` and the summed quantity have different internal formats while
being numerically equal. If you would rather see `cmp.Diff` on a normalised form,
say so and I will switch.

## Does this PR introduce a user-facing change?

```release-note
NONE
