### PR TITLE
fix: bound disaggregatedset kubectl queries

### DIFF
--- a/test/e2e/disaggregatedset/e2e_test.go
+++ b/test/e2e/disaggregatedset/e2e_test.go
@@ -157,13 +157,20 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			By("verifying LWS resources are created for both roles")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.CountLWSByRole(deploymentName, "prefill")).To(Equal(1))
-				g.Expect(kubectl.CountLWSByRole(deploymentName, "decode")).To(Equal(1))
+				count, err := kubectl.CountLWSByRole(deploymentName, "prefill")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(1))
+
+				count, err = kubectl.CountLWSByRole(deploymentName, "decode")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(1))
 			}, 60*time.Second, time.Second).Should(Succeed())
 
 			By("verifying pods become ready")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.CountRunningPods(deploymentName)).To(Equal(2))
+				count, err := kubectl.CountRunningPods(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(2))
 			}, 90*time.Second, time.Second).Should(Succeed())
 		})
 	})
@@ -187,7 +194,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("waiting for initial deployment to stabilize")
 			kubectl.ForRunningPodCount(deploymentName, 4)
 
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("triggering rolling update by changing image")
@@ -202,7 +210,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			By("verifying Services from old revisions are garbage collected via their owning LWS")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.CountService(deploymentName)).To(Equal(2))
+				count, err := kubectl.CountService(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(2))
 			}, kubectl.DefaultTimeout, kubectl.DefaultInterval).Should(Succeed())
 
 			By("verifying no orphaned single-role workloads exist")
@@ -252,7 +262,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("waiting for initial deployment to stabilize")
 			kubectl.ForRunningPodCount(deploymentName, 8)
 
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("triggering rolling update by changing image")
@@ -532,8 +543,10 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			// recreating force-deleted pods, and terminating ExclusiveTopology
 			// pods still repel other sets' pods. Wait until the pods are fully
 			// gone so later specs can schedule on a single-node cluster.
-			Eventually(func() int {
-				return kubectl.CountPods(deploymentName)
+			Eventually(func(g Gomega) int {
+				count, err := kubectl.CountPods(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				return count
 			}, 90*time.Second, time.Second).Should(Equal(0))
 		})
 
@@ -574,9 +587,17 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			By("waiting for resources to be created")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.CountLWS(deploymentName)).To(Equal(2))
-				g.Expect(kubectl.CountRunningPods(deploymentName)).To(Equal(2))
-				g.Expect(kubectl.CountService(deploymentName)).To(Equal(2))
+				lwsCount, err := kubectl.CountLWS(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(lwsCount).To(Equal(2))
+
+				runningPodCount, err := kubectl.CountRunningPods(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(runningPodCount).To(Equal(2))
+
+				serviceCount, err := kubectl.CountService(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(serviceCount).To(Equal(2))
 			}, 90*time.Second, time.Second).Should(Succeed())
 
 			By("deleting the DisaggregatedSet")
@@ -588,7 +609,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			By("verifying all Services are garbage collected")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.CountService(deploymentName)).To(Equal(0))
+				count, err := kubectl.CountService(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(Equal(0))
 			}, 30*time.Second, time.Second).Should(Succeed())
 
 			By("verifying all pods are removed")
@@ -668,7 +691,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 				kubectl.ForRunningPodCountWithTimeout(deploymentName, expectedInitialPods, 3*time.Minute)
 
 				// Get the initial revision
-				oldRevision := kubectl.GetRevision(deploymentName)
+				oldRevision, err := kubectl.GetRevision(deploymentName)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(oldRevision).NotTo(BeEmpty())
 				_, _ = fmt.Fprintf(GinkgoWriter, "Initial revision: %s\n", oldRevision)
 
@@ -774,7 +798,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			By("verifying 3 LWS resources exist (one per role)")
 			kubectl.ForLWSCount(deploymentName, 3)
 
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("triggering rolling update by changing image")
@@ -819,7 +844,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 6, 3*time.Minute)
 
 			// Get the initial revision
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("applying update that renames 'encode' to 'decode-long-context'")
@@ -842,7 +868,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				// Verify encode role from old revision is scaled to 0
-				g.Expect(kubectl.GetTotalReplicas(deploymentName, oldRevision)).To(Equal(0))
+				replicas, err := kubectl.GetTotalReplicas(deploymentName, oldRevision)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(replicas).To(Equal(0))
 			}, 60*time.Second, time.Second).Should(Succeed())
 
 			By("verifying total running pods is correct")
@@ -872,7 +900,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 5, 3*time.Minute)
 
 			By("recording initial revision")
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("adding new role 'gamma'")
@@ -920,7 +949,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 10, 3*time.Minute)
 
 			By("recording initial revision")
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("adding new role 'encode' - this should trigger progressive rollout")
@@ -935,7 +965,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(updatedYaml)).To(Succeed())
 
 			By("tracking rollout to verify progressive scaling (not brutal drain)")
-			result := kubectl.TrackProgressiveRollout(deploymentName, oldRevision, 10, 12)
+			result, err := kubectl.TrackProgressiveRollout(deploymentName, oldRevision, 10, 12)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying progressive rollout occurred (not brutal drain)")
 			Expect(result.SawIntermediateOld || result.SawIntermediateNew).To(BeTrue(),
@@ -975,7 +1006,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 12, 3*time.Minute)
 
 			By("recording initial revision")
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("removing 'encode' role - this should trigger progressive rollout")
@@ -989,7 +1021,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(updatedYaml)).To(Succeed())
 
 			By("tracking rollout to verify progressive scaling")
-			result := kubectl.TrackProgressiveRollout(deploymentName, oldRevision, 12, 10)
+			result, err := kubectl.TrackProgressiveRollout(deploymentName, oldRevision, 12, 10)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying progressive rollout occurred")
 			Expect(result.SawIntermediateOld || result.SawIntermediateNew).To(BeTrue(),
@@ -1000,7 +1033,9 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 
 			By("verifying encode role no longer exists or has 0 replicas")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.GetTotalReplicas(deploymentName, oldRevision)).To(Equal(0))
+				replicas, err := kubectl.GetTotalReplicas(deploymentName, oldRevision)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(replicas).To(Equal(0))
 			}, 30*time.Second, time.Second).Should(Succeed())
 
 			By("verifying total running pods (no encode role)")
@@ -1023,7 +1058,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			).YAML()
 			Expect(applyYAML(yamlA)).To(Succeed())
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 12, 3*time.Minute)
-			revisionA := kubectl.GetRevision(deploymentName)
+			revisionA, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(revisionA).NotTo(BeEmpty())
 			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Revision A (stable original): %s ===\n", revisionA)
 
@@ -1035,8 +1071,10 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			Expect(applyYAML(yamlB)).To(Succeed())
 
 			By("waiting for B rollout to start (new LWS created)")
-			Eventually(func() int {
-				return kubectl.CountLWS(deploymentName)
+			Eventually(func(g Gomega) int {
+				count, err := kubectl.CountLWS(deploymentName)
+				g.Expect(err).NotTo(HaveOccurred())
+				return count
 			}, 30*time.Second, time.Second).Should(BeNumerically(">", 2))
 
 			// Find revision B
@@ -1098,9 +1136,12 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			aDrainedBeforeB := false
 
 			Eventually(func(g Gomega) bool {
-				aTotal := kubectl.GetTotalReplicas(deploymentName, revisionA)
-				bTotal := kubectl.GetTotalReplicas(deploymentName, revisionB)
-				cTotal := kubectl.GetTotalReplicas(deploymentName, revisionC)
+				aTotal, err := kubectl.GetTotalReplicas(deploymentName, revisionA)
+				g.Expect(err).NotTo(HaveOccurred())
+				bTotal, err := kubectl.GetTotalReplicas(deploymentName, revisionB)
+				g.Expect(err).NotTo(HaveOccurred())
+				cTotal, err := kubectl.GetTotalReplicas(deploymentName, revisionC)
+				g.Expect(err).NotTo(HaveOccurred())
 
 				_, _ = fmt.Fprintf(GinkgoWriter, "A(%s)=%d  B(%s)=%d  C(%s)=%d\n",
 					revisionA[:8], aTotal, revisionB[:8], bTotal, revisionC[:8], cTotal)
@@ -1147,7 +1188,8 @@ var _ = Describe("DisaggregatedSet E2E Tests", Ordered, func() {
 			kubectl.ForRunningPodCountWithTimeout(deploymentName, 10, 3*time.Minute)
 
 			By("recording initial revision")
-			oldRevision := kubectl.GetRevision(deploymentName)
+			oldRevision, err := kubectl.GetRevision(deploymentName)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(oldRevision).NotTo(BeEmpty())
 
 			By("renaming 'zeta' to 'gamma' (remove zeta, add gamma)")

--- a/test/e2e/disaggregatedset/hpa_test.go
+++ b/test/e2e/disaggregatedset/hpa_test.go
@@ -61,13 +61,19 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", func() {
 
 			By("waiting for the controller to auto-create the scaler")
 			Eventually(func(g Gomega) {
-				_, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default", "-o", "name"))
+				_, err := utils.Run(exec.Command(
+					"kubectl", "get", "dsrs", scalerName,
+					"-n", "default", "-o", "name",
+				))
 				g.Expect(err).NotTo(HaveOccurred())
 			}).Should(Succeed())
 
 			By("verifying the scaler carries the parent DS as controller ownerRef")
-			out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-				"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+			out, err := utils.Run(exec.Command(
+				"kubectl", "get", "dsrs", scalerName,
+				"-n", "default",
+				"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`,
+			))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strings.TrimSpace(out)).To(Equal(dsName))
 
@@ -79,7 +85,8 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", func() {
 			// AbleToScale=False / FailedGetScale.
 			scaleURL := fmt.Sprintf(
 				"/apis/disaggregatedset.x-k8s.io/v1/namespaces/default/disaggregatedsetrolescalers/%s/scale",
-				scalerName)
+				scalerName,
+			)
 			Eventually(func(g Gomega) {
 				raw, err := utils.Run(exec.Command("kubectl", "get", "--raw", scaleURL))
 				g.Expect(err).NotTo(HaveOccurred(),
@@ -109,20 +116,32 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", func() {
 
 			By("waiting for the scaler to exist")
 			Eventually(func(g Gomega) {
-				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+				out, err := utils.Run(exec.Command(
+					"kubectl", "get", "dsrs", scalerName,
+					"-n", "default",
+					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`,
+				))
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(out)).To(Equal(dsName))
 			}).Should(Succeed())
 
 			By("writing spec.replicas=3 via the /scale subresource (same call HPA/KEDA use)")
-			_, err := utils.Run(exec.Command("kubectl", "scale",
-				"disaggregatedsetrolescaler/"+scalerName, "-n", "default", "--replicas=3"))
+			_, err := utils.Run(exec.Command(
+				"kubectl", "scale",
+				"disaggregatedsetrolescaler/"+scalerName,
+				"-n", "default",
+				"--replicas=3",
+			))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the LWS for prefill scales to 3")
 			Eventually(func(g Gomega) {
-				g.Expect(kubectl.GetTotalReplicas(dsName, kubectl.GetRevision(dsName))).To(BeNumerically(">=", 3))
+				revision, err := kubectl.GetRevision(dsName)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				replicas, err := kubectl.GetTotalReplicas(dsName, revision)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(replicas).To(BeNumerically(">=", 3))
 			}).Should(Succeed())
 		})
 	})
@@ -146,20 +165,30 @@ var _ = Describe("DisaggregatedSet HPA External Scaling", func() {
 
 			By("waiting for the scaler to exist")
 			Eventually(func(g Gomega) {
-				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`))
+				out, err := utils.Run(exec.Command(
+					"kubectl", "get", "dsrs", scalerName,
+					"-n", "default",
+					"-o", `jsonpath={.metadata.ownerReferences[?(@.controller==true)].name}`,
+				))
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(out)).To(Equal(dsName))
 			}).Should(Succeed())
 
 			By("deleting the DisaggregatedSet")
-			_, err := kubectl.Delete("disaggregatedset", dsName).Namespace("default").Run()
+			_, err := kubectl.Delete("disaggregatedset", dsName).
+				Namespace("default").
+				Timeout("30s").
+				Run()
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the scaler is garbage-collected")
 			Eventually(func(g Gomega) {
-				out, err := utils.Run(exec.Command("kubectl", "get", "dsrs", scalerName, "-n", "default",
-					"--ignore-not-found", "-o", "name"))
+				out, err := utils.Run(exec.Command(
+					"kubectl", "get", "dsrs", scalerName,
+					"-n", "default",
+					"--ignore-not-found",
+					"-o", "name",
+				))
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(out)).To(BeEmpty())
 			}).Should(Succeed())

--- a/test/testutils/disaggregatedset/kubectl/kubectl.go
+++ b/test/testutils/disaggregatedset/kubectl/kubectl.go
@@ -115,6 +115,12 @@ func (b *Builder) Timeout(duration string) *Builder {
 	return b
 }
 
+// RequestTimeout adds --request-timeout flag.
+func (b *Builder) RequestTimeout(duration string) *Builder {
+	b.flags = append(b.flags, "--request-timeout="+duration)
+	return b
+}
+
 // NoHeaders adds --no-headers flag.
 func (b *Builder) NoHeaders() *Builder {
 	b.flags = append(b.flags, "--no-headers")

--- a/test/testutils/disaggregatedset/kubectl/queries.go
+++ b/test/testutils/disaggregatedset/kubectl/queries.go
@@ -44,7 +44,7 @@ func LWSByRevision(deploymentName, revision string) *Builder {
 func LWSNotRevision(deploymentName, revision string) *Builder {
 	return Get("lws").
 		Label(labelName, deploymentName).
-		Label(labelRevision+"!=", revision).
+		LabelNot(labelRevision, revision).
 		Namespace(defaultNS)
 }
 
@@ -98,7 +98,10 @@ func EndpointSliceByRole(deploymentName, role string) *Builder {
 
 // CountPods returns the number of pods for a deployment.
 func CountPods(deploymentName string) int {
-	output, err := Pods(deploymentName).Output("name").RunQuiet()
+	output, err := Pods(deploymentName).
+		Output("name").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -107,7 +110,10 @@ func CountPods(deploymentName string) int {
 
 // CountRunningPods returns the number of running pods for a deployment.
 func CountRunningPods(deploymentName string) int {
-	output, err := RunningPods(deploymentName).NoHeaders().RunQuiet()
+	output, err := RunningPods(deploymentName).
+		NoHeaders().
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -116,7 +122,10 @@ func CountRunningPods(deploymentName string) int {
 
 // CountLWS returns the number of LWS resources for a deployment.
 func CountLWS(deploymentName string) int {
-	output, err := LWS(deploymentName).Output("name").RunQuiet()
+	output, err := LWS(deploymentName).
+		Output("name").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -125,7 +134,10 @@ func CountLWS(deploymentName string) int {
 
 // CountLWSByRole returns the number of LWS for a deployment and role.
 func CountLWSByRole(deploymentName, role string) int {
-	output, err := LWSByRole(deploymentName, role).Output("name").RunQuiet()
+	output, err := LWSByRole(deploymentName, role).
+		Output("name").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -134,7 +146,10 @@ func CountLWSByRole(deploymentName, role string) int {
 
 // CountService returns the number of services for a deployment.
 func CountService(deploymentName string) int {
-	output, err := Service(deploymentName).Output("name").RunQuiet()
+	output, err := Service(deploymentName).
+		Output("name").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -146,7 +161,9 @@ func CountService(deploymentName string) int {
 // GetTotalReplicas returns total replicas across all LWS for a revision.
 func GetTotalReplicas(deploymentName, revision string) int {
 	output, err := LWSByRevision(deploymentName, revision).
-		JSONPath("{range .items[*]}{.spec.replicas} {end}").RunQuiet()
+		JSONPath("{range .items[*]}{.spec.replicas} {end}").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -156,7 +173,9 @@ func GetTotalReplicas(deploymentName, revision string) int {
 // GetTotalReplicasNotRevision returns total replicas for LWS NOT matching revision.
 func GetTotalReplicasNotRevision(deploymentName, revision string) int {
 	output, err := LWSNotRevision(deploymentName, revision).
-		JSONPath("{range .items[*]}{.spec.replicas} {end}").RunQuiet()
+		JSONPath("{range .items[*]}{.spec.replicas} {end}").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return 0
 	}
@@ -166,7 +185,9 @@ func GetTotalReplicasNotRevision(deploymentName, revision string) int {
 // GetRevision returns the revision label of the first LWS for a deployment.
 func GetRevision(deploymentName string) string {
 	output, err := LWS(deploymentName).
-		JSONPath("{.items[0].metadata.labels.disaggregatedset\\.x-k8s\\.io/revision}").RunQuiet()
+		JSONPath("{.items[0].metadata.labels.disaggregatedset\\.x-k8s\\.io/revision}").
+		Timeout("30s").
+		RunQuiet()
 	if err != nil {
 		return ""
 	}
@@ -201,9 +222,38 @@ func sumInts(output string) int {
 
 // CleanupDeployment removes a DisaggregatedSet and all related resources.
 func CleanupDeployment(deploymentName string) {
-	_, _ = Delete("disaggregatedset", deploymentName).Namespace(defaultNS).IgnoreNotFound().Timeout("30s").RunQuiet()
-	_, _ = Delete("lws").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().Timeout("30s").RunQuiet()
-	_, _ = Delete("pods").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().GracePeriod(0).Force().RunQuiet()
-	_, _ = Delete("svc").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().RunQuiet()
-	_, _ = Delete("dsrs").Label(labelName, deploymentName).Namespace(defaultNS).IgnoreNotFound().RunQuiet()
+	_, _ = Delete("disaggregatedset", deploymentName).
+		Namespace(defaultNS).
+		IgnoreNotFound().
+		Timeout("30s").
+		RunQuiet()
+
+	_, _ = Delete("lws").
+		Label(labelName, deploymentName).
+		Namespace(defaultNS).
+		IgnoreNotFound().
+		Timeout("30s").
+		RunQuiet()
+
+	_, _ = Delete("pods").
+		Label(labelName, deploymentName).
+		Namespace(defaultNS).
+		IgnoreNotFound().
+		GracePeriod(0).
+		Force().
+		Timeout("30s").
+		RunQuiet()
+
+	_, _ = Delete("svc").
+		Label(labelName, deploymentName).
+		Namespace(defaultNS).
+		IgnoreNotFound().
+		Timeout("30s").
+		RunQuiet()
+
+	_, _ = Delete("dsrs").
+		Label(labelName, deploymentName).
+		Namespace(defaultNS).
+		IgnoreNotFound().
+		RunQuiet()
 }

--- a/test/testutils/disaggregatedset/kubectl/queries.go
+++ b/test/testutils/disaggregatedset/kubectl/queries.go
@@ -97,101 +97,101 @@ func EndpointSliceByRole(deploymentName, role string) *Builder {
 // --- Counting Helpers ---
 
 // CountPods returns the number of pods for a deployment.
-func CountPods(deploymentName string) int {
+func CountPods(deploymentName string) (int, error) {
 	output, err := Pods(deploymentName).
 		Output("name").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return len(GetNonEmptyLines(output))
+	return len(GetNonEmptyLines(output)), nil
 }
 
 // CountRunningPods returns the number of running pods for a deployment.
-func CountRunningPods(deploymentName string) int {
+func CountRunningPods(deploymentName string) (int, error) {
 	output, err := RunningPods(deploymentName).
 		NoHeaders().
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return len(GetNonEmptyLines(output))
+	return len(GetNonEmptyLines(output)), nil
 }
 
 // CountLWS returns the number of LWS resources for a deployment.
-func CountLWS(deploymentName string) int {
+func CountLWS(deploymentName string) (int, error) {
 	output, err := LWS(deploymentName).
 		Output("name").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return len(GetNonEmptyLines(output))
+	return len(GetNonEmptyLines(output)), nil
 }
 
 // CountLWSByRole returns the number of LWS for a deployment and role.
-func CountLWSByRole(deploymentName, role string) int {
+func CountLWSByRole(deploymentName, role string) (int, error) {
 	output, err := LWSByRole(deploymentName, role).
 		Output("name").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return len(GetNonEmptyLines(output))
+	return len(GetNonEmptyLines(output)), nil
 }
 
 // CountService returns the number of services for a deployment.
-func CountService(deploymentName string) int {
+func CountService(deploymentName string) (int, error) {
 	output, err := Service(deploymentName).
 		Output("name").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return len(GetNonEmptyLines(output))
+	return len(GetNonEmptyLines(output)), nil
 }
 
 // --- Replica Helpers ---
 
 // GetTotalReplicas returns total replicas across all LWS for a revision.
-func GetTotalReplicas(deploymentName, revision string) int {
+func GetTotalReplicas(deploymentName, revision string) (int, error) {
 	output, err := LWSByRevision(deploymentName, revision).
 		JSONPath("{range .items[*]}{.spec.replicas} {end}").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return sumInts(output)
+	return sumInts(output), nil
 }
 
 // GetTotalReplicasNotRevision returns total replicas for LWS NOT matching revision.
-func GetTotalReplicasNotRevision(deploymentName, revision string) int {
+func GetTotalReplicasNotRevision(deploymentName, revision string) (int, error) {
 	output, err := LWSNotRevision(deploymentName, revision).
 		JSONPath("{range .items[*]}{.spec.replicas} {end}").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return sumInts(output)
+	return sumInts(output), nil
 }
 
 // GetRevision returns the revision label of the first LWS for a deployment.
-func GetRevision(deploymentName string) string {
+func GetRevision(deploymentName string) (string, error) {
 	output, err := LWS(deploymentName).
 		JSONPath("{.items[0].metadata.labels.disaggregatedset\\.x-k8s\\.io/revision}").
 		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return strings.TrimSpace(output)
+	return strings.TrimSpace(output), nil
 }
 
 // --- Utility Functions ---

--- a/test/testutils/disaggregatedset/kubectl/queries.go
+++ b/test/testutils/disaggregatedset/kubectl/queries.go
@@ -89,7 +89,7 @@ func EndpointSlice(deploymentName string) *Builder {
 	return Get("endpointslice").Label(labelName, deploymentName).Namespace(defaultNS)
 }
 
-// EndpointSliceByRole returns a builder for querying endpoint slices by role.
+// EndpointSliceByRole returns a builder for querying endpoint slices by deployment and role.
 func EndpointSliceByRole(deploymentName, role string) *Builder {
 	return EndpointSlice(deploymentName).Label(labelRole, role)
 }
@@ -100,7 +100,7 @@ func EndpointSliceByRole(deploymentName, role string) *Builder {
 func CountPods(deploymentName string) int {
 	output, err := Pods(deploymentName).
 		Output("name").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -112,7 +112,7 @@ func CountPods(deploymentName string) int {
 func CountRunningPods(deploymentName string) int {
 	output, err := RunningPods(deploymentName).
 		NoHeaders().
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -124,7 +124,7 @@ func CountRunningPods(deploymentName string) int {
 func CountLWS(deploymentName string) int {
 	output, err := LWS(deploymentName).
 		Output("name").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -136,7 +136,7 @@ func CountLWS(deploymentName string) int {
 func CountLWSByRole(deploymentName, role string) int {
 	output, err := LWSByRole(deploymentName, role).
 		Output("name").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -148,7 +148,7 @@ func CountLWSByRole(deploymentName, role string) int {
 func CountService(deploymentName string) int {
 	output, err := Service(deploymentName).
 		Output("name").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -162,7 +162,7 @@ func CountService(deploymentName string) int {
 func GetTotalReplicas(deploymentName, revision string) int {
 	output, err := LWSByRevision(deploymentName, revision).
 		JSONPath("{range .items[*]}{.spec.replicas} {end}").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -174,7 +174,7 @@ func GetTotalReplicas(deploymentName, revision string) int {
 func GetTotalReplicasNotRevision(deploymentName, revision string) int {
 	output, err := LWSNotRevision(deploymentName, revision).
 		JSONPath("{range .items[*]}{.spec.replicas} {end}").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return 0
@@ -186,7 +186,7 @@ func GetTotalReplicasNotRevision(deploymentName, revision string) int {
 func GetRevision(deploymentName string) string {
 	output, err := LWS(deploymentName).
 		JSONPath("{.items[0].metadata.labels.disaggregatedset\\.x-k8s\\.io/revision}").
-		Timeout("30s").
+		RequestTimeout("30s").
 		RunQuiet()
 	if err != nil {
 		return ""
@@ -255,5 +255,6 @@ func CleanupDeployment(deploymentName string) {
 		Label(labelName, deploymentName).
 		Namespace(defaultNS).
 		IgnoreNotFound().
+		Timeout("30s").
 		RunQuiet()
 }

--- a/test/testutils/disaggregatedset/kubectl/waiters.go
+++ b/test/testutils/disaggregatedset/kubectl/waiters.go
@@ -33,35 +33,45 @@ const (
 // ForPodCount waits until the deployment has exactly count pods.
 func ForPodCount(deploymentName string, count int) {
 	Eventually(func(g Gomega) {
-		g.Expect(CountPods(deploymentName)).To(Equal(count))
+		actual, err := CountPods(deploymentName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(actual).To(Equal(count))
 	}, DefaultTimeout, DefaultInterval).Should(Succeed())
 }
 
 // ForRunningPodCount waits until the deployment has exactly count running pods.
 func ForRunningPodCount(deploymentName string, count int) {
 	Eventually(func(g Gomega) {
-		g.Expect(CountRunningPods(deploymentName)).To(Equal(count))
+		actual, err := CountRunningPods(deploymentName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(actual).To(Equal(count))
 	}, DefaultTimeout, DefaultInterval).Should(Succeed())
 }
 
 // ForRunningPodCountWithTimeout waits with custom timeout.
 func ForRunningPodCountWithTimeout(deploymentName string, count int, timeout time.Duration) {
 	Eventually(func(g Gomega) {
-		g.Expect(CountRunningPods(deploymentName)).To(Equal(count))
+		actual, err := CountRunningPods(deploymentName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(actual).To(Equal(count))
 	}, timeout, DefaultInterval).Should(Succeed())
 }
 
 // ForLWSCount waits until the deployment has exactly count LWS resources.
 func ForLWSCount(deploymentName string, count int) {
 	Eventually(func(g Gomega) {
-		g.Expect(CountLWS(deploymentName)).To(Equal(count))
+		actual, err := CountLWS(deploymentName)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(actual).To(Equal(count))
 	}, DefaultTimeout, DefaultInterval).Should(Succeed())
 }
 
 // ForRevisionDrained waits until all LWS of the given revision have 0 replicas.
 func ForRevisionDrained(deploymentName, revision string) {
 	Eventually(func(g Gomega) {
-		g.Expect(GetTotalReplicas(deploymentName, revision)).To(Equal(0))
+		actual, err := GetTotalReplicas(deploymentName, revision)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(actual).To(Equal(0))
 	}, 4*time.Minute, 2*time.Second).Should(Succeed())
 }
 
@@ -74,6 +84,7 @@ func ForSingleActiveRevision(deploymentName, oldRevision string) {
 	Eventually(func(g Gomega) {
 		output, err := LWS(deploymentName).
 			JSONPath(`{range .items[*]}{.metadata.labels.disaggregatedset\.x-k8s\.io/revision} {.spec.replicas}{"\n"}{end}`).
+			RequestTimeout("30s").
 			RunQuiet()
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -86,15 +97,18 @@ func ForSingleActiveRevision(deploymentName, oldRevision string) {
 func evalSingleActiveRevision(output, oldRevision string) string {
 	revReplicas := make(map[string]int)
 	revZeroRoles := make(map[string]int)
+
 	for _, line := range GetNonEmptyLines(output) {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
+
 		n, err := strconv.Atoi(fields[1])
 		if err != nil {
 			continue
 		}
+
 		revReplicas[fields[0]] += n
 		if n == 0 {
 			revZeroRoles[fields[0]]++
@@ -114,30 +128,32 @@ func evalSingleActiveRevision(output, oldRevision string) string {
 			active++
 		}
 	}
+
 	if active != 1 {
 		return "expected exactly one active revision, got " + strconv.Itoa(active)
 	}
+
 	return ""
 }
 
 // ForRoleReplicas waits until a role has the expected replica count.
-// If replicas=0 and the LWS doesn't exist, that counts as 0 replicas.
+// If the LWS doesn't exist, that counts as 0 replicas.
 func ForRoleReplicas(deploymentName, role string, replicas int) {
 	Eventually(func(g Gomega) {
 		output, err := LWSByRole(deploymentName, role).
-			JSONPath("{.items[*].spec.replicas}").RunQuiet()
-		if err != nil {
-			// If error and expecting 0 replicas, LWS may not exist which is fine
-			if replicas == 0 {
-				return
-			}
-			g.Expect(err).NotTo(HaveOccurred())
-		}
-		// Empty output means no LWS found
+			JSONPath("{.items[*].spec.replicas}").
+			RequestTimeout("30s").
+			RunQuiet()
+
+		// A kubectl error is not equivalent to an LWS with 0 replicas.
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Empty output means no LWS found.
 		if strings.TrimSpace(output) == "" {
 			g.Expect(replicas).To(Equal(0), "Role LWS not found but expected %d replicas", replicas)
 			return
 		}
+
 		g.Expect(sumInts(output)).To(Equal(replicas))
 	}, DefaultTimeout, DefaultInterval).Should(Succeed())
 }
@@ -150,15 +166,22 @@ type ProgressiveRolloutResult struct {
 
 // TrackProgressiveRollout tracks rollout states and returns whether intermediate states were observed.
 // Parameters: startOld/startNew are initial replica counts, targetNew is final new replica count.
-func TrackProgressiveRollout(deploymentName, oldRevision string, startOld, targetNew int) ProgressiveRolloutResult {
+func TrackProgressiveRollout(deploymentName, oldRevision string, startOld, targetNew int) (ProgressiveRolloutResult, error) {
 	result := ProgressiveRolloutResult{}
 	startTime := time.Now()
 
 	for time.Since(startTime) < 4*time.Minute {
-		oldTotal := GetTotalReplicas(deploymentName, oldRevision)
-		newTotal := GetTotalReplicasNotRevision(deploymentName, oldRevision)
+		oldTotal, err := GetTotalReplicas(deploymentName, oldRevision)
+		if err != nil {
+			return result, err
+		}
 
-		// Track intermediate states
+		newTotal, err := GetTotalReplicasNotRevision(deploymentName, oldRevision)
+		if err != nil {
+			return result, err
+		}
+
+		// Track intermediate states.
 		if oldTotal > 0 && oldTotal < startOld {
 			result.SawIntermediateOld = true
 		}
@@ -166,12 +189,13 @@ func TrackProgressiveRollout(deploymentName, oldRevision string, startOld, targe
 			result.SawIntermediateNew = true
 		}
 
-		// Check if rollout is complete
+		// Check if rollout is complete.
 		if oldTotal == 0 && newTotal == targetNew {
 			break
 		}
+
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	return result
+	return result, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it

Fixes flaky DisaggregatedSet progressive rollout E2E tests and adds bound timeouts

#### Which issue(s) this PR fixes

Fixes #1039 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```